### PR TITLE
🧙‍♂️ Wizard: Add "Clear Filters" to Post Review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- [2026-02-05 12:00:00] Added "Clear Filters" button to the Post Review page for easier navigation when filters are active.
 - [2026-01-17 08:24:50] Added Developer Mode and Dev Tools page for generating template scaffolds (Voices, Structures, Templates) using AI.
 - [2026-01-20 10:00:00] Added client-side search functionality to the Planner topic list, allowing users to filter brainstormed topics before scheduling.
 - 2025-12-25: Added client-side search functionality to the Prompt Sections admin page and "Copy to Clipboard" button for section keys.

--- a/ai-post-scheduler/templates/admin/post-review.php
+++ b/ai-post-scheduler/templates/admin/post-review.php
@@ -55,6 +55,9 @@ $templates = $template_repository->get_all();
 			<label class="screen-reader-text" for="aips-post-search-input"><?php esc_html_e('Search Posts:', 'ai-post-scheduler'); ?></label>
 			<input type="search" id="aips-post-search-input" name="s" value="<?php echo esc_attr($search_query); ?>" placeholder="<?php esc_attr_e('Search posts...', 'ai-post-scheduler'); ?>">
 			<input type="submit" id="aips-post-search-btn" class="button" value="<?php esc_attr_e('Search', 'ai-post-scheduler'); ?>">
+			<?php if (!empty($search_query) || !empty($template_id)): ?>
+				<a href="<?php echo esc_url(admin_url('admin.php?page=aips-post-review')); ?>" class="button"><?php esc_html_e('Clear Filters', 'ai-post-scheduler'); ?></a>
+			<?php endif; ?>
 		</p>
 		
 		<?php if (!empty($templates)): ?>


### PR DESCRIPTION
Implemented a "Clear Filters" button in the Post Review admin page. This button appears when a user has filtered the post list by search query or template, allowing them to quickly reset the view with a single click, improving the overall user experience. This follows the "Feature Wizard" philosophy of small, high-impact improvements.

---
*PR created automatically by Jules for task [6201621544182251996](https://jules.google.com/task/6201621544182251996) started by @rpnunez*