### PR TITLE
Fix History Repository Performance and Enhance Test Infrastructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - 2024-05-30: Optimized author topic generation by replacing iterative database inserts with a single bulk INSERT query, reducing database round-trips from N to 1.
 
 ### Fixed
+- [2026-05-27] Fixed performance regression in `AIPS_History_Repository::get_history` where duplicated columns were selected. Default behavior is now optimized to select only list columns.
 - 2024-05-28: Fixed infinite loop in schedule processing where failed "One Time" schedules were incorrectly rescheduled for the next day. They are now deactivated upon failure.
 
 ### Added

--- a/ai-post-scheduler/includes/class-aips-history-repository.php
+++ b/ai-post-scheduler/includes/class-aips-history-repository.php
@@ -72,7 +72,7 @@ class AIPS_History_Repository {
             'template_id' => 0,
             'orderby' => 'created_at',
             'order' => 'DESC',
-            'fields' => 'all',
+            'fields' => 'list', // Optimized default
         );
         
         $args = wp_parse_args($args, $defaults);
@@ -82,7 +82,7 @@ class AIPS_History_Repository {
         // Build select fields
         $fields_sql = "h.*, t.name as template_name";
         if ($args['fields'] === 'list') {
-            $fields_sql = "h.id, h.uuid, h.post_id, h.template_id, h.status, h.generated_title, h.created_at, h.error_message, h.created_at, h.completed_at, t.name as template_name";
+            $fields_sql = "h.id, h.uuid, h.post_id, h.template_id, h.status, h.generated_title, h.error_message, h.created_at, h.completed_at, t.name as template_name";
         }
 
         // Build where clauses

--- a/ai-post-scheduler/tests/bootstrap.php
+++ b/ai-post-scheduler/tests/bootstrap.php
@@ -30,42 +30,42 @@ if (!defined('WP_CORE_DIR')) {
 // Check if WordPress test library exists
 if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
     require_once WP_TESTS_DIR . '/includes/functions.php';
-    
+
     /**
      * Manually load the plugin being tested.
      */
     function _manually_load_plugin() {
         define('ABSPATH', WP_CORE_DIR . '/');
-        
+
         // Load plugin files
         require dirname(__DIR__) . '/ai-post-scheduler.php';
     }
     tests_add_filter('muplugins_loaded', '_manually_load_plugin');
-    
+
     // Start up the WP testing environment
     require WP_TESTS_DIR . '/includes/bootstrap.php';
 } else {
     // Fallback when WordPress test library is not available
     echo "Warning: WordPress test library not found at " . WP_TESTS_DIR . "\n";
     echo "Tests will run in limited mode without WordPress environment.\n\n";
-    
+
     // Define minimal WordPress constants and functions for basic testing
     if (!defined('ABSPATH')) {
         define('ABSPATH', dirname(__DIR__) . '/');
     }
-    
+
     if (!defined('AIPS_VERSION')) {
         define('AIPS_VERSION', '1.4.0');
     }
-    
+
     if (!defined('AIPS_PLUGIN_DIR')) {
         define('AIPS_PLUGIN_DIR', dirname(__DIR__) . '/');
     }
-    
+
     if (!defined('AIPS_PLUGIN_URL')) {
         define('AIPS_PLUGIN_URL', 'http://example.com/wp-content/plugins/ai-post-scheduler/');
     }
-    
+
     if (!defined('AIPS_PLUGIN_BASENAME')) {
         define('AIPS_PLUGIN_BASENAME', 'ai-post-scheduler/ai-post-scheduler.php');
     }
@@ -76,16 +76,16 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             'filters' => array(),
         );
     }
-    
+
     // WordPress constants
     if (!defined('OBJECT')) {
         define('OBJECT', 'OBJECT');
     }
-    
+
     if (!defined('ARRAY_A')) {
         define('ARRAY_A', 'ARRAY_A');
     }
-    
+
     if (!defined('ARRAY_N')) {
         define('ARRAY_N', 'ARRAY_N');
     }
@@ -93,7 +93,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
     if (!defined('HOUR_IN_SECONDS')) {
         define('HOUR_IN_SECONDS', 3600);
     }
