### PR TITLE
Refactor history feed query and cleanup AI service logs

### DIFF
--- a/ai-post-scheduler/includes/class-aips-ai-service.php
+++ b/ai-post-scheduler/includes/class-aips-ai-service.php
@@ -262,9 +262,6 @@ class AIPS_AI_Service {
                 // Use simpleJsonQuery which returns structured JSON data
                 // $result = $mwai->simpleJsonQuery($prompt, $json_query_params);
                 $result = $mwai->simpleJsonQuery($prompt);
-
-                error_log('Result type: ' . gettype($result));
-                error_log('Result content: ' . var_export($result, true));
                 
                 if (empty($result)) {
                     $error = new WP_Error('empty_response', __('AI Engine returned an empty JSON response.', 'ai-post-scheduler'));

--- a/ai-post-scheduler/includes/class-aips-history-repository.php
+++ b/ai-post-scheduler/includes/class-aips-history-repository.php
@@ -301,6 +301,58 @@ class AIPS_History_Repository {
     }
     
     /**
+     * Get activity feed (high-level events)
+     *
+     * Returns only ACTIVITY type entries for display in activity feed.
+     *
+     * @param int $limit Number of items to return
+     * @param int $offset Offset for pagination
+     * @param array $filters Optional filters (event_type, event_status, search)
+     * @return array Activity entries
+     */
+    public function get_activity_feed($limit = 50, $offset = 0, $filters = array()) {
+        $where_clauses = array("history_type_id = %d");
+        $where_args = array(AIPS_History_Type::ACTIVITY);
+
+        // Event type filter
+        if (!empty($filters['event_type'])) {
+            $where_clauses[] = "details LIKE %s";
+            $where_args[] = '%"event_type":"' . $this->wpdb->esc_like($filters['event_type']) . '"%';
+        }
+
+        // Event status filter
+        if (!empty($filters['event_status'])) {
+            $where_clauses[] = "details LIKE %s";
+            $where_args[] = '%"event_status":"' . $this->wpdb->esc_like($filters['event_status']) . '"%';
+        }
+
+        // Search filter
+        if (!empty($filters['search'])) {
+            $search_term = '%' . $this->wpdb->esc_like($filters['search']) . '%';
+            $where_clauses[] = "(log_type LIKE %s OR details LIKE %s)";
+            $where_args[] = $search_term;
+            $where_args[] = $search_term;
+        }
+
+        $where_sql = implode(' AND ', $where_clauses);
+        $where_args[] = $limit;
+        $where_args[] = $offset;
+
+        $sql = "SELECT hl.*, h.post_id, h.template_id
+                FROM {$this->table_name_log} hl
+                LEFT JOIN {$this->table_name} h ON hl.history_id = h.id
+                WHERE $where_sql
+                ORDER BY hl.timestamp DESC
+                LIMIT %d OFFSET %d";
+
+        if (empty($where_args)) {
+            return $this->wpdb->get_results($sql);
+        }
+
+        return $this->wpdb->get_results($this->wpdb->prepare($sql, $where_args));
+    }
+
+    /**
      * Create a new history entry.
      *
      * @param array $data {

--- a/ai-post-scheduler/includes/class-aips-history-service.php
+++ b/ai-post-scheduler/includes/class-aips-history-service.php
@@ -57,50 +57,7 @@ class AIPS_History_Service {
 	 * @return array Activity entries
 	 */
 	public function get_activity_feed($limit = 50, $offset = 0, $filters = array()) {
-		global $wpdb;
-		
-		$where_clauses = array("history_type_id = %d");
-		$where_args = array(AIPS_History_Type::ACTIVITY);
-		
-		// Event type filter
-		if (!empty($filters['event_type'])) {
-			$where_clauses[] = "details LIKE %s";
-			$where_args[] = '%"event_type":"' . $wpdb->esc_like($filters['event_type']) . '"%';
-		}
-		
-		// Event status filter
-		if (!empty($filters['event_status'])) {
-			$where_clauses[] = "details LIKE %s";
-			$where_args[] = '%"event_status":"' . $wpdb->esc_like($filters['event_status']) . '"%';
-		}
-		
-		// Search filter
-		if (!empty($filters['search'])) {
-			$search_term = '%' . $wpdb->esc_like($filters['search']) . '%';
-			$where_clauses[] = "(log_type LIKE %s OR details LIKE %s)";
-			$where_args[] = $search_term;
-			$where_args[] = $search_term;
-		}
-		
-		$where_sql = implode(' AND ', $where_clauses);
-		$where_args[] = $limit;
-		$where_args[] = $offset;
-		
-		$history_log_table = $wpdb->prefix . 'aips_history_log';
-		$history_table = $wpdb->prefix . 'aips_history';
-		
-		$sql = "SELECT hl.*, h.post_id, h.template_id 
-		        FROM {$history_log_table} hl 
-		        LEFT JOIN {$history_table} h ON hl.history_id = h.id 
-		        WHERE $where_sql 
-		        ORDER BY hl.timestamp DESC 
-		        LIMIT %d OFFSET %d";
-		
-		if (empty($where_args)) {
-			return $wpdb->get_results($sql);
-		}
-		
-		return $wpdb->get_results($wpdb->prepare($sql, $where_args));
+		return $this->repository->get_activity_feed($limit, $offset, $filters);
 	}
 	
 	/**


### PR DESCRIPTION
This PR refactors the `get_activity_feed` method by moving the SQL query construction from the Service layer (`AIPS_History_Service`) to the Repository layer (`AIPS_History_Repository`). This aligns with the architectural pattern of keeping data access logic within repositories. Additionally, it removes leftover debug logging from the `AIPS_AI_Service::generate_json` method.

Changes:
- Added `get_activity_feed` method to `AIPS_History_Repository`.
- Updated `AIPS_History_Service` to use the repository method.
- Removed `error_log` calls in `AIPS_AI_Service`.

---
*PR created automatically by Jules for task [17333013304283916755](https://jules.google.com/task/17333013304283916755) started by @rpnunez*