### PR TITLE
Enhance $wpdb mock in bootstrap.php to support repository tests

### DIFF
--- a/ai-post-scheduler/tests/bootstrap.php
+++ b/ai-post-scheduler/tests/bootstrap.php
@@ -30,42 +30,42 @@ if (!defined('WP_CORE_DIR')) {
 // Check if WordPress test library exists
 if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
     require_once WP_TESTS_DIR . '/includes/functions.php';
-    
+
     /**
      * Manually load the plugin being tested.
      */
     function _manually_load_plugin() {
         define('ABSPATH', WP_CORE_DIR . '/');
-        
+
         // Load plugin files
         require dirname(__DIR__) . '/ai-post-scheduler.php';
     }
     tests_add_filter('muplugins_loaded', '_manually_load_plugin');
-    
+
     // Start up the WP testing environment
     require WP_TESTS_DIR . '/includes/bootstrap.php';
 } else {
     // Fallback when WordPress test library is not available
     echo "Warning: WordPress test library not found at " . WP_TESTS_DIR . "\n";
     echo "Tests will run in limited mode without WordPress environment.\n\n";
-    
+
     // Define minimal WordPress constants and functions for basic testing
     if (!defined('ABSPATH')) {
         define('ABSPATH', dirname(__DIR__) . '/');
     }
-    
+
     if (!defined('AIPS_VERSION')) {
         define('AIPS_VERSION', '1.4.0');
     }
-    
+
     if (!defined('AIPS_PLUGIN_DIR')) {
         define('AIPS_PLUGIN_DIR', dirname(__DIR__) . '/');
     }
-    
+
     if (!defined('AIPS_PLUGIN_URL')) {
         define('AIPS_PLUGIN_URL', 'http://example.com/wp-content/plugins/ai-post-scheduler/');
     }
-    
+
     if (!defined('AIPS_PLUGIN_BASENAME')) {
         define('AIPS_PLUGIN_BASENAME', 'ai-post-scheduler/ai-post-scheduler.php');
     }
@@ -76,16 +76,16 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             'filters' => array(),
         );
     }
-    
+
     // WordPress constants
     if (!defined('OBJECT')) {
         define('OBJECT', 'OBJECT');
     }
-    
+
     if (!defined('ARRAY_A')) {
         define('ARRAY_A', 'ARRAY_A');
     }
-    
+
     if (!defined('ARRAY_N')) {
         define('ARRAY_N', 'ARRAY_N');
     }
@@ -93,7 +93,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
     if (!defined('HOUR_IN_SECONDS')) {
         define('HOUR_IN_SECONDS', 3600);
     }
-    
+
     // Mock WordPress functions if not available
     if (!function_exists('esc_html__')) {
         function esc_html__($text, $domain = 'default') {
@@ -130,25 +130,25 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return $url;
         }
     }
-    
+
     if (!function_exists('plugin_dir_path')) {
         function plugin_dir_path($file) {
             return dirname($file) . '/';
         }
     }
-    
+
     if (!function_exists('plugin_dir_url')) {
         function plugin_dir_url($file) {
             return 'http://example.com/wp-content/plugins/' . basename(dirname($file)) . '/';
         }
     }
-    
+
     if (!function_exists('plugin_basename')) {
         function plugin_basename($file) {
             return basename(dirname($file)) . '/' . basename($file);
         }
     }
-    
+
     if (!function_exists('add_action')) {
         function add_action($hook, $callback, $priority = 10, $accepted_args = 1) {
             if (!isset($GLOBALS['aips_test_hooks']['actions'][$hook])) {
@@ -165,7 +165,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             );
         }
     }
-    
+
     if (!function_exists('add_filter')) {
         function add_filter($hook, $callback, $priority = 10, $accepted_args = 1) {
             if (!isset($GLOBALS['aips_test_hooks']['filters'][$hook])) {
@@ -182,7 +182,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             );
         }
     }
-    
+
     if (!function_exists('apply_filters')) {
         function apply_filters($hook, $value) {
             $args = func_get_args();
@@ -203,7 +203,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return $value;
         }
     }
-    
+
     if (!function_exists('do_action')) {
         function do_action($hook) {
             $args = func_get_args();
@@ -285,7 +285,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return delete_option('_transient_' . $transient);
         }
     }
