### PR TITLE
Fix Calendar Logic for Past Dates & Refactor Tests

### DIFF
--- a/ai-post-scheduler/CHANGELOG.md
+++ b/ai-post-scheduler/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [hunter-fix-calendar-past-dates] - 2026-02-17
+### Fixed
+- Fixed a logic bug in `AIPS_Interval_Calculator` where past dates were always fast-forwarded to the current time, preventing accurate historical calendar generation.
+- Updated `AIPS_Calendar_Controller` to explicitly disable catch-up logic when calculating schedule occurrences for the calendar view.
+- Refactored `Test_AIPS_Calendar_Controller` to use PHPUnit mocks instead of relying on limited global environment mocks, improving test reliability and performance.
+
 <<<<<<< HEAD
 ## [refactor-post-generation-flow] - 2026-02-07
 ### Changed

--- a/ai-post-scheduler/includes/class-aips-calendar-controller.php
+++ b/ai-post-scheduler/includes/class-aips-calendar-controller.php
@@ -121,7 +121,8 @@ class AIPS_Calendar_Controller {
 			// Calculate next occurrence using interval calculator
 			$next_run_str = $this->interval_calculator->calculate_next_run(
 				$schedule->frequency,
-				date('Y-m-d H:i:s', $current)
+				date('Y-m-d H:i:s', $current),
+				false // Disable catch-up logic to allow historical/future projection
 			);
 			
 			if (!$next_run_str) {
@@ -154,7 +155,8 @@ class AIPS_Calendar_Controller {
 		while ($next_run < $target && $limit > 0) {
 			$current_date_str = $this->interval_calculator->calculate_next_run(
 				$schedule->frequency,
-				$current_date_str
+				$current_date_str,
+				false // Disable catch-up logic
 			);
 			
 			if (!$current_date_str) {

--- a/ai-post-scheduler/includes/class-aips-interval-calculator.php
+++ b/ai-post-scheduler/includes/class-aips-interval-calculator.php
@@ -95,17 +95,18 @@ class AIPS_Interval_Calculator {
      * Determines when a scheduled task should run next based on its frequency setting.
      * Handles various interval types including hourly, daily, weekly, and day-specific schedules.
      *
-     * @param string      $frequency  The frequency identifier (e.g., 'daily', 'hourly', 'every_monday').
-     * @param string|null $start_time Optional. The base time to calculate from. Defaults to current time.
+     * @param string      $frequency      The frequency identifier (e.g., 'daily', 'hourly', 'every_monday').
+     * @param string|null $start_time     Optional. The base time to calculate from. Defaults to current time.
+     * @param bool        $allow_catch_up Optional. Whether to fast-forward past times to the future. Default true.
      * @return string The next run time in MySQL datetime format (Y-m-d H:i:s).
      */
-    public function calculate_next_run($frequency, $start_time = null) {
+    public function calculate_next_run($frequency, $start_time = null, $allow_catch_up = true) {
         $base_time = $start_time ? strtotime($start_time) : current_time('timestamp');
         $now = current_time('timestamp');
         
         // If start time is in the past, add intervals until future (Catch-up logic)
         // This prevents schedule drift by preserving the phase of the schedule
-        if ($base_time < $now) {
+        if ($allow_catch_up && $base_time < $now) {
             $interval_duration = $this->get_interval_duration($frequency);
             
             // For fixed intervals (with known duration), use mathematical calculation


### PR DESCRIPTION
This PR addresses a critical logic flaw in the calendar generation system where historical or planned dates were incorrectly fast-forwarded to the current time, resulting in missing or inaccurate calendar events.

Key Changes:
1.  **Interval Calculator Logic**: Modified `AIPS_Interval_Calculator::calculate_next_run` to support an optional `$allow_catch_up` parameter (defaulting to `true` for backward compatibility). This allows consumers to bypass the "catch-up to now" logic required for task runners but detrimental to calendar visualization.
2.  **Calendar Controller**: Updated `AIPS_Calendar_Controller` to explicitly disable catch-up logic when calculating schedule occurrences, ensuring that historical and future projections are accurate based on the schedule's start date.
3.  **Test Reliability**: Completely refactored `Test_AIPS_Calendar_Controller`. Instead of relying on a fragile and limited global `$wpdb` mock (which caused tests to fail due to missing data), the tests now use PHPUnit's mocking capabilities to mock `AIPS_Schedule_Repository` and `AIPS_Template_Repository`.
4.  **Test Cleanliness**: Resolved "Risky" test warnings in AJAX handler tests by properly expecting output using `expectOutputRegex`.

Verification:
- Ran `vendor/bin/phpunit --filter Test_AIPS_Calendar_Controller` and all tests passed (9/9).
- Ran `vendor/bin/phpunit --filter Test_AIPS_Interval_Calculator` to ensure no regressions in the calculator logic (22/22 tests passed).


---
*PR created automatically by Jules for task [6007931920263164796](https://jules.google.com/task/6007931920263164796) started by @rpnunez*