-    
+
     // Mock WordPress functions if not available
     if (!function_exists('esc_html__')) {
         function esc_html__($text, $domain = 'default') {
@@ -130,25 +130,25 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return $url;
         }
     }
-    
+
     if (!function_exists('plugin_dir_path')) {
         function plugin_dir_path($file) {
             return dirname($file) . '/';
         }
     }
-    
+
     if (!function_exists('plugin_dir_url')) {
         function plugin_dir_url($file) {
             return 'http://example.com/wp-content/plugins/' . basename(dirname($file)) . '/';
         }
     }
-    
+
     if (!function_exists('plugin_basename')) {
         function plugin_basename($file) {
             return basename(dirname($file)) . '/' . basename($file);
         }
     }
-    
+
     if (!function_exists('add_action')) {
         function add_action($hook, $callback, $priority = 10, $accepted_args = 1) {
             if (!isset($GLOBALS['aips_test_hooks']['actions'][$hook])) {
@@ -165,7 +165,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             );
         }
     }
-    
+
     if (!function_exists('add_filter')) {
         function add_filter($hook, $callback, $priority = 10, $accepted_args = 1) {
             if (!isset($GLOBALS['aips_test_hooks']['filters'][$hook])) {
@@ -182,7 +182,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             );
         }
     }
-    
+
     if (!function_exists('apply_filters')) {
         function apply_filters($hook, $value) {
             $args = func_get_args();
@@ -203,7 +203,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return $value;
         }
     }
-    
+
     if (!function_exists('do_action')) {
         function do_action($hook) {
             $args = func_get_args();
@@ -285,7 +285,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return delete_option('_transient_' . $transient);
         }
     }
-    
+
     if (!function_exists('current_time')) {
         function current_time($type = 'mysql', $gmt = 0) {
             $timestamp = $gmt ? time() : time(); // Simplified time handling
@@ -302,13 +302,13 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return date($type, $timestamp);
         }
     }
-    
+
     if (!function_exists('wp_json_encode')) {
         function wp_json_encode($data, $options = 0, $depth = 512) {
             return json_encode($data, $options, $depth);
         }
     }