-    
+
     if (!function_exists('current_time')) {
         function current_time($type = 'mysql', $gmt = 0) {
             $timestamp = $gmt ? time() : time(); // Simplified time handling
@@ -302,13 +302,13 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return date($type, $timestamp);
         }
     }
-    
+
     if (!function_exists('wp_json_encode')) {
         function wp_json_encode($data, $options = 0, $depth = 512) {
             return json_encode($data, $options, $depth);
         }
     }
-    
+
     if (!function_exists('wp_upload_dir')) {
         function wp_upload_dir() {
             return [
@@ -330,12 +330,12 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return true;
         }
     }
-    
+
     if (!class_exists('WP_Error')) {
         class WP_Error {
             private $errors = [];
             private $error_data = [];
-            
+
             public function __construct($code = '', $message = '', $data = '') {
                 if (empty($code)) {
                     return;
@@ -345,12 +345,12 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
                     $this->error_data[$code] = $data;
                 }
             }
-            
+
             public function get_error_code() {
                 $codes = array_keys($this->errors);
                 return empty($codes) ? '' : $codes[0];
             }
-            
+
             public function get_error_message($code = '') {
                 if (empty($code)) {
                     $code = $this->get_error_code();
@@ -358,14 +358,14 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
                 $messages = isset($this->errors[$code]) ? $this->errors[$code] : [];
                 return empty($messages) ? '' : $messages[0];
             }
-            
+
             public function get_error_data($code = '') {
                 if (empty($code)) {
                     $code = $this->get_error_code();
                 }
                 return isset($this->error_data[$code]) ? $this->error_data[$code] : null;
             }
-            
+
             public function add($code, $message, $data = '') {
                 $this->errors[$code][] = $message;
                 if (!empty($data)) {
@@ -374,7 +374,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             }
         }
     }
-    
+
     if (!function_exists('is_wp_error')) {
         function is_wp_error($thing) {
             return ($thing instanceof WP_Error);
@@ -414,12 +414,6 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
                 default:
                     return '';
             }
-        }
-    }
-
-    if (!function_exists('get_option')) {
-        function get_option($option, $default = false) {
-            return $default;
         }
     }
 
@@ -510,12 +504,12 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return true;
         }
     }
-    
+
     if (!class_exists('WP_UnitTestCase')) {
         // Provide a basic test case for when WordPress test library is not available
         class WP_UnitTestCase extends \PHPUnit\Framework\TestCase {
             protected $factory;
-            
+
             public function setUp(): void {
                 parent::setUp();
                 if (!isset($this->factory)) {
@@ -535,7 +529,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
                     };
                 }
             }
-            
+
             public function tearDown(): void {
                 $this->reset_hooks();
                 parent::tearDown();
@@ -558,7 +552,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             }
         }
     }
-    
+
     // Mock AJAX functions
     if (!function_exists('check_ajax_referer')) {
         function check_ajax_referer($action = -1, $query_arg = '_wpnonce', $die = true) {
@@ -572,39 +566,39 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return 1;
         }
     }
-    
+
     if (!function_exists('wp_die')) {
         function wp_die($message = '', $title = '', $args = array()) {
             throw new WPAjaxDieStopException($message);
         }
     }
-    
+
     if (!function_exists('wp_create_nonce')) {
         function wp_create_nonce($action = -1) {
             return 'test_nonce_' . $action;
         }
     }
-    
+
     if (!function_exists('wp_verify_nonce')) {
         function wp_verify_nonce($nonce, $action = -1) {
             return $nonce === wp_create_nonce($action) ? 1 : false;
         }
     }
-    
+
     if (!function_exists('wp_send_json_success')) {
         function wp_send_json_success($data = null, $status_code = null) {
             echo json_encode(array('success' => true, 'data' => $data));
             throw new WPAjaxDieContinueException();
         }
     }
-    
+
     if (!function_exists('wp_send_json_error')) {
         function wp_send_json_error($data = null, $status_code = null) {
             echo json_encode(array('success' => false, 'data' => $data));
             throw new WPAjaxDieContinueException();
         }
     }
-    
+
     if (!function_exists('wp_set_current_user')) {
         function wp_set_current_user($id, $name = '') {
             global $current_user_id;
@@ -612,7 +606,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return $id;
         }
     }
