### PR TITLE
🧙‍♂️ Wizard: Add Clear Filters to Generated Posts

### DIFF
--- a/ai-post-scheduler/templates/admin/generated-posts.php
+++ b/ai-post-scheduler/templates/admin/generated-posts.php
@@ -43,6 +43,9 @@ if (!defined('ABSPATH')) {
 						<label class="screen-reader-text" for="post-search-input"><?php esc_html_e('Search Posts:', 'ai-post-scheduler'); ?></label>
 						<input type="search" id="post-search-input" name="s" value="<?php echo esc_attr($search_query); ?>" class="aips-form-input" style="max-width: 300px;" placeholder="<?php esc_attr_e('Search posts...', 'ai-post-scheduler'); ?>">
 						<input type="submit" id="search-submit" class="aips-btn aips-btn-secondary" value="<?php esc_attr_e('Search Posts', 'ai-post-scheduler'); ?>">
+						<?php if (!empty($search_query)): ?>
+							<a href="<?php echo esc_url(remove_query_arg('s')); ?>" class="aips-btn aips-btn-secondary"><?php esc_html_e('Clear', 'ai-post-scheduler'); ?></a>
+						<?php endif; ?>
 					</form>
 				</div>
 
@@ -178,6 +181,9 @@ if (!defined('ABSPATH')) {
 							<label class="screen-reader-text" for="aips-post-search-input"><?php esc_html_e('Search Posts:', 'ai-post-scheduler'); ?></label>
 							<input type="search" id="aips-post-search-input" name="s" value="<?php echo esc_attr($search_query); ?>" class="aips-form-input" placeholder="<?php esc_attr_e('Search posts...', 'ai-post-scheduler'); ?>">
 							<input type="submit" id="aips-post-search-btn" class="aips-btn aips-btn-secondary" value="<?php esc_attr_e('Search', 'ai-post-scheduler'); ?>">
+							<?php if (!empty($search_query)): ?>
+								<a href="<?php echo esc_url(remove_query_arg('s')) . '#aips-pending-review'; ?>" class="aips-btn aips-btn-secondary"><?php esc_html_e('Clear', 'ai-post-scheduler'); ?></a>
+							<?php endif; ?>
 						</p>
 						
 						<?php if (!empty($templates)): ?>


### PR DESCRIPTION
Added 'Clear' buttons to the search filters in `ai-post-scheduler/templates/admin/generated-posts.php`.
- In the "Generated Posts" tab, the button resets the `s` query parameter.
- In the "Pending Review" tab, the button resets the `s` query parameter and appends the `#aips-pending-review` hash to ensure the user stays on the correct tab.
Verified with mock PHP rendering and Playwright tests.

---
*PR created automatically by Jules for task [5186437883228336393](https://jules.google.com/task/5186437883228336393) started by @rpnunez*