### PR TITLE
🧙‍♂️ Wizard: Add Copy System Report

### DIFF
--- a/ai-post-scheduler/assets/js/admin.js
+++ b/ai-post-scheduler/assets/js/admin.js
@@ -158,6 +158,7 @@
 
             // Copy to Clipboard
             $(document).on('click', '.aips-copy-btn', this.copyToClipboard);
+            $(document).on('click', '#aips-copy-system-report', this.copySystemReport);
 
             // Article Structures UI handlers
 
@@ -323,6 +324,79 @@
                         alert(response.data.message || aipsAdminL10n.deleteSectionFailed);
                     }
                 }).fail(function(){ alert(aipsAdminL10n.errorOccurred); });
+            });
+        },
+
+        copySystemReport: function(e) {
+            e.preventDefault();
+            var $btn = $(this);
+            var report = 'AI Post Scheduler - System Report\n';
+            report += 'Generated: ' + new Date().toISOString() + '\n\n';
+
+            $('.aips-content-panel').each(function() {
+                var sectionTitle = $(this).find('.aips-panel-header h2').text().trim();
+
+                if (!sectionTitle) return;
+
+                report += '### ' + sectionTitle + ' ###\n';
+
+                $(this).find('table tbody tr').each(function() {
+                    var $cols = $(this).find('td');
+                    if ($cols.length < 3) return;
+
+                    var check = $cols.eq(0).text().trim();
+                    var $valueCol = $cols.eq(1);
+                    var status = $cols.eq(2).text().trim();
+
+                    // Get primary value (excluding details/links)
+                    // We clone to not affect the DOM, remove children (like the details toggle link/div), and get text
+                    var value = $valueCol.clone().children().remove().end().text().trim();
+
+                    // Check for detailed log in textarea
+                    var $textarea = $valueCol.find('textarea');
+                    var details = $textarea.length ? $textarea.val() : '';
+
+                    report += check + ': ' + value + ' (' + status + ')\n';
+
+                    if (details && details.trim().length > 0) {
+                        report += 'Details:\n' + details.trim() + '\n';
+                    }
+                });
+
+                report += '\n';
+            });
+
+            var showSuccess = function() {
+                var originalHtml = $btn.html();
+                $btn.html('<span class="dashicons dashicons-yes"></span> Copied!');
+                $btn.prop('disabled', true);
+                setTimeout(function() {
+                    $btn.html(originalHtml);
+                    $btn.prop('disabled', false);
+                }, 2000);
+            };
+
+            if (!navigator.clipboard) {
+                var textArea = document.createElement("textarea");
+                textArea.value = report;
+                document.body.appendChild(textArea);
+                textArea.select();
+                try {
+                    document.execCommand('copy');
+                    showSuccess();
+                } catch (err) {
+                    console.error('Fallback: Oops, unable to copy', err);
+                    alert('Failed to copy report to clipboard.');
+                }
+                document.body.removeChild(textArea);
+                return;
+            }
+
+            navigator.clipboard.writeText(report).then(function() {
+                showSuccess();
+            }, function(err) {
+                console.error('Async: Could not copy text: ', err);
+                alert('Failed to copy report to clipboard.');
             });
         },
 

--- a/ai-post-scheduler/templates/admin/system-status.php
+++ b/ai-post-scheduler/templates/admin/system-status.php
@@ -12,6 +12,12 @@ if (!defined('ABSPATH')) {
                     <h1 class="aips-page-title"><?php esc_html_e('System Status', 'ai-post-scheduler'); ?></h1>
                     <p class="aips-page-description"><?php esc_html_e('Monitor system health, PHP configuration, WordPress environment, and plugin compatibility.', 'ai-post-scheduler'); ?></p>
                 </div>
+                <div class="aips-page-actions">
+                    <button class="aips-btn aips-btn-secondary" id="aips-copy-system-report">
+                        <span class="dashicons dashicons-clipboard"></span>
+                        <?php esc_html_e('Copy System Report', 'ai-post-scheduler'); ?>
+                    </button>
+                </div>
             </div>
         </div>
 


### PR DESCRIPTION
This PR adds a "Copy System Report" button to the System Status page. This small but high-impact enhancement allows users to easily copy the entire system status report (including hidden details) to their clipboard as formatted plain text. This significantly improves the workflow for reporting issues or sharing system configuration with support.

Changes:
- Modified `ai-post-scheduler/templates/admin/system-status.php` to include the button in the page header.
- Modified `ai-post-scheduler/assets/js/admin.js` to implement the scraping and clipboard logic, with a fallback for older browsers.

---
*PR created automatically by Jules for task [7327064660986883268](https://jules.google.com/task/7327064660986883268) started by @rpnunez*