### PR TITLE
🧙‍♂️ Wizard: Add Copy Log button to System Status

### DIFF
--- a/.jules/wizard.md
+++ b/.jules/wizard.md
@@ -31,3 +31,7 @@
 ## 2026-01-21 - Generated Posts Empty State
 **Learning:** `generated-posts.php` was missing the standard Empty State pattern (`.aips-empty-state`) and a direct "View" action, causing inconsistency with `history.php`.
 **Action:** Implemented the standard Empty State and added a "View" button with accessibility attributes (`aria-label`, `rel="noopener"`) to match the "Feature Wizard" polish standards.
+
+## 2026-01-22 - System Status Copy Log
+**Learning:** The "System Status" page displayed read-only textareas for logs/details but lacked a quick way to copy the content, which is a frequent need for support and debugging.
+**Action:** Implemented a "Copy Log" button for each detail section in `system-status.php` and enhanced `admin.js` to support `data-clipboard-target` for copying content from specific elements.

--- a/ai-post-scheduler/assets/js/admin.js
+++ b/ai-post-scheduler/assets/js/admin.js
@@ -297,6 +297,13 @@
             var $btn = $(this);
             var text = $btn.data('clipboard-text');
 
+            if (!text && $btn.data('clipboard-target')) {
+                var $target = $($btn.data('clipboard-target'));
+                if ($target.length) {
+                    text = $target.val() || $target.text();
+                }
+            }
+
             if (!text) return;
 
             var showSuccess = function() {

--- a/ai-post-scheduler/templates/admin/system-status.php
+++ b/ai-post-scheduler/templates/admin/system-status.php
@@ -33,7 +33,12 @@ if (!defined('ABSPATH')) {
                                         <?php esc_html_e('Show Details', 'ai-post-scheduler'); ?>
                                     </a>
                                     <div id="log-details-<?php echo esc_attr($key); ?>" class="aips-log-details" style="display:none; margin-top: 10px;">
-                                        <textarea class="large-text code" rows="10" readonly><?php echo esc_textarea(implode("\n", $check['details'])); ?></textarea>
+                                        <div style="text-align: right; margin-bottom: 5px;">
+                                            <button type="button" class="button aips-copy-btn" data-clipboard-target="#log-textarea-<?php echo esc_attr($key); ?>">
+                                                <span class="dashicons dashicons-clipboard"></span> <?php esc_html_e('Copy Log', 'ai-post-scheduler'); ?>
+                                            </button>
+                                        </div>
+                                        <textarea id="log-textarea-<?php echo esc_attr($key); ?>" class="large-text code" rows="10" readonly><?php echo esc_textarea(implode("\n", $check['details'])); ?></textarea>
                                     </div>
                                 <?php endif; ?>
                             </td>


### PR DESCRIPTION
Implemented a "Copy Log" button in the System Status page to facilitate copying of debug logs.
Enhanced the existing `copyToClipboard` function in `admin.js` to support copying content from a target element via `data-clipboard-target` attribute, improving reusability.
Verified the functionality using a Playwright script.

---
*PR created automatically by Jules for task [5711957678614602800](https://jules.google.com/task/5711957678614602800) started by @rpnunez*