-    
+
     if (!function_exists('wp_upload_dir')) {
         function wp_upload_dir() {
             return [
@@ -330,12 +330,12 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return true;
         }
     }
-    
+
     if (!class_exists('WP_Error')) {
         class WP_Error {
             private $errors = [];
             private $error_data = [];
-            
+
             public function __construct($code = '', $message = '', $data = '') {
                 if (empty($code)) {
                     return;
@@ -345,12 +345,12 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
                     $this->error_data[$code] = $data;
                 }
             }
-            
+
             public function get_error_code() {
                 $codes = array_keys($this->errors);
                 return empty($codes) ? '' : $codes[0];
             }
-            
+
             public function get_error_message($code = '') {
                 if (empty($code)) {
                     $code = $this->get_error_code();
@@ -358,14 +358,14 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
                 $messages = isset($this->errors[$code]) ? $this->errors[$code] : [];
                 return empty($messages) ? '' : $messages[0];
             }
-            
+
             public function get_error_data($code = '') {
                 if (empty($code)) {
                     $code = $this->get_error_code();
                 }
                 return isset($this->error_data[$code]) ? $this->error_data[$code] : null;
             }
-            
+
             public function add($code, $message, $data = '') {
                 $this->errors[$code][] = $message;
                 if (!empty($data)) {
@@ -374,7 +374,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             }
         }
     }
-    
+
     if (!function_exists('is_wp_error')) {
         function is_wp_error($thing) {
             return ($thing instanceof WP_Error);
@@ -510,12 +510,12 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return true;
         }
     }
-    
+
     if (!class_exists('WP_UnitTestCase')) {
         // Provide a basic test case for when WordPress test library is not available
         class WP_UnitTestCase extends \PHPUnit\Framework\TestCase {
             protected $factory;
-            
+
             public function setUp(): void {
                 parent::setUp();
                 if (!isset($this->factory)) {
@@ -535,7 +535,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
                     };
                 }
             }
-            
+
             public function tearDown(): void {
                 $this->reset_hooks();
                 parent::tearDown();
@@ -558,7 +558,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             }
         }
     }
-    
+
     // Mock AJAX functions
     if (!function_exists('check_ajax_referer')) {
         function check_ajax_referer($action = -1, $query_arg = '_wpnonce', $die = true) {
@@ -572,39 +572,39 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return 1;
         }
     }
-    
+
     if (!function_exists('wp_die')) {
         function wp_die($message = '', $title = '', $args = array()) {
             throw new WPAjaxDieStopException($message);
         }
     }
-    
+
     if (!function_exists('wp_create_nonce')) {
         function wp_create_nonce($action = -1) {
             return 'test_nonce_' . $action;
         }
     }
-    
+
     if (!function_exists('wp_verify_nonce')) {
         function wp_verify_nonce($nonce, $action = -1) {
             return $nonce === wp_create_nonce($action) ? 1 : false;
         }
     }
-    
+
     if (!function_exists('wp_send_json_success')) {
         function wp_send_json_success($data = null, $status_code = null) {
             echo json_encode(array('success' => true, 'data' => $data));
             throw new WPAjaxDieContinueException();
         }
     }
-    
+
     if (!function_exists('wp_send_json_error')) {
         function wp_send_json_error($data = null, $status_code = null) {
             echo json_encode(array('success' => false, 'data' => $data));
             throw new WPAjaxDieContinueException();
         }
     }
-    
+
     if (!function_exists('wp_set_current_user')) {
         function wp_set_current_user($id, $name = '') {
             global $current_user_id;
@@ -612,7 +612,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return $id;
         }
     }
-    
+
     if (!function_exists('current_user_can')) {
         function current_user_can($capability) {
             global $current_user_id, $test_users;
@@ -627,39 +627,39 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return false;
         }
     }
-    
+
     if (!function_exists('sanitize_text_field')) {
         function sanitize_text_field($str) {
             return strip_tags($str);
         }
     }
-    
+
     if (!function_exists('sanitize_file_name')) {
         function sanitize_file_name($filename) {
             $filename = preg_replace('/[^a-zA-Z0-9._-]/', '_', $filename);
             return $filename;
         }
     }
-    
+
     if (!function_exists('sanitize_textarea_field')) {
         function sanitize_textarea_field($str) {
             return strip_tags($str);
         }
     }
-    
+
     if (!function_exists('wp_kses_post')) {
         function wp_kses_post($data) {
             // Allow some HTML tags
             return strip_tags($data, '<a><strong><em><p><br><ul><ol><li>');
         }
     }
-    
+
     if (!function_exists('absint')) {
         function absint($maybeint) {
             return abs(intval($maybeint));
         }
     }
-    
+
     if (!function_exists('__')) {
         function __($text, $domain = 'default') {
             return $text;
@@ -753,7 +753,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return $result;
         }
     }
-    
+
     if (!function_exists('wp_parse_args')) {
         function wp_parse_args($args, $defaults = array()) {
             if (is_object($args)) {
@@ -763,117 +763,34 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             } else {
                 parse_str($args, $parsed_args);
             }
-            
+
             if (is_array($defaults)) {
                 return array_merge($defaults, $parsed_args);
             }
             return $parsed_args;
         }
     }
-    
+
     // AJAX exception classes for testing
     if (!class_exists('WPAjaxDieContinueException')) {
         class WPAjaxDieContinueException extends Exception {}
     }
-    
+
     if (!class_exists('WPAjaxDieStopException')) {
         class WPAjaxDieStopException extends Exception {}
     }
-    
+
     // Mock global $wpdb
     if (!isset($GLOBALS['wpdb'])) {
-        $GLOBALS['wpdb'] = new class {
-            public $prefix = 'wp_';
-            public $insert_id = 0;
-            private $data = array();
-            
-            public function esc_like($text) {
-                return addcslashes($text, '_%\\');
-            }
-
-            public function prepare($query, ...$args) {
-                // Simple mock prepare - just return the query with args
-                // In real implementation, this would properly escape and format
-                if (empty($args)) {
-                    return $query;
-                }
-
-                // Handle array argument (WP 3.5+)
-                if (count($args) === 1 && is_array($args[0])) {
-                    $args = $args[0];
-                }
-
-                // Replace placeholders in order
-                foreach ($args as $arg) {
-                    if (is_array($arg)) {
-                        // Handle array args (e.g., for IN clauses)
-                        $arg = "'" . implode("','", $arg) . "'";
-                        $query = preg_replace('/%[sd]/', $arg, $query, 1);
-                    } else {
-                        $query = preg_replace('/%[sd]/', is_numeric($arg) ? $arg : "'$arg'", $query, 1);
-                    }
-                }
-                return $query;
-            }
-            
-            public function get_results($query, $output = OBJECT) {
-                return array();
-            }
-            
-            public function get_row($query, $output = OBJECT, $y = 0) {
-                // Return a default object with common properties to prevent null reference errors
-                $obj = new stdClass();
-                $obj->id = 1; // Default ID
-                $obj->total = 0;
-                $obj->completed = 0;
-                $obj->failed = 0;
-                $obj->processing = 0;
-                $obj->count = 0;
-
-                if ($output == ARRAY_A) {
-                    return (array) $obj;
-                }
-
-                return $obj;
-            }
-            
-            public function get_var($query, $x = 0, $y = 0) {
-                return null;
-            }
-            
-            public function query($query) {
-                return true;
-            }
-            
-            public function insert($table, $data, $format = null) {
-                static $next_insert_id = 1;
-                $this->insert_id = $next_insert_id++;
-                return true;
-            }
-            
-            public function update($table, $data, $where, $format = null, $where_format = null) {
-                return true;
-            }
-            
-            public function delete($table, $where, $where_format = null) {
-                return true;
-            }
-
-            public function get_charset_collate() {
-                return "DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci";
-            }
-
-            public function get_col($query = null, $x = 0) {
-                return array();
-            }
-        };
+        require_once __DIR__ . '/mock-wpdb-implementation.php';
+        $GLOBALS['wpdb'] = new MockWPDB();
     }
-    
+
     // Mock global $wp_filter for action/filter hooks
     if (!isset($GLOBALS['wp_filter'])) {
         $GLOBALS['wp_filter'] = array();
     }
-    
+
     // Load plugin classes
     $includes_dir = dirname(__DIR__) . '/includes/';
     $files = [
@@ -914,7 +831,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
         'class-aips-templates-controller.php',
         'class-aips-research-controller.php',
     ];
-    
+
     foreach ($files as $file) {
         if (file_exists($includes_dir . $file)) {
             require_once $includes_dir . $file;

--- a/ai-post-scheduler/tests/mock-wpdb-implementation.php
+++ b/ai-post-scheduler/tests/mock-wpdb-implementation.php
@@ -1,0 +1,495 @@
+<?php
+
+class MockWPDB {
+    public $prefix = 'wp_';
+    public $insert_id = 0;
+    public $last_error = '';
+    private $data = array();
+
+    public function esc_like($text) {
+        if ($text === null) {
+            return '';
+        }
+        return addcslashes($text, '_%\\');
+    }
+
+    public function prepare($query, ...$args) {
+        if (empty($args)) {
+            return $query;
+        }
+        if (count($args) === 1 && is_array($args[0])) {
+            $args = $args[0];
+        }
+
+        $query = str_replace("'%s'", '%s', $query); // Fix double quotes if any
+        $query = str_replace("'%d'", '%d', $query);
+        $query = str_replace("'%f'", '%f', $query);
+
+        foreach ($args as $arg) {
+            if (is_array($arg)) {
+                // For IN clauses mostly, though standard wpdb::prepare doesn't handle arrays directly like this usually
+                // But for our mock simplistic replacement:
+                $arg = implode("','", array_map(function($a) { return addslashes((string)$a); }, $arg));
+                $query = preg_replace('/%[sdf]/', "'$arg'", $query, 1);
+            } else {
+                $val = is_numeric($arg) ? $arg : "'" . addslashes((string)$arg) . "'";
+                $query = preg_replace('/%[sdf]/', $val, $query, 1);
+            }
+        }
+        return $query;
+    }
+
+    public function get_results($query, $output = 'OBJECT') {
+        $query = trim($query);
+
+        // Basic parsing
+        if (preg_match('/^SELECT\s+(.+?)\s+FROM\s+([^\s]+)(.*)$/is', $query, $matches)) {
+            $fields_str = $matches[1];
+            $table = $matches[2];
+            $rest = $matches[3];
+
+            // Clean table name (remove backticks if any)
+            $table = str_replace('`', '', $table);
+
+            if (!isset($this->data[$table])) {
+                return array();
+            }
+
+            $rows = $this->data[$table];
+
+            // Handle JOINs (simplistic: ignored, assuming data is already flattened or we don't support joins well)
+            // If JOIN is present, we might be in trouble.
+            // The tests use JOIN for templates.
+            // "LEFT JOIN wp_aips_templates t ON h.template_id = t.id"
+
+            if (stripos($rest, 'JOIN') !== false) {
+                 // Simplistic JOIN handling: Just ignore it for now and return base table rows
+                 // Or better: if we can identify the joined table, maybe we can do something?
+                 // But for now let's just proceed with the base table.
+            }
+
+            // Handle WHERE
+            if (preg_match('/WHERE\s+(.*?)(ORDER BY|LIMIT|$)/is', $rest, $where_matches)) {
+                $where_clause = $where_matches[1];
+                $rows = array_filter($rows, function($row) use ($where_clause) {
+                    return $this->evaluate_where($where_clause, $row);
+                });
+            }
+
+            // Handle ORDER BY
+            if (preg_match('/ORDER BY\s+(.*?)(LIMIT|$)/is', $rest, $order_matches)) {
+                $order_clause = $order_matches[1];
+                $this->sort_rows($rows, $order_clause);
+            }
+
+            // Handle LIMIT/OFFSET
+            if (preg_match('/LIMIT\s+(\d+)(?:\s+OFFSET\s+(\d+))?/is', $rest, $limit_matches)) {
+                $limit = intval($limit_matches[1]);
+                $offset = isset($limit_matches[2]) ? intval($limit_matches[2]) : 0;
+                $rows = array_slice($rows, $offset, $limit);
+            }
+
+            // Handle formatting
+            if ($output == 'ARRAY_A') {
+                return array_map(function($row) { return (array)$row; }, $rows);
+            }
+
+            // Convert array to objects
+            return array_map(function($row) { return (object)$row; }, $rows);
+        }
+
+        return array();
+    }
+
+    public function get_row($query, $output = 'OBJECT', $y = 0) {
+        $results = $this->get_results($query, $output);
+
+        if (!empty($results)) {
+            return $results[0];
+        }
+
+        // Fallback to default object to support legacy tests
+        $obj = new stdClass();
+        $obj->id = 1;
+        $obj->total = 0;
+        $obj->completed = 0;
+        $obj->failed = 0;
+        $obj->processing = 0;
+        $obj->count = 0;
+
+        if ($output == 'ARRAY_A') {
+            return (array) $obj;
+        }
+
+        return $obj;
+    }
+
+    public function get_var($query, $x = 0, $y = 0) {
+        $results = $this->get_results($query, 'ARRAY_A');
+        if (!empty($results)) {
+            $row = array_values($results[0]);
+            return isset($row[$x]) ? $row[$x] : null;
+        }
+
+        // Handle COUNT(*) specifically if get_results failed to parse it or returned full rows
+        if (preg_match('/SELECT\s+COUNT\(\*\)\s+FROM\s+([^\s]+)(.*)/is', $query, $matches)) {
+             // Re-use get_results logic but with * to get count
+             // Hacky way: replace COUNT(*) with * and count results
+             $list_query = str_replace('COUNT(*)', '*', $query);
+             $results = $this->get_results($list_query, 'ARRAY_A');
+             return count($results);
+        }
+
+        return null;
+    }
+
+    public function query($query) {
+        $query = trim($query);
+
+        // Handle INSERT
+        if (stripos($query, 'INSERT INTO') === 0) {
+            // INSERT INTO table (cols) VALUES (vals), (vals)
+            if (preg_match('/INSERT INTO\s+([^\s]+)\s*\((.*?)\)\s*VALUES\s*(.*)/is', $query, $matches)) {
+                $table = $matches[1];
+                $columns = array_map('trim', explode(',', $matches[2]));
+                $values_str = $matches[3];
+
+                // Parse values using simpler split logic because quoted strings are hard in regex
+                // But since values are coming from prepare(), they are well-formed.
+                // Rows are separated by "), ("
+
+                // Hacky split: split by "), ("
+                // This assumes no string contains "), ("
+                // This is risky but likely covers 99% of cases here.
+
+                // First, remove outer parens of the whole block if needed? No, standard is (val), (val)
+
+                // Let's iterate to find rows
+                $rows = array();
+                $buffer = '';
+                $in_quote = false;
+                $paren_depth = 0;
+                $len = strlen($values_str);
+
+                for ($i = 0; $i < $len; $i++) {
+                    $char = $values_str[$i];
+
+                    if ($char === "'") {
+                        if ($i > 0 && $values_str[$i-1] === '\\') {
+                            // Escaped quote
+                        } else {
+                            $in_quote = !$in_quote;
+                        }
+                    } elseif ($char === '(' && !$in_quote) {
+                        $paren_depth++;
+                    } elseif ($char === ')' && !$in_quote) {
+                        $paren_depth--;
+                    }
+
+                    $buffer .= $char;
+
+                    if ($paren_depth === 0 && $char === ')' && !$in_quote) {
+                        // End of row
+                        // Check if next char is comma
+                        $next_char = ($i + 1 < $len) ? $values_str[$i+1] : '';
+                        while (($i + 1 < $len) && ctype_space($values_str[$i+1])) {
+                             $i++; // skip space
+                             $next_char = ($i + 1 < $len) ? $values_str[$i+1] : '';
+                        }
+
+                        if ($next_char === ',' || $i + 1 >= $len) {
+                            $rows[] = trim($buffer);
+                            $buffer = '';
+                            if ($next_char === ',') $i++; // Skip comma
+                        }
+                    }
+                }
+
+                if (!empty($buffer) && trim($buffer) !== '') {
+                    $rows[] = trim($buffer);
+                }
+
+                foreach ($rows as $row_str) {
+                    // row_str is like (1, 'val')
+                    $row_str = trim($row_str, '()');
+
+                    // Split values by comma, respecting quotes
+                    $values = str_getcsv($row_str, ',', "'");
+
+                    $data = array();
+                    foreach ($columns as $i => $col) {
+                        $val = isset($values[$i]) ? $values[$i] : null;
+                        // Values from str_getcsv might be strings "1" or "'val'".
+                        // str_getcsv removes quotes if enclosed properly? Yes.
+                        // But wait, prepare() adds quotes. So input is 'val'.
+                        // str_getcsv with quote="'" will strip outer quotes.
+                        // So 'val' becomes val.
+                        // 1 becomes 1.
+                        // 'val\'s' becomes val's.
+
+                        $data[$col] = $val;
+                    }
+                    $this->insert($table, $data);
+                }
+                return count($rows);
+            }
+        }
+
+        // Handle TRUNCATE
+        if (stripos($query, 'TRUNCATE TABLE') === 0) {
+            if (preg_match('/TRUNCATE TABLE\s+([^\s]+)/is', $query, $matches)) {
+                $table = $matches[1];
+                $this->data[$table] = array();
+                return true;
+            }
+        }
+
+        // Handle DELETE
+        if (stripos($query, 'DELETE FROM') === 0) {
+             // Use get_results logic to find rows to delete?
+             // Simpler: iterate and delete
+             if (preg_match('/DELETE FROM\s+([^\s]+)(.*)/is', $query, $matches)) {
+                 $table = $matches[1];
+                 $rest = $matches[2];
+
+                 if (!isset($this->data[$table])) {
+                     return 0;
+                 }
+
+                 if (empty(trim($rest))) {
+                     // Delete all
+                     $count = count($this->data[$table]);
+                     $this->data[$table] = array();
+                     return $count;
+                 }
+
+                 if (preg_match('/WHERE\s+(.*)/is', $rest, $where_matches)) {
+                     $where_clause = $where_matches[1];
+                     $initial_count = count($this->data[$table]);
+                     $this->data[$table] = array_filter($this->data[$table], function($row) use ($where_clause) {
+                         return !$this->evaluate_where($where_clause, $row);
+                     });
+                     // Re-index array
+                     $this->data[$table] = array_values($this->data[$table]);
+                     return $initial_count - count($this->data[$table]);
+                 }
+             }
+        }
+
+        return true;
+    }
+
+    public function insert($table, $data, $format = null) {
+        if (!isset($this->data[$table])) {
+            $this->data[$table] = array();
+        }
+
+        static $next_ids = array();
+        if (!isset($next_ids[$table])) {
+            $next_ids[$table] = 1;
+        }
+
+        if (!isset($data['id'])) {
+            $data['id'] = $next_ids[$table]++;
+        }
+
+        $this->data[$table][] = $data;
+        $this->insert_id = $data['id'];
+        return 1;
+    }
+
+    public function update($table, $data, $where, $format = null, $where_format = null) {
+        if (!isset($this->data[$table])) {
+            return false;
+        }
+
+        $updated_count = 0;
+        foreach ($this->data[$table] as &$row) {
+            $match = true;
+            foreach ($where as $key => $val) {
+                if (!isset($row[$key]) || $row[$key] != $val) {
+                    $match = false;
+                    break;
+                }
+            }
+
+            if ($match) {
+                foreach ($data as $key => $val) {
+                    $row[$key] = $val;
+                }
+                $updated_count++;
+            }
+        }
+        return $updated_count;
+    }
+
+    public function delete($table, $where, $where_format = null) {
+        if (!isset($this->data[$table])) {
+            return false;
+        }
+
+        $initial_count = count($this->data[$table]);
+        $this->data[$table] = array_filter($this->data[$table], function($row) use ($where) {
+            foreach ($where as $key => $val) {
+                if (!isset($row[$key]) || $row[$key] != $val) {
+                    return true; // Keep row if it doesn't match
+                }
+            }
+            return false; // Remove row if it matches
+        });
+
+        // Re-index
+        $this->data[$table] = array_values($this->data[$table]);
+
+        return $initial_count - count($this->data[$table]);
+    }
+
+    public function get_charset_collate() {
+        return "DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci";
+    }
+
+    public function get_col($query = null, $x = 0) {
+        $results = $this->get_results($query, 'ARRAY_N');
+        $col = array();
+        foreach ($results as $row) {
+            if (isset($row[$x])) {
+                $col[] = $row[$x];
+            }
+        }
+        return $col;
+    }
+
+    private function evaluate_where($where_clause, $row) {
+        // Very basic evaluator
+        // Handles: AND, =, >=, <=, LIKE, IN
+
+        // Remove 1=1
+        $where_clause = str_replace('1=1', '1=1', $where_clause); // no-op
+
+        $parts = explode(' AND ', $where_clause);
+
+        foreach ($parts as $part) {
+            $part = trim($part);
+            if ($part == '1=1') continue;
+            if (empty($part)) continue;
+
+            // h.status = 'value'
+            if (preg_match('/^([a-zA-Z0-9_.]+)\s*(=|>=|<=|>|<|!=)\s*(.*)$/', $part, $matches)) {
+                $col = trim($matches[1]);
+                $op = $matches[2];
+                $val = trim($matches[3], "' ");
+
+                // Remove table alias prefix if present (h.status -> status)
+                if (strpos($col, '.') !== false) {
+                    $col = explode('.', $col)[1];
+                }
+
+                if (!isset($row[$col])) {
+                    // If column missing, assuming false unless checking for null?
+                    // For now strict.
+                    return false;
+                }
+
+                $row_val = $row[$col];
+
+                switch ($op) {
+                    case '=': if ($row_val != $val) return false; break;
+                    case '!=': if ($row_val == $val) return false; break;
+                    case '>=': if ($row_val < $val) return false; break;
+                    case '<=': if ($row_val > $val) return false; break;
+                    case '>': if ($row_val <= $val) return false; break;
+                    case '<': if ($row_val >= $val) return false; break;
+                }
+            }
+            // LIKE
+            elseif (preg_match('/^([a-zA-Z0-9_.]+)\s+LIKE\s+(.*)$/i', $part, $matches)) {
+                $col = trim($matches[1]);
+                $val = trim($matches[2], "' ");
+
+                 if (strpos($col, '.') !== false) {
+                    $col = explode('.', $col)[1];
+                }
+
+                if (!isset($row[$col])) return false;
+
+                // Convert SQL LIKE to Regex
+                $pattern = '/^' . str_replace('%', '.*', preg_quote($val, '/')) . '$/i';
+                // Unescape % which were quoted
+                $pattern = str_replace(preg_quote('%', '/'), '.*', $pattern); // This is getting messy.
+                // Simple version:
+                $val_regex = str_replace('%', '.*', $val);
+                if (!preg_match("/$val_regex/i", $row[$col])) return false;
+            }
+            // IN
+            elseif (preg_match('/^([a-zA-Z0-9_.]+)\s+IN\s*\((.*)\)$/i', $part, $matches)) {
+                $col = trim($matches[1]);
+                $vals_str = $matches[2];
+
+                 if (strpos($col, '.') !== false) {
+                    $col = explode('.', $col)[1];
+                }
+
+                if (!isset($row[$col])) return false;
+
+                $vals = str_getcsv($vals_str, ',', "'");
+                $vals = array_map('trim', $vals); // trim quotes/spaces
+
+                // Need to clean quotes from str_getcsv results if they persist
+                $cleaned_vals = [];
+                foreach($vals as $v) $cleaned_vals[] = trim($v, "'");
+
+                if (!in_array($row[$col], $cleaned_vals)) return false;
+            }
+            // DATE_SUB logic (researched_at >= DATE_SUB(NOW(), INTERVAL 7 DAY))
+            elseif (preg_match('/^([a-zA-Z0-9_.]+)\s*(>=|<=|>|<)\s*DATE_SUB\(NOW\(\),\s*INTERVAL\s+(\d+)\s+DAY\)/i', $part, $matches)) {
+                 $col = trim($matches[1]);
+                 $op = $matches[2];
+                 $days = intval($matches[3]);
+
+                 if (strpos($col, '.') !== false) {
+                    $col = explode('.', $col)[1];
+                }
+
+                if (!isset($row[$col])) return false;
+
+                $row_time = strtotime($row[$col]);
+                $limit_time = strtotime("-$days days");
+
+                switch ($op) {
+                    case '>=': if ($row_time < $limit_time) return false; break;
+                    case '<=': if ($row_time > $limit_time) return false; break;
+                    case '>': if ($row_time <= $limit_time) return false; break;
+                    case '<': if ($row_time >= $limit_time) return false; break;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private function sort_rows(&$rows, $order_clause) {
+        // "h.created_at DESC"
+        $parts = explode(',', $order_clause);
+        // Only handle first order for now
+        $part = trim($parts[0]);
+
+        if (preg_match('/^([a-zA-Z0-9_.]+)(\s+(ASC|DESC))?$/i', $part, $matches)) {
+            $col = $matches[1];
+            $dir = isset($matches[3]) ? strtoupper($matches[3]) : 'ASC';
+
+            if (strpos($col, '.') !== false) {
+                $col = explode('.', $col)[1];
+            }
+
+            usort($rows, function($a, $b) use ($col, $dir) {
+                $valA = isset($a[$col]) ? $a[$col] : null;
+                $valB = isset($b[$col]) ? $b[$col] : null;
+
+                if ($valA == $valB) return 0;
+
+                $res = ($valA < $valB) ? -1 : 1;
+                return ($dir === 'DESC') ? -$res : $res;
+            });
+        }
+    }
+}


### PR DESCRIPTION
This PR addresses performance issues in `AIPS_History_Repository` and significantly improves the test environment.

**Hunter (Stability/Bug Fix):**
- Fixed a bug in `AIPS_History_Repository::get_history` where `created_at` was selected twice in `list` mode.
- Changed the default behavior of `get_history` to use `list` mode (explicit columns) instead of `all` (previously `*`), reducing memory usage and database load. This resolves the failure in `Test_AIPS_History_Repository_Performance`.

**Atlas (Architecture/Test Infrastructure):**
- Refactored `tests/bootstrap.php` to use a dedicated `MockWPDB` class defined in `tests/mock-wpdb-implementation.php`.
- The new `MockWPDB` provides a stateful in-memory database simulation, allowing for better testing of repository CRUD operations compared to the previous stateless mock.
- Implemented basic SQL parsing for `INSERT`, `UPDATE`, `DELETE`, and `SELECT` to support standard WPDB methods.
- Added backward compatibility to `get_row` to support existing tests that expect a default object instead of null.

---
*PR created automatically by Jules for task [11460421367933857523](https://jules.google.com/task/11460421367933857523) started by @rpnunez*