### PR TITLE
Fix test environment and refactor bootstrap to use autoloader

### DIFF
--- a/ai-post-scheduler/tests/bootstrap.php
+++ b/ai-post-scheduler/tests/bootstrap.php
@@ -30,42 +30,42 @@ if (!defined('WP_CORE_DIR')) {
 // Check if WordPress test library exists
 if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
     require_once WP_TESTS_DIR . '/includes/functions.php';
-    
+
     /**
      * Manually load the plugin being tested.
      */
     function _manually_load_plugin() {
         define('ABSPATH', WP_CORE_DIR . '/');
-        
+
         // Load plugin files
         require dirname(__DIR__) . '/ai-post-scheduler.php';
     }
     tests_add_filter('muplugins_loaded', '_manually_load_plugin');
-    
+
     // Start up the WP testing environment
     require WP_TESTS_DIR . '/includes/bootstrap.php';
 } else {
     // Fallback when WordPress test library is not available
     echo "Warning: WordPress test library not found at " . WP_TESTS_DIR . "\n";
     echo "Tests will run in limited mode without WordPress environment.\n\n";
-    
+
     // Define minimal WordPress constants and functions for basic testing
     if (!defined('ABSPATH')) {
         define('ABSPATH', dirname(__DIR__) . '/');
     }
-    
+
     if (!defined('AIPS_VERSION')) {
         define('AIPS_VERSION', '1.4.0');
     }
-    
+
     if (!defined('AIPS_PLUGIN_DIR')) {
         define('AIPS_PLUGIN_DIR', dirname(__DIR__) . '/');
     }
-    
+
     if (!defined('AIPS_PLUGIN_URL')) {
         define('AIPS_PLUGIN_URL', 'http://example.com/wp-content/plugins/ai-post-scheduler/');
     }
-    
+
     if (!defined('AIPS_PLUGIN_BASENAME')) {
         define('AIPS_PLUGIN_BASENAME', 'ai-post-scheduler/ai-post-scheduler.php');
     }
@@ -76,16 +76,16 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             'filters' => array(),
         );
     }
-    
+
     // WordPress constants
     if (!defined('OBJECT')) {
         define('OBJECT', 'OBJECT');
     }
-    
+
     if (!defined('ARRAY_A')) {
         define('ARRAY_A', 'ARRAY_A');
     }
-    
+
     if (!defined('ARRAY_N')) {
         define('ARRAY_N', 'ARRAY_N');
     }
@@ -93,7 +93,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
     if (!defined('HOUR_IN_SECONDS')) {
         define('HOUR_IN_SECONDS', 3600);
     }
-    
+
     // Mock WordPress functions if not available
     if (!function_exists('esc_html__')) {
         function esc_html__($text, $domain = 'default') {
@@ -130,25 +130,25 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return $url;
         }
     }
-    
+
     if (!function_exists('plugin_dir_path')) {
         function plugin_dir_path($file) {
             return dirname($file) . '/';
         }
     }
-    
+
     if (!function_exists('plugin_dir_url')) {
         function plugin_dir_url($file) {
             return 'http://example.com/wp-content/plugins/' . basename(dirname($file)) . '/';
         }
     }
-    
+
     if (!function_exists('plugin_basename')) {
         function plugin_basename($file) {
             return basename(dirname($file)) . '/' . basename($file);
         }
     }
-    
+
     if (!function_exists('add_action')) {
         function add_action($hook, $callback, $priority = 10, $accepted_args = 1) {
             if (!isset($GLOBALS['aips_test_hooks']['actions'][$hook])) {
@@ -165,7 +165,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             );
         }
     }
-    
+
     if (!function_exists('add_filter')) {
         function add_filter($hook, $callback, $priority = 10, $accepted_args = 1) {
             if (!isset($GLOBALS['aips_test_hooks']['filters'][$hook])) {
@@ -182,7 +182,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             );
         }
     }
-    
+
     if (!function_exists('apply_filters')) {
         function apply_filters($hook, $value) {
             $args = func_get_args();
@@ -203,7 +203,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return $value;
         }
     }
-    
+
     if (!function_exists('do_action')) {
         function do_action($hook) {
             $args = func_get_args();
@@ -285,7 +285,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return delete_option('_transient_' . $transient);
         }
     }
-    
+
     if (!function_exists('current_time')) {
         function current_time($type = 'mysql', $gmt = 0) {
             $timestamp = $gmt ? time() : time(); // Simplified time handling
@@ -302,13 +302,13 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return date($type, $timestamp);
         }
     }
-    
+
     if (!function_exists('wp_json_encode')) {
         function wp_json_encode($data, $options = 0, $depth = 512) {
             return json_encode($data, $options, $depth);
         }
     }
