### PR TITLE
🎨 Palette: Add accessible labels to action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - Accessibility Patterns for WordPress Admin
 **Learning:** Standard WordPress Admin UI patterns (like modals and empty states with Dashicons) often lack default ARIA attributes. Specifically, modal close buttons (`&times;`) are frequently missing `aria-label`, and decorative Dashicons are missing `aria-hidden="true"`.
 **Action:** When working on WP Admin interfaces, always audit modal close buttons and decorative icons for these specific attributes. Use `esc_attr_e('Close modal', 'text-domain')` for consistency.
+
+## 2024-05-24 - Contextual Action Buttons in Data Tables
+**Learning:** In WordPress admin tables (`wp-list-table`), action buttons like "Edit" or "Delete" are often repeated in every row, creating ambiguity for screen reader users ("Delete" what?).
+**Action:** Always add `aria-label` attributes to these buttons that include the row's identifying data (e.g., `aria-label="<?php printf(esc_attr__('Delete author %s', 'domain'), esc_attr($name)); ?>"`).

--- a/ai-post-scheduler/templates/admin/authors.php
+++ b/ai-post-scheduler/templates/admin/authors.php
@@ -91,16 +91,16 @@ if (isset($_GET['page']) && $_GET['page'] === 'aips-authors') {
                                         </span>
                                     </td>
                                     <td class="column-actions">
-                                        <button class="button aips-view-author" data-id="<?php echo esc_attr($author->id); ?>">
+                                        <button class="button aips-view-author" data-id="<?php echo esc_attr($author->id); ?>" aria-label="<?php printf(esc_attr__('View topics for %s', 'ai-post-scheduler'), esc_attr($author->name)); ?>">
                                             <?php esc_html_e('View Topics', 'ai-post-scheduler'); ?>
                                         </button>
-                                        <button class="button aips-edit-author" data-id="<?php echo esc_attr($author->id); ?>">
+                                        <button class="button aips-edit-author" data-id="<?php echo esc_attr($author->id); ?>" aria-label="<?php printf(esc_attr__('Edit author %s', 'ai-post-scheduler'), esc_attr($author->name)); ?>">
                                             <?php esc_html_e('Edit', 'ai-post-scheduler'); ?>
                                         </button>
-                                        <button class="button aips-generate-topics-now" data-id="<?php echo esc_attr($author->id); ?>">
+                                        <button class="button aips-generate-topics-now" data-id="<?php echo esc_attr($author->id); ?>" aria-label="<?php printf(esc_attr__('Generate topics for %s', 'ai-post-scheduler'), esc_attr($author->name)); ?>">
                                             <?php esc_html_e('Generate Topics Now', 'ai-post-scheduler'); ?>
                                         </button>
-                                        <button class="button button-link-delete aips-delete-author" data-id="<?php echo esc_attr($author->id); ?>">
+                                        <button class="button button-link-delete aips-delete-author" data-id="<?php echo esc_attr($author->id); ?>" aria-label="<?php printf(esc_attr__('Delete author %s', 'ai-post-scheduler'), esc_attr($author->name)); ?>">
                                             <?php esc_html_e('Delete', 'ai-post-scheduler'); ?>
                                         </button>
                                     </td>

--- a/ai-post-scheduler/templates/admin/schedule.php
+++ b/ai-post-scheduler/templates/admin/schedule.php
@@ -73,7 +73,10 @@ $rotation_patterns = $template_type_selector->get_rotation_patterns();
                     data-article-structure-id="<?php echo esc_attr($schedule->article_structure_id); ?>"
                     data-rotation-pattern="<?php echo esc_attr($schedule->rotation_pattern); ?>">
                     <td class="column-template">
-                        <?php echo esc_html($schedule->template_name ?: __('Unknown Template', 'ai-post-scheduler')); ?>
+                        <?php
+                        $template_name = $schedule->template_name ?: __('Unknown Template', 'ai-post-scheduler');
+                        echo esc_html($template_name);
+                        ?>
                     </td>
                     <td class="column-structure">
                         <?php echo esc_html($structure_display); ?>
@@ -134,10 +137,10 @@ $rotation_patterns = $template_type_selector->get_rotation_patterns();
                         </div>
                     </td>
                     <td class="column-actions">
-                        <button class="button aips-clone-schedule" aria-label="<?php esc_attr_e('Clone schedule', 'ai-post-scheduler'); ?>">
+                        <button class="button aips-clone-schedule" aria-label="<?php printf(esc_attr__('Clone schedule for %s', 'ai-post-scheduler'), esc_attr($template_name)); ?>">
                             <?php esc_html_e('Clone', 'ai-post-scheduler'); ?>
                         </button>
-                        <button class="button button-link-delete aips-delete-schedule" data-id="<?php echo esc_attr($schedule->id); ?>">
+                        <button class="button button-link-delete aips-delete-schedule" data-id="<?php echo esc_attr($schedule->id); ?>" aria-label="<?php printf(esc_attr__('Delete schedule for %s', 'ai-post-scheduler'), esc_attr($template_name)); ?>">
                             <?php esc_html_e('Delete', 'ai-post-scheduler'); ?>
                         </button>
                     </td>


### PR DESCRIPTION
💡 What: Added dynamic `aria-label` attributes to action buttons in the Authors and Schedule admin tables.
🎯 Why: Screen reader users previously heard repetitive 'Edit', 'Delete', or 'Clone' announcements for every row without context. Now they will hear 'Edit author John Doe', 'Delete schedule for Daily Blog', etc.
📸 Before/After: Visuals are unchanged. Underlying HTML now includes contextual `aria-label`s.
♿ Accessibility: WCAG 2.4.4 (Link Purpose) compliance improved.

---
*PR created automatically by Jules for task [9107598748533238021](https://jules.google.com/task/9107598748533238021) started by @rpnunez*