### PR TITLE
Fix AI Service JSON generation and improve Logger interface

### DIFF
--- a/ai-post-scheduler/includes/class-aips-ai-service.php
+++ b/ai-post-scheduler/includes/class-aips-ai-service.php
@@ -260,11 +260,7 @@ class AIPS_AI_Service {
                 $this->logger->log('Calling simpleJsonQuery with params: ' . wp_json_encode(array_keys($json_query_params)), 'debug');
                 
                 // Use simpleJsonQuery which returns structured JSON data
-                // $result = $mwai->simpleJsonQuery($prompt, $json_query_params);
-                $result = $mwai->simpleJsonQuery($prompt);
-
-                error_log('Result type: ' . gettype($result));
-                error_log('Result content: ' . var_export($result, true));
+                $result = $mwai->simpleJsonQuery($prompt, $json_query_params);
                 
                 if (empty($result)) {
                     $error = new WP_Error('empty_response', __('AI Engine returned an empty JSON response.', 'ai-post-scheduler'));

--- a/ai-post-scheduler/includes/class-aips-generation-logger.php
+++ b/ai-post-scheduler/includes/class-aips-generation-logger.php
@@ -109,11 +109,6 @@ class AIPS_Generation_Logger {
      * @param array $context Context data.
      */
     public function warning($message, $context = array()) {
-        // Fix potential bug where logger doesn't have warning method
-        if (method_exists($this->logger, 'warning')) {
-            $this->logger->warning($message, $context);
-        } else {
-            $this->logger->log($message, 'warning', $context);
-        }
+        $this->logger->warning($message, $context);
     }
 }

--- a/ai-post-scheduler/includes/class-aips-logger.php
+++ b/ai-post-scheduler/includes/class-aips-logger.php
@@ -88,6 +88,26 @@ class AIPS_Logger {
         }
     }
     
+    /**
+     * Log a warning message.
+     *
+     * @param string $message Warning message.
+     * @param array $context Context data.
+     */
+    public function warning($message, $context = array()) {
+        $this->log($message, 'warning', $context);
+    }
+
+    /**
+     * Log an error message.
+     *
+     * @param string $message Error message.
+     * @param array $context Context data.
+     */
+    public function error($message, $context = array()) {
+        $this->log($message, 'error', $context);
+    }
+
     public function get_logs($lines = 100) {
         if (!file_exists($this->log_file)) {
             return array();

--- a/ai-post-scheduler/tests/test-generation-logger.php
+++ b/ai-post-scheduler/tests/test-generation-logger.php
@@ -60,7 +60,7 @@ class Test_AIPS_Generation_Logger extends WP_UnitTestCase {
 					return isset($details['prompt']) &&
 					       isset($details['options']) &&
 					       isset($details['response']) &&
-					       isset($details['error']) &&
+					       array_key_exists('error', $details) &&
 					       $details['prompt'] === 'Generate a title' &&
 					       $details['response'] === base64_encode('Great Title') &&
 					       $details['error'] === null;
@@ -254,32 +254,6 @@ class Test_AIPS_Generation_Logger extends WP_UnitTestCase {
 
 		$generation_logger = new AIPS_Generation_Logger(
 			$logger_with_warning,
-			$this->history_repository,
-			$this->session
-		);
-
-		$generation_logger->warning('Warning message', array('context' => 'test'));
-	}
-
-	/**
-	 * Test warning method falls back to log when logger has no warning method.
-	 */
-	public function test_warning_falls_back_to_log_method() {
-		// Create a logger mock without warning method
-		$logger_without_warning = $this->getMockBuilder(stdClass::class)
-			->addMethods(array('log'))
-			->getMock();
-
-		$logger_without_warning->expects($this->once())
-			->method('log')
-			->with(
-				$this->equalTo('Warning message'),
-				$this->equalTo('warning'),
-				$this->equalTo(array('context' => 'test'))
-			);
-
-		$generation_logger = new AIPS_Generation_Logger(
-			$logger_without_warning,
 			$this->history_repository,
 			$this->session
 		);


### PR DESCRIPTION
This PR addresses two main areas:
1.  **Bug Fix (Hunter):** Resolved an `ArgumentCountError` in `AIPS_AI_Service::generate_json` where `simpleJsonQuery` was called with insufficient arguments. This was identified by running `Test_AIPS_AI_Service`. Also fixed a failing test in `Test_AIPS_Generation_Logger` related to null value assertions.
2.  **Architecture Improvement (Atlas):** Enhanced the `AIPS_Logger` class by adding explicit `warning` and `error` methods. This allowed for the simplification of `AIPS_Generation_Logger`, removing the need for defensive `method_exists` checks and making the code cleaner and more robust. Legacy tests relying on the fallback behavior were removed/updated.

---
*PR created automatically by Jules for task [11641589652398644020](https://jules.google.com/task/11641589652398644020) started by @rpnunez*