-    
+
     if (!function_exists('current_user_can')) {
         function current_user_can($capability) {
             global $current_user_id, $test_users;
@@ -627,39 +621,27 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return false;
         }
     }
-    
-    if (!function_exists('sanitize_text_field')) {
-        function sanitize_text_field($str) {
-            return strip_tags($str);
-        }
-    }
-    
+
     if (!function_exists('sanitize_file_name')) {
         function sanitize_file_name($filename) {
             $filename = preg_replace('/[^a-zA-Z0-9._-]/', '_', $filename);
             return $filename;
         }
     }
-    
+
     if (!function_exists('sanitize_textarea_field')) {
         function sanitize_textarea_field($str) {
             return strip_tags($str);
         }
     }
-    
+
     if (!function_exists('wp_kses_post')) {
         function wp_kses_post($data) {
             // Allow some HTML tags
             return strip_tags($data, '<a><strong><em><p><br><ul><ol><li>');
         }
     }
-    
-    if (!function_exists('absint')) {
-        function absint($maybeint) {
-            return abs(intval($maybeint));
-        }
-    }
-    
+
     if (!function_exists('__')) {
         function __($text, $domain = 'default') {
             return $text;
@@ -753,47 +735,28 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return $result;
         }
     }
-    
-    if (!function_exists('wp_parse_args')) {
-        function wp_parse_args($args, $defaults = array()) {
-            if (is_object($args)) {
-                $parsed_args = get_object_vars($args);
-            } elseif (is_array($args)) {
-                $parsed_args = &$args;
-            } else {
-                parse_str($args, $parsed_args);
-            }
-            
-            if (is_array($defaults)) {
-                return array_merge($defaults, $parsed_args);
-            }
-            return $parsed_args;
-        }
-    }
-    
+
     // AJAX exception classes for testing
     if (!class_exists('WPAjaxDieContinueException')) {
         class WPAjaxDieContinueException extends Exception {}
     }
-    
+
     if (!class_exists('WPAjaxDieStopException')) {
         class WPAjaxDieStopException extends Exception {}
     }
-    
+
     // Mock global $wpdb
     if (!isset($GLOBALS['wpdb'])) {
         $GLOBALS['wpdb'] = new class {
             public $prefix = 'wp_';
             public $insert_id = 0;
-            private $data = array();
-            
+            public $data = array();
+
             public function esc_like($text) {
                 return addcslashes($text, '_%\\');
             }
 
             public function prepare($query, ...$args) {
-                // Simple mock prepare - just return the query with args
-                // In real implementation, this would properly escape and format
                 if (empty($args)) {
                     return $query;
                 }
@@ -810,53 +773,406 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
                         $arg = "'" . implode("','", $arg) . "'";
                         $query = preg_replace('/%[sd]/', $arg, $query, 1);
                     } else {
+                        $arg = is_numeric($arg) ? $arg : addslashes((string)$arg);
                         $query = preg_replace('/%[sd]/', is_numeric($arg) ? $arg : "'$arg'", $query, 1);
                     }
                 }
                 return $query;
             }