-    
+
     if (!function_exists('wp_upload_dir')) {
         function wp_upload_dir() {
             return [
@@ -330,12 +330,12 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return true;
         }
     }
-    
+
     if (!class_exists('WP_Error')) {
         class WP_Error {
             private $errors = [];
             private $error_data = [];
-            
+
             public function __construct($code = '', $message = '', $data = '') {
                 if (empty($code)) {
                     return;
@@ -345,12 +345,12 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
                     $this->error_data[$code] = $data;
                 }
             }
-            
+
             public function get_error_code() {
                 $codes = array_keys($this->errors);
                 return empty($codes) ? '' : $codes[0];
             }
-            
+
             public function get_error_message($code = '') {
                 if (empty($code)) {
                     $code = $this->get_error_code();
@@ -358,14 +358,14 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
                 $messages = isset($this->errors[$code]) ? $this->errors[$code] : [];
                 return empty($messages) ? '' : $messages[0];
             }
-            
+
             public function get_error_data($code = '') {
                 if (empty($code)) {
                     $code = $this->get_error_code();
                 }
                 return isset($this->error_data[$code]) ? $this->error_data[$code] : null;
             }
-            
+
             public function add($code, $message, $data = '') {
                 $this->errors[$code][] = $message;
                 if (!empty($data)) {
@@ -374,7 +374,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             }
         }
     }
-    
+
     if (!function_exists('is_wp_error')) {
         function is_wp_error($thing) {
             return ($thing instanceof WP_Error);
@@ -510,12 +510,12 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return true;
         }
     }
-    
+
     if (!class_exists('WP_UnitTestCase')) {
         // Provide a basic test case for when WordPress test library is not available
         class WP_UnitTestCase extends \PHPUnit\Framework\TestCase {
             protected $factory;
-            
+
             public function setUp(): void {
                 parent::setUp();
                 if (!isset($this->factory)) {
@@ -535,7 +535,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
                     };
                 }
             }
-            
+
             public function tearDown(): void {
                 $this->reset_hooks();
                 parent::tearDown();
@@ -558,7 +558,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             }
         }
     }
-    
+
     // Mock AJAX functions
     if (!function_exists('check_ajax_referer')) {
         function check_ajax_referer($action = -1, $query_arg = '_wpnonce', $die = true) {
@@ -572,39 +572,39 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return 1;
         }
     }
-    
+
     if (!function_exists('wp_die')) {
         function wp_die($message = '', $title = '', $args = array()) {
             throw new WPAjaxDieStopException($message);
         }
     }
-    
+
     if (!function_exists('wp_create_nonce')) {
         function wp_create_nonce($action = -1) {
             return 'test_nonce_' . $action;
         }
     }
-    
+
     if (!function_exists('wp_verify_nonce')) {
         function wp_verify_nonce($nonce, $action = -1) {
             return $nonce === wp_create_nonce($action) ? 1 : false;
         }
     }
-    
+
     if (!function_exists('wp_send_json_success')) {
         function wp_send_json_success($data = null, $status_code = null) {
             echo json_encode(array('success' => true, 'data' => $data));
             throw new WPAjaxDieContinueException();
         }
     }
-    
+
     if (!function_exists('wp_send_json_error')) {
         function wp_send_json_error($data = null, $status_code = null) {
             echo json_encode(array('success' => false, 'data' => $data));
             throw new WPAjaxDieContinueException();
         }
     }
-    
+
     if (!function_exists('wp_set_current_user')) {
         function wp_set_current_user($id, $name = '') {
             global $current_user_id;
@@ -612,7 +612,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return $id;
         }
     }
-    
+
     if (!function_exists('current_user_can')) {
         function current_user_can($capability) {
             global $current_user_id, $test_users;
@@ -627,39 +627,39 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return false;
         }
     }
-    
+
     if (!function_exists('sanitize_text_field')) {
         function sanitize_text_field($str) {
             return strip_tags($str);
         }
     }
-    
+
     if (!function_exists('sanitize_file_name')) {
         function sanitize_file_name($filename) {
             $filename = preg_replace('/[^a-zA-Z0-9._-]/', '_', $filename);
             return $filename;
         }
     }
-    
+
     if (!function_exists('sanitize_textarea_field')) {
         function sanitize_textarea_field($str) {
             return strip_tags($str);
         }
     }
-    
+
     if (!function_exists('wp_kses_post')) {
         function wp_kses_post($data) {
             // Allow some HTML tags
             return strip_tags($data, '<a><strong><em><p><br><ul><ol><li>');
         }
     }
-    
+
     if (!function_exists('absint')) {
         function absint($maybeint) {
             return abs(intval($maybeint));
         }
     }
-    
+
     if (!function_exists('__')) {
         function __($text, $domain = 'default') {
             return $text;
@@ -753,7 +753,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return $result;
         }
     }
-    
+
     if (!function_exists('wp_parse_args')) {
         function wp_parse_args($args, $defaults = array()) {
             if (is_object($args)) {
@@ -763,30 +763,30 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             } else {
                 parse_str($args, $parsed_args);
             }
-            
+
             if (is_array($defaults)) {
                 return array_merge($defaults, $parsed_args);
             }
             return $parsed_args;
         }
     }
-    
+
     // AJAX exception classes for testing
     if (!class_exists('WPAjaxDieContinueException')) {
         class WPAjaxDieContinueException extends Exception {}
     }
-    
+
     if (!class_exists('WPAjaxDieStopException')) {
         class WPAjaxDieStopException extends Exception {}
     }
-    
+
     // Mock global $wpdb
     if (!isset($GLOBALS['wpdb'])) {
         $GLOBALS['wpdb'] = new class {
             public $prefix = 'wp_';
             public $insert_id = 0;
             private $data = array();
-            
+
             public function esc_like($text) {
                 return addcslashes($text, '_%\\');
             }
@@ -815,11 +815,11 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
                 }
                 return $query;
             }
-            
+
             public function get_results($query, $output = OBJECT) {
                 return array();
             }
-            
+
             public function get_row($query, $output = OBJECT, $y = 0) {
                 // Return a default object with common properties to prevent null reference errors
                 $obj = new stdClass();
@@ -836,25 +836,25 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
 
                 return $obj;
             }
-            
+
             public function get_var($query, $x = 0, $y = 0) {
                 return null;
             }
-            
+
             public function query($query) {
                 return true;
             }
-            
+
             public function insert($table, $data, $format = null) {
                 static $next_insert_id = 1;
                 $this->insert_id = $next_insert_id++;
                 return true;
             }
-            
+
             public function update($table, $data, $where, $format = null, $where_format = null) {
                 return true;
             }
-            
+
             public function delete($table, $where, $where_format = null) {
                 return true;
             }
@@ -868,56 +868,18 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             }
         };
     }
