### PR TITLE
🎨 Palette: Add ARIA label to post review modal close button

### DIFF
--- a/ai-post-scheduler/CHANGELOG.md
+++ b/ai-post-scheduler/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [palette-a11y-post-review-modal] - 2026-02-04
+### Fixed
+- Added missing `aria-label` to the modal close button in the Post Review admin page for better accessibility.
+
 ## [wizard-run-schedule-now] - 2025-01-05
 ### Added
 - Added "Run Schedule Now" capability to `AIPS_Scheduler` and `AIPS_Schedule_Controller`, allowing immediate execution of schedules regardless of their timing or active status.

--- a/ai-post-scheduler/templates/admin/post-review.php
+++ b/ai-post-scheduler/templates/admin/post-review.php
@@ -229,7 +229,7 @@ $templates = $template_repository->get_all();
 	<div class="aips-modal-content">
 		<div class="aips-modal-header">
 			<h2><?php esc_html_e('Generation Logs', 'ai-post-scheduler'); ?></h2>
-			<button type="button" class="aips-modal-close">&times;</button>
+			<button type="button" class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
 		</div>
 		<div class="aips-modal-body" id="aips-log-viewer-content">
 			<p><?php esc_html_e('Loading...', 'ai-post-scheduler'); ?></p>


### PR DESCRIPTION
## 🎨 Palette: Add ARIA label to post review modal close button

**💡 What:**
Added an `aria-label` attribute to the "Close" button in the "Generation Logs" modal within the Post Review admin page (`ai-post-scheduler/templates/admin/post-review.php`).

**🎯 Why:**
The close button previously only contained a visual `&times;` (x) entity. Screen readers would announce this as "times" or "multiplication sign", or simply "button" without context, making it difficult for visually impaired users to understand the button's purpose.

**♿ Accessibility:**
- Added `aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>"`
- Ensures the button is announced as "Close modal" (or localized equivalent) by assistive technologies.

**📸 Verification:**
- Verified using a custom PHP script that rendered the template mock and confirmed the presence of the `aria-label` attribute.

Reference: UX-A11Y-001

---
*PR created automatically by Jules for task [4240040116748001970](https://jules.google.com/task/4240040116748001970) started by @rpnunez*