### PR TITLE
🧙‍♂️ Wizard: Add "Copy System Report" Button

### DIFF
--- a/ai-post-scheduler/assets/js/admin.js
+++ b/ai-post-scheduler/assets/js/admin.js
@@ -158,6 +158,7 @@
 
             // Copy to Clipboard
             $(document).on('click', '.aips-copy-btn', this.copyToClipboard);
+            $(document).on('click', '#aips-copy-system-report', this.copySystemReport);
 
             // Article Structures UI handlers
 
@@ -379,6 +380,58 @@
                 showSuccess();
             }, function(err) {
                 console.error('Async: Could not copy text: ', err);
+            });
+        },
+
+        copySystemReport: function(e) {
+            e.preventDefault();
+            var report = [];
+
+            $('.aips-status-page .aips-content-panel').each(function() {
+                var sectionTitle = $(this).find('.aips-panel-header h2').text().trim();
+                report.push('### ' + sectionTitle + ' ###');
+
+                $(this).find('table tbody tr').each(function() {
+                    var $cols = $(this).find('td');
+                    if ($cols.length >= 2) {
+                        var label = $cols.eq(0).text().trim();
+                        // Get text without "Show Details" link or hidden textarea text initially
+                        var value = $cols.eq(1).clone().children().remove().end().text().trim();
+
+                        var detailsTextarea = $cols.eq(1).find('textarea');
+                        if (detailsTextarea.length && detailsTextarea.val()) {
+                            value += '\n[Details]\n' + detailsTextarea.val();
+                        }
+
+                        report.push(label + ': ' + value);
+                    }
+                });
+                report.push(''); // Empty line between sections
+            });
+
+            var finalReport = report.join('\n').trim();
+
+            if (!navigator.clipboard) {
+                var textArea = document.createElement("textarea");
+                textArea.value = finalReport;
+                document.body.appendChild(textArea);
+                textArea.select();
+                try {
+                    document.execCommand('copy');
+                    AIPS.showToast('System report copied to clipboard!', 'success');
+                } catch (err) {
+                    console.error('Fallback: Oops, unable to copy', err);
+                    AIPS.showToast('Failed to copy report.', 'error');
+                }
+                document.body.removeChild(textArea);
+                return;
+            }
+
+            navigator.clipboard.writeText(finalReport).then(function() {
+                AIPS.showToast('System report copied to clipboard!', 'success');
+            }, function(err) {
+                console.error('Async: Could not copy text: ', err);
+                AIPS.showToast('Failed to copy report.', 'error');
             });
         },
 

--- a/ai-post-scheduler/templates/admin/system-status.php
+++ b/ai-post-scheduler/templates/admin/system-status.php
@@ -12,6 +12,12 @@ if (!defined('ABSPATH')) {
                     <h1 class="aips-page-title"><?php esc_html_e('System Status', 'ai-post-scheduler'); ?></h1>
                     <p class="aips-page-description"><?php esc_html_e('Monitor system health, PHP configuration, WordPress environment, and plugin compatibility.', 'ai-post-scheduler'); ?></p>
                 </div>
+            <div class="aips-page-actions">
+                <button class="aips-btn aips-btn-secondary" id="aips-copy-system-report">
+                    <span class="dashicons dashicons-clipboard"></span>
+                    <?php esc_html_e('Copy System Report', 'ai-post-scheduler'); ?>
+                </button>
+            </div>
             </div>
         </div>
 


### PR DESCRIPTION
This PR adds a "Copy System Report" button to the System Status page. This feature aggregates all the system information displayed on the page (including hidden details) into a plain-text format and copies it to the clipboard. This simplifies the process of sharing system information for support and debugging purposes.

**Changes:**
- Modified `ai-post-scheduler/templates/admin/system-status.php` to add the button in the page header.
- Modified `ai-post-scheduler/assets/js/admin.js` to add the `copySystemReport` function and bind it to the button.

**Testing:**
- Verified manually using a mocked PHP environment and Playwright script.
- Confirmed that the copy functionality correctly extracts section titles, labels, values, and hidden details.
- Verified that the success toast notification appears.

---
*PR created automatically by Jules for task [9760625152770127380](https://jules.google.com/task/9760625152770127380) started by @rpnunez*