### PR TITLE
Add pagination and search to Author Topics

### DIFF
--- a/ai-post-scheduler/assets/js/authors.js
+++ b/ai-post-scheduler/assets/js/authors.js
@@ -53,12 +53,19 @@
 	// Authors Module
 	const AuthorsModule = {
 		currentAuthorId: null,
+		currentPage: 1,
+		perPage: 10,
+		searchQuery: '',
 
 		init: function () {
 			this.bindEvents();
 		},
 
 		bindEvents: function () {
+			// Search and Pagination
+			$(document).on('input', '#aips-topics-search', this.debounce(this.handleSearch.bind(this), 500));
+			$(document).on('click', '.aips-pagination-btn', this.handlePagination.bind(this));
+
 			// Add Author Button
 			$('.aips-add-author-btn').on('click', this.openAddModal.bind(this));
 
@@ -100,12 +107,39 @@
 			$(document).on('click', '.aips-select-all-topics', this.toggleSelectAll.bind(this));
 			$(document).on('click', '.aips-select-all-feedback', this.toggleSelectAllFeedback.bind(this));
 			$(document).on('click', '.aips-bulk-action-execute', this.executeBulkAction.bind(this));
-			
+
 			// View topic posts
 			$(document).on('click', '.aips-post-count-badge', this.viewTopicPosts.bind(this));
-			
+
 			// Topic detail expand/collapse
 			$(document).on('click', '.aips-topic-expand-btn', this.toggleTopicDetail.bind(this));
+		},
+
+		// Utility for debounce
+		debounce: function(func, wait) {
+			let timeout;
+			return function(...args) {
+				const context = this;
+				clearTimeout(timeout);
+				timeout = setTimeout(() => func.apply(context, args), wait);
+			};
+		},
+
+		handleSearch: function(e) {
+			this.searchQuery = $(e.target).val();
+			this.currentPage = 1; // Reset to page 1 on search
+			const activeTab = $('.aips-tab-link.active').data('tab');
+			this.loadTopics(activeTab);
+		},
+
+		handlePagination: function(e) {
+			e.preventDefault();
+			const page = $(e.currentTarget).data('page');
+			if (page && page !== this.currentPage) {
+				this.currentPage = page;
+				const activeTab = $('.aips-tab-link.active').data('tab');
+				this.loadTopics(activeTab);
+			}
 		},
 
 		openAddModal: function (e) {
@@ -273,16 +307,19 @@
 
 			const authorId = $(e.currentTarget).data('id');
 			this.currentAuthorId = authorId;
+			this.currentPage = 1;
+			this.searchQuery = '';
+			$('#aips-topics-search').val('');
 
 			$('#aips-topics-content').html('<p>' + aipsAuthorsL10n.loadingTopics + '</p>');
-			
+
 			// Reset tabs to pending
 			$('.aips-tab-link').removeClass('active');
 			$('.aips-tab-link[data-tab="pending"]').addClass('active');
-			
+
 			// Update bulk action dropdown for pending tab
 			this.updateBulkActionDropdown('pending');
-			
+
 			$('#aips-topics-modal').fadeIn();
 
 			this.loadTopics('pending');
@@ -296,11 +333,15 @@
 					action: 'aips_get_author_topics',
 					nonce: aipsAuthorsL10n.nonce,
 					author_id: this.currentAuthorId,
-					status: status
+					status: status,
+					page: this.currentPage,
+					per_page: this.perPage,
+					search: this.searchQuery
 				},
 				success: (response) => {
 					if (response.success) {
 						this.renderTopics(response.data.topics, status);
+						this.renderPagination(response.data.total, response.data.pages, response.data.current_page);
 						this.updateTopicCounts(response.data.status_counts);
 					} else {
 						$('#aips-topics-content').html('<p>' + (response.data && response.data.message ? response.data.message : aipsAuthorsL10n.errorLoadingTopics) + '</p>');
@@ -333,14 +374,14 @@
 				html += '<span class="dashicons dashicons-arrow-right-alt2"></span>';
 				html += '</button> ';
 				html += '<span class="topic-title">' + this.escapeHtml(topic.topic_title) + '</span>';
-				
+
 				// Add post count badge if there are any posts
 				if (topic.post_count && topic.post_count > 0) {
 					html += ' <span class="aips-post-count-badge" data-topic-id="' + topic.id + '" title="' + aipsAuthorsL10n.viewPosts + '">';
 					html += '<span class="dashicons dashicons-admin-post"></span> ' + topic.post_count;
 					html += '</span>';
 				}
-				
+
 				html += '<input type="text" class="topic-title-edit" style="display:none;" value="' + this.escapeHtml(topic.topic_title) + '">';
 				html += '</td>';
 				html += '<td>' + topic.generated_at + '</td>';
@@ -356,7 +397,7 @@
 
 				html += '<button class="button aips-edit-topic" data-id="' + topic.id + '">' + aipsAuthorsL10n.edit + '</button>';
 				html += '</td></tr>';
-				
+
 				// Add collapsible detail row
 				html += '<tr class="aips-topic-detail-row" data-topic-id="' + topic.id + '" style="display:none;">';
 				html += '<td colspan="4" class="aips-topic-detail-cell">';
@@ -375,6 +416,38 @@
 
 			html += '</tbody></table>';
 			$('#aips-topics-content').html(html);
+		},
+
+		renderPagination: function(total, pages, currentPage) {
+			// Remove existing pagination
+			$('#aips-topics-pagination').remove();
+
+			if (total === 0 || pages <= 1) {
+				return;
+			}
+
+			let html = '<div id="aips-topics-pagination" class="aips-pagination" style="display: flex; justify-content: center; align-items: center; gap: 10px; margin-top: 15px;">';
+
+			// Previous button
+			if (currentPage > 1) {
+				html += '<button class="button aips-pagination-btn" data-page="' + (currentPage - 1) + '">' + (aipsAuthorsL10n.previous || 'Previous') + '</button>';
+			} else {
+				html += '<button class="button" disabled>' + (aipsAuthorsL10n.previous || 'Previous') + '</button>';
+			}
+
+			// Page info
+			html += '<span>' + (aipsAuthorsL10n.page || 'Page') + ' ' + currentPage + ' ' + (aipsAuthorsL10n.of || 'of') + ' ' + pages + '</span>';
+
+			// Next button
+			if (currentPage < pages) {
+				html += '<button class="button aips-pagination-btn" data-page="' + (currentPage + 1) + '">' + (aipsAuthorsL10n.next || 'Next') + '</button>';
+			} else {
+				html += '<button class="button" disabled>' + (aipsAuthorsL10n.next || 'Next') + '</button>';
+			}
+
+			html += '</div>';
+
+			$('#aips-topics-content').append(html);
 		},
 
 		updateTopicCounts: function (counts) {
@@ -403,16 +476,23 @@
 
 			// Update bulk action dropdown options based on tab
 			this.updateBulkActionDropdown(status);
+
+			// Toggle search bar visibility
+			if (status === 'feedback') {
+				$('#aips-topics-search').parent().hide();
+			} else {
+				$('#aips-topics-search').parent().show();
+			}
 		},
 
 		updateBulkActionDropdown: function (status) {
 			const $dropdowns = $('.aips-bulk-action-select');
-			
+
 			// Clear existing options except the default one
 			$dropdowns.each(function() {
 				const $dropdown = $(this);
 				$dropdown.find('option:not(:first)').remove();
-				
+
 				// Add options based on the active tab
 				if (status === 'pending') {
 					// Pending Review tab: Approve, Reject, Delete
@@ -520,7 +600,7 @@
 		loadFeedback: function () {
 			if (!this.currentAuthorId) {
 				$('#aips-topics-content').html('<p>No author selected.</p>');
-				
+
 				return;
 			}
 
@@ -764,19 +844,19 @@
 			html += '</tbody></table>';
 			$('#aips-topic-logs-content').html(html);
 		},
-		
+
 		viewTopicPosts: function (e) {
 			e.preventDefault();
 			e.stopPropagation();
-			
+
 			const topicId = $(e.currentTarget).data('topic-id');
-			
+
 			$('#aips-topic-posts-content').html('<p>' + aipsAuthorsL10n.loadingPosts + '</p>');
 			$('#aips-topic-posts-modal').fadeIn();
-			
+
 			this.loadTopicPosts(topicId);
 		},
-		
+
 		loadTopicPosts: function (topicId) {
 			$.ajax({
 				url: ajaxurl,
@@ -790,11 +870,11 @@
 					if (response.success) {
 						const topic = response.data.topic;
 						const posts = response.data.posts;
-						
+
 						$('#aips-topic-posts-modal-title').text(
 							aipsAuthorsL10n.postsGeneratedFrom + ': ' + this.escapeHtml(topic.topic_title)
 						);
-						
+
 						this.renderTopicPosts(posts);
 					} else {
 						$('#aips-topic-posts-content').html(
@@ -807,13 +887,13 @@
 				}
 			});
 		},
-		
+
 		renderTopicPosts: function (posts) {
 			if (!posts || posts.length === 0) {
 				$('#aips-topic-posts-content').html('<p>' + aipsAuthorsL10n.noPostsFound + '</p>');
 				return;
 			}
-			
+
 			let html = '<table class="wp-list-table widefat fixed striped"><thead><tr>';
 			html += '<th>' + aipsAuthorsL10n.postId + '</th>';
 			html += '<th>' + aipsAuthorsL10n.postTitle + '</th>';
@@ -821,7 +901,7 @@
 			html += '<th>' + aipsAuthorsL10n.datePublished + '</th>';
 			html += '<th>' + aipsAuthorsL10n.actions + '</th>';
 			html += '</tr></thead><tbody>';
-			
+
 			posts.forEach(post => {
 				html += '<tr>';
 				html += '<td>' + this.escapeHtml(post.post_id) + '</td>';
@@ -838,7 +918,7 @@
 				html += '</td>';
 				html += '</tr>';
 			});
-			
+
 			html += '</tbody></table>';
 			$('#aips-topic-posts-content').html(html);
 		},
@@ -880,7 +960,7 @@
 			}
 
 			if (ids.length === 0) {
-				const message = activeTab === 'feedback' 
+				const message = activeTab === 'feedback'
 					? (aipsAuthorsL10n.noFeedbackSelected || 'Please select at least one feedback item.')
 					: (aipsAuthorsL10n.noTopicsSelected || 'Please select at least one topic.');
 				showToast(message, 'warning');
@@ -975,7 +1055,7 @@
 			const messages = {
 				approve: aipsAuthorsL10n.confirmBulkApprove || 'Are you sure you want to approve %d topics?',
 				reject: aipsAuthorsL10n.confirmBulkReject || 'Are you sure you want to reject %d topics?',
-				delete: activeTab === 'feedback' 
+				delete: activeTab === 'feedback'
 					? (aipsAuthorsL10n.confirmBulkDeleteFeedback || 'Are you sure you want to delete %d feedback items? This action cannot be undone.')
 					: (aipsAuthorsL10n.confirmBulkDelete || 'Are you sure you want to delete %d topics? This action cannot be undone.'),
 				generate_now: aipsAuthorsL10n.confirmBulkGenerate || 'Are you sure you want to generate posts for %d topics?'
@@ -995,10 +1075,10 @@
 				if (text === null || text === undefined) {
 					return '';
 				}
-				
+
 				// Convert to string if not already
 				const str = String(text);
-				
+
 				const map = {
 					'&': '&amp;',
 					'<': '&lt;',
@@ -1026,25 +1106,25 @@
 				if (!url) {
 					return '';
 				}
-				
+
 				// Convert to string and trim whitespace
 				const urlStr = String(url).trim();
-				
+
 				if (!urlStr) {
 					return '';
 				}
-				
+
 				// Check for dangerous protocols (case-insensitive)
 				const dangerousProtocols = ['javascript:', 'data:', 'vbscript:', 'file:'];
 				const lowerUrl = urlStr.toLowerCase();
-				
+
 				for (const protocol of dangerousProtocols) {
 					if (lowerUrl.startsWith(protocol)) {
 						console.warn('Dangerous URL protocol detected:', protocol);
 						return '';
 					}
 				}
-				
+
 				// For absolute URLs, validate with URL constructor
 				if (urlStr.startsWith('http://') || urlStr.startsWith('https://')) {
 					try {
@@ -1056,12 +1136,12 @@
 						return '';
 					}
 				}
-				
+
 				// For relative URLs (WordPress admin paths), return as-is after validation
 				if (urlStr.startsWith('/')) {
 					return urlStr;
 				}
-				
+
 				// Reject anything else
 				console.warn('URL does not match allowed patterns:', urlStr);
 				return '';
@@ -1071,7 +1151,7 @@
 			}
 		}
 	};
-	
+
 	// Generation Queue Module
 	const GenerationQueueModule = {
 		init: function () {
@@ -1081,7 +1161,7 @@
 		bindEvents: function () {
 			// Main page tab switching
 			$(document).on('click', '.aips-authors-tab-link', this.switchMainTab.bind(this));
-			
+
 			// Queue-specific actions
 			$(document).on('click', '.aips-queue-bulk-action-execute', this.executeQueueBulkAction.bind(this));
 			$(document).on('click', '.aips-queue-select-all', this.toggleQueueSelectAll.bind(this));
@@ -1204,7 +1284,7 @@
 
 		generateNowFromQueue: function (topicIds) {
 			const confirmMessage = (aipsAuthorsL10n.confirmGenerateFromQueue || 'Generate posts now for %d selected topic(s)?').replace('%d', topicIds.length);
-			
+
 			if (!confirm(confirmMessage)) {
 				return;
 			}
@@ -1223,7 +1303,7 @@
 				success: (response) => {
 					if (response.success) {
 						showToast(response.data.message || aipsAuthorsL10n.postsGenerated || 'Posts generated successfully.', 'success');
-						
+
 						// Reload the queue
 						this.loadQueueTopics();
 					} else {

--- a/ai-post-scheduler/includes/class-aips-admin-assets.php
+++ b/ai-post-scheduler/includes/class-aips-admin-assets.php
@@ -179,6 +179,11 @@ class AIPS_Admin_Assets {
 				'logUser' => __('User', 'ai-post-scheduler'),
 				'logDate' => __('Date', 'ai-post-scheduler'),
 				'logDetails' => __('Details', 'ai-post-scheduler'),
+				'previous' => __('Previous', 'ai-post-scheduler'),
+				'next' => __('Next', 'ai-post-scheduler'),
+				'page' => __('Page', 'ai-post-scheduler'),
+				'of' => __('of', 'ai-post-scheduler'),
+				'searchPlaceholder' => __('Search topics...', 'ai-post-scheduler'),
 			));
 		}
 

--- a/ai-post-scheduler/includes/class-aips-author-topics-repository.php
+++ b/ai-post-scheduler/includes/class-aips-author-topics-repository.php
@@ -41,24 +41,109 @@ class AIPS_Author_Topics_Repository {
 	}
 	
 	/**
-	 * Get all topics for an author.
+	 * Get all topics for an author with optional filtering and pagination.
 	 *
 	 * @param int $author_id Author ID.
-	 * @param string $status Optional. Filter by status (pending, approved, rejected). Default null (all).
+	 * @param string|array $args Optional. Filter by status (string) or array of arguments.
+	 *                           If array, supports:
+	 *                           - status: string (pending, approved, rejected)
+	 *                           - search: string (search query for title/description)
+	 *                           - limit: int (posts per page)
+	 *                           - offset: int (pagination offset)
+	 *                           - orderby: string (column to order by)
+	 *                           - order: string (ASC or DESC)
 	 * @return array Array of topic objects.
 	 */
-	public function get_by_author($author_id, $status = null) {
-		if ($status) {
-			return $this->wpdb->get_results($this->wpdb->prepare(
-				"SELECT * FROM {$this->table_name} WHERE author_id = %d AND status = %s ORDER BY generated_at DESC",
-				$author_id,
-				$status
-			));
+	public function get_by_author($author_id, $args = null) {
+		$defaults = array(
+			'status' => null,
+			'search' => '',
+			'limit' => null,
+			'offset' => 0,
+			'orderby' => 'generated_at',
+			'order' => 'DESC'
+		);
+
+		// Handle backward compatibility where $args was just $status string
+		if (is_string($args)) {
+			$args = array('status' => $args);
 		}
-		return $this->wpdb->get_results($this->wpdb->prepare(
-			"SELECT * FROM {$this->table_name} WHERE author_id = %d ORDER BY generated_at DESC",
-			$author_id
-		));
+
+		$args = wp_parse_args($args, $defaults);
+
+		$where = array('author_id = %d');
+		$query_args = array($author_id);
+
+		if (!empty($args['status'])) {
+			$where[] = 'status = %s';
+			$query_args[] = $args['status'];
+		}
+
+		if (!empty($args['search'])) {
+			$where[] = '(topic_title LIKE %s OR topic_description LIKE %s)';
+			$search_term = '%' . $this->wpdb->esc_like($args['search']) . '%';
+			$query_args[] = $search_term;
+			$query_args[] = $search_term;
+		}
+
+		$where_clause = implode(' AND ', $where);
+
+		// Sanitize orderby to prevent SQL injection
+		$allowed_orderby = array('id', 'topic_title', 'generated_at', 'status', 'score');
+		$orderby = in_array($args['orderby'], $allowed_orderby) ? $args['orderby'] : 'generated_at';
+		$order = strtoupper($args['order']) === 'ASC' ? 'ASC' : 'DESC';
+
+		$sql = "SELECT * FROM {$this->table_name} WHERE {$where_clause} ORDER BY {$orderby} {$order}";
+
+		if (!empty($args['limit'])) {
+			$sql .= " LIMIT %d OFFSET %d";
+			$query_args[] = $args['limit'];
+			$query_args[] = $args['offset'];
+		}
+
+		return $this->wpdb->get_results($this->wpdb->prepare($sql, $query_args));
+	}
+
+	/**
+	 * Get total count of topics for an author matching criteria.
+	 *
+	 * @param int $author_id Author ID.
+	 * @param string|array $args Optional. Filter arguments (status, search).
+	 * @return int Total count.
+	 */
+	public function count_by_author($author_id, $args = null) {
+		$defaults = array(
+			'status' => null,
+			'search' => ''
+		);
+
+		// Handle backward compatibility where $args was just $status string
+		if (is_string($args)) {
+			$args = array('status' => $args);
+		}
+
+		$args = wp_parse_args($args, $defaults);
+
+		$where = array('author_id = %d');
+		$query_args = array($author_id);
+
+		if (!empty($args['status'])) {
+			$where[] = 'status = %s';
+			$query_args[] = $args['status'];
+		}
+
+		if (!empty($args['search'])) {
+			$where[] = '(topic_title LIKE %s OR topic_description LIKE %s)';
+			$search_term = '%' . $this->wpdb->esc_like($args['search']) . '%';
+			$query_args[] = $search_term;
+			$query_args[] = $search_term;
+		}
+
+		$where_clause = implode(' AND ', $where);
+
+		$sql = "SELECT COUNT(*) FROM {$this->table_name} WHERE {$where_clause}";
+
+		return (int) $this->wpdb->get_var($this->wpdb->prepare($sql, $query_args));
 	}
 	
 	/**

--- a/ai-post-scheduler/includes/class-aips-authors-controller.php
+++ b/ai-post-scheduler/includes/class-aips-authors-controller.php
@@ -224,12 +224,25 @@ class AIPS_Authors_Controller {
 		
 		$author_id = isset($_POST['author_id']) ? absint($_POST['author_id']) : 0;
 		$status = isset($_POST['status']) ? sanitize_text_field($_POST['status']) : null;
+		$page = isset($_POST['page']) ? absint($_POST['page']) : 1;
+		$per_page = isset($_POST['per_page']) ? absint($_POST['per_page']) : 10;
+		$search = isset($_POST['search']) ? sanitize_text_field($_POST['search']) : '';
 		
 		if (!$author_id) {
 			wp_send_json_error(array('message' => __('Invalid author ID.', 'ai-post-scheduler')));
 		}
 		
-		$topics = $this->topics_repository->get_by_author($author_id, $status);
+		$offset = ($page - 1) * $per_page;
+
+		$args = array(
+			'status' => $status,
+			'limit' => $per_page,
+			'offset' => $offset,
+			'search' => $search
+		);
+
+		$topics = $this->topics_repository->get_by_author($author_id, $args);
+		$total_topics = $this->topics_repository->count_by_author($author_id, $args);
 		$status_counts = $this->topics_repository->get_status_counts($author_id);
 		
 		// Add post count to each topic
@@ -246,7 +259,10 @@ class AIPS_Authors_Controller {
 		
 		wp_send_json_success(array(
 			'topics' => $topics,
-			'status_counts' => $status_counts
+			'status_counts' => $status_counts,
+			'total' => $total_topics,
+			'pages' => ceil($total_topics / $per_page),
+			'current_page' => $page
 		));
 	}
 	

--- a/ai-post-scheduler/templates/admin/authors.php
+++ b/ai-post-scheduler/templates/admin/authors.php
@@ -321,6 +321,10 @@ if (isset($_GET['page']) && $_GET['page'] === 'aips-authors') {
                 </div>
         
                 <div class="aips-topics-list-container">
+                    <div class="aips-filter-bar" style="margin-bottom: 15px;">
+                        <input type="search" id="aips-topics-search" class="aips-form-input" style="max-width: 300px;" placeholder="<?php esc_attr_e('Search topics...', 'ai-post-scheduler'); ?>">
+                    </div>
+
                     <div class="aips-bulk-actions">
                         <select class="aips-bulk-action-select">
                             <option value=""><?php esc_html_e('Bulk Actions', 'ai-post-scheduler'); ?></option>

--- a/ai-post-scheduler/tests/test-author-topics-repository-pagination.php
+++ b/ai-post-scheduler/tests/test-author-topics-repository-pagination.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Test Author Topics Repository Pagination
+ *
+ * @package AI_Post_Scheduler
+ */
+
+class AIPS_Author_Topics_Repository_Pagination_Test extends WP_UnitTestCase {
+
+	private $original_wpdb;
+	private $mock_wpdb;
+	private $repository;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		// Save original wpdb
+		if (isset($GLOBALS['wpdb'])) {
+			$this->original_wpdb = $GLOBALS['wpdb'];
+		}
+
+		// Create mock wpdb
+		$this->mock_wpdb = $this->getMockBuilder('stdClass')
+			->setMethods(array('prepare', 'get_results', 'get_var', 'esc_like'))
+			->getMock();
+
+		$this->mock_wpdb->prefix = 'wp_';
+
+		// Set up default behaviors
+		$this->mock_wpdb->expects($this->any())
+			->method('esc_like')
+			->will($this->returnCallback(function($text) { return $text; }));
+
+		$GLOBALS['wpdb'] = $this->mock_wpdb;
+
+		$this->repository = new AIPS_Author_Topics_Repository();
+	}
+
+	public function tearDown(): void {
+		// Restore original wpdb
+		if (isset($this->original_wpdb)) {
+			$GLOBALS['wpdb'] = $this->original_wpdb;
+		}
+		parent::tearDown();
+	}
+
+	public function test_get_by_author_pagination() {
+		// Expect prepare to be called with SQL containing LIMIT and OFFSET
+		$this->mock_wpdb->expects($this->once())
+			->method('prepare')
+			->with(
+				$this->stringContains('LIMIT %d OFFSET %d'),
+				$this->callback(function($args) {
+					// Verify args contains limit and offset
+					// The args array structure depends on how prepare is called (array vs variable args)
+					// In the repo: $this->wpdb->prepare($sql, $query_args) where $query_args is an array
+					// So $args here will be [sql, query_args_array] ?? No, prepare signature is ($query, ...$args)
+					// But WP 3.5+ supports prepare($query, $args_array).
+					// The MockWPDB in bootstrap supports ...$args.
+					// PHPUnit mock will receive the arguments passed to prepare.
+
+					// The repository calls: $this->wpdb->prepare($sql, $query_args)
+					// So the second argument should be the array of values.
+
+					$params = $args; // In repo: $query_args is the second arg to prepare
+
+					// We expect: [author_id, limit, offset]
+					return isset($params[1]) && $params[1] == 10 && $params[2] == 20;
+				})
+			)
+			->will($this->returnValue('SELECT * FROM wp_aips_author_topics ... LIMIT 10 OFFSET 20'));
+
+		$this->mock_wpdb->expects($this->once())
+			->method('get_results')
+			->willReturn(array());
+
+		$this->repository->get_by_author(1, array('limit' => 10, 'offset' => 20));
+	}
+
+	public function test_get_by_author_search() {
+		// Expect prepare to be called with SQL containing LIKE
+		$this->mock_wpdb->expects($this->once())
+			->method('prepare')
+			->with(
+				$this->stringContains('topic_title LIKE %s'),
+				$this->callback(function($params) {
+					// We expect: [author_id, %search%, %search%]
+					return isset($params[1]) && strpos($params[1], 'term') !== false;
+				})
+			)
+			->will($this->returnValue('SELECT ... LIKE ...'));
+
+		$this->repository->get_by_author(1, array('search' => 'term'));
+	}
+
+	public function test_count_by_author() {
+		$this->mock_wpdb->expects($this->once())
+			->method('prepare')
+			->will($this->returnArgument(0)); // Return the SQL string
+
+		$this->mock_wpdb->expects($this->once())
+			->method('get_var')
+			->with(
+				$this->stringContains('SELECT COUNT(*)')
+			)
+			->willReturn(5);
+
+		$count = $this->repository->count_by_author(1);
+		$this->assertEquals(5, $count);
+	}
+}


### PR DESCRIPTION
Implemented pagination and search functionality for the Author Topics list. This includes backend updates to the repository and controller to support LIMIT/OFFSET and LIKE queries, and frontend updates to render pagination controls and a search bar. A new unit test was added to verify the repository changes. This addresses the missing pagination and filter functionality identified in the gap analysis.

---
*PR created automatically by Jules for task [15767300034542725792](https://jules.google.com/task/15767300034542725792) started by @rpnunez*