-            
-            public function get_results($query, $output = OBJECT) {
-                return array();
-            }
-            
-            public function get_row($query, $output = OBJECT, $y = 0) {
-                // Return a default object with common properties to prevent null reference errors
-                $obj = new stdClass();
-                $obj->id = 1; // Default ID
-                $obj->total = 0;
-                $obj->completed = 0;
-                $obj->failed = 0;
-                $obj->processing = 0;
-                $obj->count = 0;
 
-                if ($output == ARRAY_A) {
-                    return (array) $obj;
+            public function get_results($query, $output = OBJECT) {
+                // Parse table name
+                preg_match('/FROM\s+([^\s]+)/i', $query, $matches);
+                $table = isset($matches[1]) ? str_replace('`', '', $matches[1]) : '';
+
+                if (empty($table) || !isset($this->data[$table])) {
+                    return array();
                 }
 
-                return $obj;
+                $results = $this->data[$table];
+
+                // Parse WHERE clauses (simple)
+                // Supports: col = val, col LIKE val, col IN (val1, val2)
+                if (preg_match('/WHERE\s+(.*?)(\sORDER|\sLIMIT|\sGROUP|$)/is', $query, $matches)) {
+                    $where_clause = $matches[1];
+                    // Split by AND
+                    $conditions = preg_split('/\s+AND\s+/i', $where_clause);
+
+                    $results = array_filter($results, function($row) use ($conditions) {
+                        foreach ($conditions as $condition) {
+                            $condition = trim($condition);
+
+                            // Handle 1=1
+                            if ($condition === '1=1') {
+                                continue;
+                            }
+
+                            if (preg_match('/([a-zA-Z0-9_]+)\s*(=|LIKE|>=|<=|>|<)\s*[\'"]?([^\'"]*)[\'"]?/i', $condition, $parts)) {
+                                $col = $parts[1];
+                                $op = strtoupper($parts[2]);
+                                $val = $parts[3];
+
+                                // Handle DATE_SUB(NOW(), ...) approximation
+                                if (strpos($val, 'DATE_SUB') !== false) {
+                                    // For testing purposes, assume true
+                                    continue;
+                                }
+
+                                if (!isset($row[$col])) return false;
+
+                                if ($op === '=') {
+                                    if ((string)$row[$col] !== (string)$val) return false;
+                                } elseif ($op === 'LIKE') {
+                                    $pattern = '/^' . str_replace('%', '.*', preg_quote($val, '/')) . '$/i';
+                                    if (!preg_match($pattern, $row[$col])) return false;
+                                } elseif ($op === '>=') {
+                                    if ($row[$col] < $val) return false;
+                                } elseif ($op === '<=') {
+                                    if ($row[$col] > $val) return false;
+                                } elseif ($op === '>') {
+                                    if ($row[$col] <= $val) return false;
+                                } elseif ($op === '<') {
+                                    if ($row[$col] >= $val) return false;
+                                }
+                            } elseif (preg_match('/([a-zA-Z0-9_]+)\s+IN\s*\((.*?)\)/i', $condition, $parts)) {
+                                $col = $parts[1];
+                                $vals = explode(',', str_replace("'", "", $parts[2]));
+                                $vals = array_map('trim', $vals);
+
+                                if (!isset($row[$col])) return false;
+                                if (!in_array((string)$row[$col], $vals)) return false;
+                            }
+                        }
+                        return true;
+                    });
+                }
+
+                // Parse ORDER BY
+                if (preg_match('/ORDER BY\s+([a-zA-Z0-9_]+)\s*(ASC|DESC)?/i', $query, $matches)) {
+                    $col = $matches[1];
+                    $dir = isset($matches[2]) ? strtoupper($matches[2]) : 'ASC';
+
+                    usort($results, function($a, $b) use ($col, $dir) {
+                        if (!isset($a[$col]) || !isset($b[$col])) return 0;
+                        if ($a[$col] == $b[$col]) return 0;
+                        if ($dir === 'ASC') {
+                            return ($a[$col] < $b[$col]) ? -1 : 1;
+                        } else {
+                            return ($a[$col] > $b[$col]) ? -1 : 1;
+                        }
+                    });
+                }
+
+                // Parse GROUP BY (Basic implementation for get_niche_list)
+                if (preg_match('/GROUP BY\s+([a-zA-Z0-9_]+)/i', $query, $matches)) {
+                     $group_col = $matches[1];
+                     $grouped_results = [];
+                     foreach ($results as $row) {
+                         $key = $row[$group_col];
+                         if (!isset($grouped_results[$key])) {
+                             $grouped_results[$key] = [
+                                 $group_col => $key,
+                                 'count' => 0
+                             ];
+                         }
+                         $grouped_results[$key]['count']++;
+                     }
+                     // If query selects count, return formatted results
+                     if (preg_match('/SELECT\s+.*COUNT\(\*\).*/i', $query)) {
+                         $results = array_values($grouped_results);
+                     }
+                }
+
+                // Parse LIMIT
+                if (preg_match('/LIMIT\s+(\d+)(?:\s+OFFSET\s+(\d+))?/i', $query, $matches)) {
+                    $limit = intval($matches[1]);
+                    $offset = isset($matches[2]) ? intval($matches[2]) : 0;
+                    $results = array_slice($results, $offset, $limit);
+                }
+
+                // Handle Aggregations in SELECT
+                if (preg_match('/SELECT\s+(.*?)\s+FROM/is', $query, $matches)) {
+                    $select_clause = $matches[1];
+
+                    if (stripos($select_clause, 'COUNT(*)') !== false && stripos($query, 'GROUP BY') === false) {
+                        // Look for 'as' alias
+                        $key = 'COUNT(*)';
+                        if (preg_match('/COUNT\(\*\)\s+as\s+([a-zA-Z0-9_]+)/i', $select_clause, $alias_matches)) {
+                            $key = $alias_matches[1];
+                        }
+                        $res = array($key => count($results));
+                        return $output == OBJECT ? array((object)$res) : array($res);
+                    }
+
+                    if (preg_match('/COUNT\(DISTINCT\s+([a-zA-Z0-9_]+)\)/i', $select_clause, $count_matches)) {
+                        $col = $count_matches[1];
+                        $unique = array_unique(array_column($results, $col));
+                        $res = array('COUNT(DISTINCT ' . $col . ')' => count($unique));
+                        return $output == OBJECT ? array((object)$res) : array($res);
+                    }
+
+                    if (preg_match('/AVG\s*\(\s*([a-zA-Z0-9_]+)\s*\)/i', $select_clause, $avg_matches)) {
+                        $col = $avg_matches[1];
+                        $values = array_column($results, $col);
+                        $avg = count($values) > 0 ? array_sum($values) / count($values) : 0;
+                        $key = 'AVG(' . $col . ')';
+                        if (preg_match('/AVG\s*\(\s*([a-zA-Z0-9_]+)\s*\)\s+as\s+([a-zA-Z0-9_]+)/i', $select_clause, $alias_matches)) {
+                             $key = $alias_matches[2];
+                        }
+                        $res = array($key => $avg);
+                        return $output == OBJECT ? array((object)$res) : array($res);
+                    }
+
+                    // Handle MAX aggregation specifically for get_niche_stats
+                    if (preg_match('/MAX\s*\(\s*([a-zA-Z0-9_]+)\s*\)/i', $select_clause, $max_matches)) {
+                         // This is a simplified handler that assumes a row return with aliases
+                         // It constructs a single row with all aggregates if multiple present
+                         $row = array();
+
+                         if (preg_match('/COUNT\(\*\)\s+as\s+([a-zA-Z0-9_]+)/i', $select_clause, $m)) {
+                             $row[$m[1]] = count($results);
+                         }
+                         if (preg_match('/AVG\s*\(\s*score\s*\)\s+as\s+([a-zA-Z0-9_]+)/i', $select_clause, $m)) {
+                             $values = array_column($results, 'score');
+                             $row[$m[1]] = count($values) > 0 ? array_sum($values) / count($values) : 0;
+                         }
+                         if (preg_match('/MAX\s*\(\s*score\s*\)\s+as\s+([a-zA-Z0-9_]+)/i', $select_clause, $m)) {
+                             $values = array_column($results, 'score');
+                             $row[$m[1]] = count($values) > 0 ? max($values) : 0;
+                         }
+                         if (preg_match('/MAX\s*\(\s*researched_at\s*\)\s+as\s+([a-zA-Z0-9_]+)/i', $select_clause, $m)) {
+                             $values = array_column($results, 'researched_at');
+                             $row[$m[1]] = count($values) > 0 ? max($values) : null;
+                         }
+
+                         return $output == OBJECT ? array((object)$row) : array($row);
+                    }
+                }
+
+                // Convert to objects
+                $results = array_values($results); // Re-index
+                if ($output == OBJECT) {
+                    $results = array_map(function($row) {
+                        return (object) $row;
+                    }, $results);
+                }
+
+                return $results;
             }
-            
+
+            public function get_row($query, $output = OBJECT, $y = 0) {
+                $results = $this->get_results($query, $output);
+                return !empty($results) ? $results[0] : null;
+            }
+
             public function get_var($query, $x = 0, $y = 0) {
+                $results = $this->get_results($query, ARRAY_A);
+                if (!empty($results)) {
+                    $row = array_values($results[0]);
+                    return isset($row[$x]) ? $row[$x] : null;
+                }
                 return null;
             }
-            
+
             public function query($query) {
+                // Handle TRUNCATE
+                if (preg_match('/TRUNCATE\s+TABLE\s+([^\s]+)/i', $query, $matches)) {
+                    $table = str_replace('`', '', $matches[1]);
+                    $this->data[$table] = array();
+                    return true;
+                }
+
+                // Handle CREATE TABLE (Initialize)
+                if (preg_match('/CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?([^\s]+)/i', $query, $matches)) {
+                    $table = str_replace('`', '', $matches[1]);
+                    if (!isset($this->data[$table])) {
+                        $this->data[$table] = array();
+                    }
+                    return true;
+                }
+
+                // Handle INSERT INTO ... VALUES ... (basic support for create_bulk)
+                if (preg_match('/INSERT\s+INTO\s+([^\s\(]+)\s*\(([^)]+)\)\s*VALUES\s*(.*)/is', $query, $matches)) {
+                    $table = str_replace('`', '', $matches[1]);
+                    $columns_str = $matches[2];
+                    $values_str = $matches[3];
+
+                    if (!isset($this->data[$table])) {
+                        $this->data[$table] = array();
+                    }
+
+                    $columns = array_map('trim', explode(',', $columns_str));
+
+                    // Simple parsing of values: assumes 'val', 'val' format and parentheses grouping
+                    // This is brittle but might work for the test case
+                    $rows = preg_split('/\)\s*,\s*\(/', $values_str);
+                    $inserted = 0;
+
+                    foreach ($rows as $row_str) {
+                        $row_str = trim($row_str, "() \t\n\r\0\x0B");
+                        // Split by comma respecting quotes is hard with simple regex, assume simple values for now
+                        // Or use str_getcsv if format allows? No, it's SQL syntax.
+                        // Assuming string values are quoted with '
+
+                        $row_values = [];
+                        $current_val = '';
+                        $in_quote = false;
+                        $len = strlen($row_str);
+                        for ($i = 0; $i < $len; $i++) {
+                            $char = $row_str[$i];
+                            if ($char === "'" && ($i === 0 || $row_str[$i-1] !== '\\')) {
+                                $in_quote = !$in_quote;
+                            } elseif ($char === ',' && !$in_quote) {
+                                $row_values[] = $current_val;
+                                $current_val = '';
+                                continue;
+                            }
+                            $current_val .= $char;
+                        }
+                        $row_values[] = $current_val;
+
+                        $data = [];
+                        foreach ($columns as $idx => $col) {
+                            $val = isset($row_values[$idx]) ? trim($row_values[$idx]) : null;
+                            // Unquote
+                            if (substr($val, 0, 1) === "'" && substr($val, -1) === "'") {
+                                $val = substr($val, 1, -1);
+                                $val = stripslashes($val);
+                            }
+                            $data[$col] = $val;
+                        }
+
+                        // Add ID
+                        static $next_insert_id = 1;
+                        if (!isset($data['id'])) {
+                            $data['id'] = $next_insert_id++;
+                        }
+
+                        $this->data[$table][] = $data;
+                        $inserted++;
+                    }
+
+                    return $inserted;
+                }
+
+                // Handle DELETE FROM ... WHERE ... IN ...
+                if (preg_match('/DELETE\s+FROM\s+([^\s]+)\s+WHERE\s+(.*)/is', $query, $matches)) {
+                    $table = str_replace('`', '', $matches[1]);
+                    $where_clause = $matches[2];
+
+                    if (!isset($this->data[$table])) {
+                        return 0;
+                    }
+
+                    $initial_count = count($this->data[$table]);
+
+                    // Parse WHERE IN
+                    if (preg_match('/([a-zA-Z0-9_]+)\s+IN\s*\((.*?)\)/i', $where_clause, $parts)) {
+                        $col = $parts[1];
+                        $vals = explode(',', str_replace("'", "", $parts[2]));
+                        $vals = array_map('trim', $vals);
+
+                        $this->data[$table] = array_filter($this->data[$table], function($row) use ($col, $vals) {
+                             if (!isset($row[$col])) return true;
+                             return !in_array((string)$row[$col], $vals);
+                        });
+
+                        // Re-index
+                        $this->data[$table] = array_values($this->data[$table]);
+
+                        return $initial_count - count($this->data[$table]);
+                    } elseif (preg_match('/([a-zA-Z0-9_]+)\s*(=|LIKE|>=|<=|>|<)\s*[\'"]?([^\'"]*)[\'"]?/i', $where_clause, $parts)) {
+                        // Simple WHERE support
+                         $col = $parts[1];
+                         $op = strtoupper($parts[2]);
+                         $val = $parts[3];
+
+                        $this->data[$table] = array_filter($this->data[$table], function($row) use ($col, $op, $val) {
+                             if (!isset($row[$col])) return true;
+
+                            if ($op === '=') {
+                                return (string)$row[$col] !== (string)$val;
+                            } elseif ($op === '<') {
+                                return $row[$col] >= $val;
+                            }
+                            // Add other ops if needed
+                            return true;
+                        });
+
+                        $this->data[$table] = array_values($this->data[$table]);
+                        return $initial_count - count($this->data[$table]);
+                    }
+
+                    return 0;
+                }
+
                 return true;
             }
-            
+
             public function insert($table, $data, $format = null) {
                 static $next_insert_id = 1;
                 $this->insert_id = $next_insert_id++;
-                return true;
+
+                if (!isset($this->data[$table])) {
+                    $this->data[$table] = array();
+                }
+
+                // Add ID if not present
+                if (!isset($data['id'])) {
+                    $data['id'] = $this->insert_id;
+                }
+
+                $this->data[$table][] = $data;
+                return 1;
             }
-            
+
             public function update($table, $data, $where, $format = null, $where_format = null) {
-                return true;
+                if (!isset($this->data[$table])) {
+                    return false;
+                }
+
+                $updated_count = 0;
+                foreach ($this->data[$table] as $key => $row) {
+                    $match = true;
+                    foreach ($where as $col => $val) {
+                        if (!isset($row[$col]) || $row[$col] != $val) {
+                            $match = false;
+                            break;
+                        }
+                    }
+
+                    if ($match) {
+                        $this->data[$table][$key] = array_merge($row, $data);
+                        $updated_count++;
+                    }
+                }
+
+                return $updated_count;
             }
-            
+
             public function delete($table, $where, $where_format = null) {
-                return true;
+                if (!isset($this->data[$table])) {
+                    return false;
+                }
+
+                $deleted_count = 0;
+                foreach ($this->data[$table] as $key => $row) {
+                    $match = true;
+                    foreach ($where as $col => $val) {
+                        if (!isset($row[$col]) || $row[$col] != $val) {
+                            $match = false;
+                            break;
+                        }
+                    }
+
+                    if ($match) {
+                        unset($this->data[$table][$key]);
+                        $deleted_count++;
+                    }
+                }
+
+                $this->data[$table] = array_values($this->data[$table]); // Re-index
+                return $deleted_count;
             }
 
             public function get_charset_collate() {
@@ -864,16 +1180,24 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             }
 
             public function get_col($query = null, $x = 0) {
-                return array();
+                 $results = $this->get_results($query, ARRAY_A);
+                 $col = array();
+                 foreach ($results as $row) {
+                     $values = array_values($row);
+                     if (isset($values[$x])) {
+                         $col[] = $values[$x];
+                     }
+                 }
+                 return $col;
             }
         };
     }
-    
+
     // Mock global $wp_filter for action/filter hooks
     if (!isset($GLOBALS['wp_filter'])) {
         $GLOBALS['wp_filter'] = array();
     }
-    
+
     // Load plugin classes
     $includes_dir = dirname(__DIR__) . '/includes/';
     $files = [
@@ -913,8 +1237,9 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
         'class-aips-structures-controller.php',
         'class-aips-templates-controller.php',
         'class-aips-research-controller.php',
+        'class-aips-trending-topics-repository.php', // Added this one
     ];
-    
+
     foreach ($files as $file) {
         if (file_exists($includes_dir . $file)) {
             require_once $includes_dir . $file;


### PR DESCRIPTION
Enhanced the $wpdb mock in tests/bootstrap.php to be stateful and support basic SQL parsing (INSERT, DELETE, SELECT with WHERE/ORDER/LIMIT/GROUP/AGGREGATES). This fixes numerous test failures in repository tests that rely on database operations.

---
*PR created automatically by Jules for task [4049044876936447431](https://jules.google.com/task/4049044876936447431) started by @rpnunez*