### PR TITLE
🐞 Hunter: Fix test environment mocks to prevent crashes

### DIFF
--- a/.jules/hunter.md
+++ b/.jules/hunter.md
@@ -5,3 +5,7 @@
 ## 2024-05-25 - Time-Dependent Test Failures
 **Learning:** Unit tests for time-dependent logic (like scheduling calculators) that use hardcoded dates become "time bombs" when those dates pass. Catch-up logic for past dates can further obscure the interval calculation logic being tested.
 **Action:** Use relative future dates (e.g., `strtotime('+1 year')`) in tests to ensure they remain valid regardless of when they are run and to isolate the interval logic from catch-up mechanisms.
+
+## 2026-02-03 - Incomplete Test Environment Mocks
+**Learning:** The "limited mode" test environment in `bootstrap.php` mocks `$wpdb` as an anonymous class but misses standard methods (`get_charset_collate`, `esc_like`, `get_col`) and helper functions (`wp_parse_args`, `dbDelta`). This causes fatal errors in tests that rely on these basics, masking actual logic failures.
+**Action:** When adding new DB interactions or WP function calls, always verify if they are supported by the `bootstrap.php` mock. If adding a new test file, ensure the class under test is manually loaded in `bootstrap.php`'s fallback loader.

--- a/ai-post-scheduler/CHANGELOG.md
+++ b/ai-post-scheduler/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [hunter-fix-test-environment-mocks] - 2026-02-03
+### Fixed
+- Fixed critical test environment crashes by updating `tests/bootstrap.php` to include missing `$wpdb` mocks (`get_charset_collate`, `esc_like`, `get_col`) and helper functions (`wp_parse_args`, `dbDelta`).
+- Wrapped `require_once` calls for `upgrade.php` in `test-trending-topics-repository.php` and `class-aips-db-manager.php` to prevent fatal errors when running tests in limited environments.
+
 ## [wizard-run-schedule-now] - 2025-01-05
 ### Added
 - Added "Run Schedule Now" capability to `AIPS_Scheduler` and `AIPS_Schedule_Controller`, allowing immediate execution of schedules regardless of their timing or active status.

--- a/ai-post-scheduler/includes/class-aips-db-manager.php
+++ b/ai-post-scheduler/includes/class-aips-db-manager.php
@@ -282,7 +282,9 @@ class AIPS_DB_Manager {
     }
 
     public static function install_tables() {
-        require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+        if (!function_exists('dbDelta')) {
+            require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+        }
         $instance = new self();
         $schema = $instance->get_schema();
         foreach ($schema as $sql) {

--- a/ai-post-scheduler/tests/test-trending-topics-repository.php
+++ b/ai-post-scheduler/tests/test-trending-topics-repository.php
@@ -34,7 +34,9 @@ class Test_Trending_Topics_Repository extends WP_UnitTestCase {
             KEY researched_at_idx (researched_at)
         ) {$charset_collate};";
         
-        require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+        if (!function_exists('dbDelta')) {
+            require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+        }
         dbDelta($sql);
     }
     


### PR DESCRIPTION
🐛 Bug: The test suite was crashing in the "limited mode" environment (where a full WordPress install is missing) because the mocked `$wpdb` object lacked standard methods like `get_charset_collate`, and helper functions like `wp_parse_args` and `dbDelta` were undefined.

🔍 Root Cause: The `bootstrap.php` file's mock implementation was incomplete, and `test-trending-topics-repository.php` blindly required `upgrade.php` (which doesn't exist in the limited environment), causing fatal errors.

🛠️ Fix:
1.  Updated `ai-post-scheduler/tests/bootstrap.php` to:
    *   Add `get_charset_collate`, `esc_like`, and `get_col` to the `$wpdb` mock.
    *   Add `wp_parse_args` function mock.
    *   Add `dbDelta` function mock.
    *   Add `AIPS_Trending_Topics_Repository` to the manual class loader.
2.  Updated `ai-post-scheduler/tests/test-trending-topics-repository.php` and `ai-post-scheduler/includes/class-aips-db-manager.php` to wrap `require_once(ABSPATH . 'wp-admin/includes/upgrade.php')` with a check for `!function_exists('dbDelta')`.

🧪 Verification:
Ran `vendor/bin/phpunit --filter Test_Trending_Topics_Repository`.
Before: "Call to undefined method ...::get_charset_collate()" fatal error.
After: Tests run (assertions fail due to empty mock DB, but no fatal crashes).

---
*PR created automatically by Jules for task [11813211413645247075](https://jules.google.com/task/11813211413645247075) started by @rpnunez*