-    
+
     // Mock global $wp_filter for action/filter hooks
     if (!isset($GLOBALS['wp_filter'])) {
         $GLOBALS['wp_filter'] = array();
     }
-    
+
     // Load plugin classes
     $includes_dir = dirname(__DIR__) . '/includes/';
-    $files = [
-        'class-aips-logger.php',
-        'class-aips-config.php',
-        'class-aips-db-manager.php',
-        'class-aips-history-repository.php',
-        'class-aips-schedule-repository.php',
-        'class-aips-template-repository.php',
-        'class-aips-article-structure-repository.php',
-        'class-aips-prompt-section-repository.php',
-        'class-aips-template-processor.php',
-        'class-aips-prompt-builder.php',
-        'class-aips-article-structure-manager.php',
-        'class-aips-template-type-selector.php',
-        'class-aips-interval-calculator.php',
-        'class-aips-resilience-service.php',
-        'class-aips-ai-service.php',
-        'class-aips-image-service.php',
-        'interface-aips-generation-context.php',
-        'class-aips-template-context.php',
-        'class-aips-topic-context.php',
-        'class-aips-generation-session.php',
-        'class-aips-post-creator.php',
-        'class-aips-generator.php',
-        'class-aips-scheduler.php',
-        'class-aips-schedule-controller.php',
-        'class-aips-planner.php',
-        'class-aips-history.php',
-        'class-aips-settings.php',
-        'class-aips-admin-assets.php',
-        'class-aips-system-status.php',
-        'class-aips-templates.php',
-        'class-aips-upgrades.php',
-        'class-aips-voices-repository.php',
-        'class-aips-voices.php',
-        'class-aips-structures-controller.php',
-        'class-aips-templates-controller.php',
-        'class-aips-research-controller.php',
-    ];
-    
-    foreach ($files as $file) {
-        if (file_exists($includes_dir . $file)) {
-            require_once $includes_dir . $file;
-        }
+
+    // Load autoloader
+    if (file_exists($includes_dir . 'class-aips-autoloader.php')) {
+        require_once $includes_dir . 'class-aips-autoloader.php';
+        AIPS_Autoloader::register();
     }
 }


### PR DESCRIPTION
*   **Hunter**: Fixed the test environment by ensuring `AIPS_Autoloader` is loaded and registered in `bootstrap.php`. This fixes the `test-autoloader.php` failure when run in isolation.
*   **Atlas**: Refactored `ai-post-scheduler/tests/bootstrap.php` to use `AIPS_Autoloader` instead of a manually maintained list of `require_once` calls, improving maintainability and reducing the risk of missing files in the test environment.
*   Verified the fix by running `test-autoloader.php`.

---
*PR created automatically by Jules for task [14910253488498098456](https://jules.google.com/task/14910253488498098456) started by @rpnunez*