### PR TITLE
Add pagination and search to Author Topics

### DIFF
--- a/ai-post-scheduler/assets/js/authors.js
+++ b/ai-post-scheduler/assets/js/authors.js
@@ -53,6 +53,9 @@
 	// Authors Module
 	const AuthorsModule = {
 		currentAuthorId: null,
+		currentPage: 1,
+		searchQuery: '',
+		searchTimeout: null,
 
 		init: function () {
 			this.bindEvents();
@@ -100,12 +103,19 @@
 			$(document).on('click', '.aips-select-all-topics', this.toggleSelectAll.bind(this));
 			$(document).on('click', '.aips-select-all-feedback', this.toggleSelectAllFeedback.bind(this));
 			$(document).on('click', '.aips-bulk-action-execute', this.executeBulkAction.bind(this));
-			
+
 			// View topic posts
 			$(document).on('click', '.aips-post-count-badge', this.viewTopicPosts.bind(this));
-			
+
 			// Topic detail expand/collapse
 			$(document).on('click', '.aips-topic-expand-btn', this.toggleTopicDetail.bind(this));
+
+			// Search
+			$(document).on('input', '#aips-topic-search', this.handleSearch.bind(this));
+
+			// Pagination
+			$(document).on('click', '.aips-pagination-prev', this.prevPage.bind(this));
+			$(document).on('click', '.aips-pagination-next', this.nextPage.bind(this));
 		},
 
 		openAddModal: function (e) {
@@ -274,15 +284,23 @@
 			const authorId = $(e.currentTarget).data('id');
 			this.currentAuthorId = authorId;
 
+			if (this.searchTimeout) {
+				clearTimeout(this.searchTimeout);
+			}
+
+			this.currentPage = 1;
+			this.searchQuery = '';
+			$('#aips-topic-search').val('');
+
 			$('#aips-topics-content').html('<p>' + aipsAuthorsL10n.loadingTopics + '</p>');
-			
+
 			// Reset tabs to pending
 			$('.aips-tab-link').removeClass('active');
 			$('.aips-tab-link[data-tab="pending"]').addClass('active');
-			
+
 			// Update bulk action dropdown for pending tab
 			this.updateBulkActionDropdown('pending');
-			
+
 			$('#aips-topics-modal').fadeIn();
 
 			this.loadTopics('pending');
@@ -296,12 +314,15 @@
 					action: 'aips_get_author_topics',
 					nonce: aipsAuthorsL10n.nonce,
 					author_id: this.currentAuthorId,
-					status: status
+					status: status,
+					page: this.currentPage,
+					search: this.searchQuery
 				},
 				success: (response) => {
 					if (response.success) {
 						this.renderTopics(response.data.topics, status);
 						this.updateTopicCounts(response.data.status_counts);
+						this.renderPagination(response.data.total, response.data.pages, response.data.current_page);
 					} else {
 						$('#aips-topics-content').html('<p>' + (response.data && response.data.message ? response.data.message : aipsAuthorsL10n.errorLoadingTopics) + '</p>');
 					}
@@ -333,14 +354,14 @@
 				html += '<span class="dashicons dashicons-arrow-right-alt2"></span>';
 				html += '</button> ';
 				html += '<span class="topic-title">' + this.escapeHtml(topic.topic_title) + '</span>';
-				
+
 				// Add post count badge if there are any posts
 				if (topic.post_count && topic.post_count > 0) {
 					html += ' <span class="aips-post-count-badge" data-topic-id="' + topic.id + '" title="' + aipsAuthorsL10n.viewPosts + '">';
 					html += '<span class="dashicons dashicons-admin-post"></span> ' + topic.post_count;
 					html += '</span>';
 				}
-				
+
 				html += '<input type="text" class="topic-title-edit" style="display:none;" value="' + this.escapeHtml(topic.topic_title) + '">';
 				html += '</td>';
 				html += '<td>' + topic.generated_at + '</td>';
@@ -356,7 +377,7 @@
 
 				html += '<button class="button aips-edit-topic" data-id="' + topic.id + '">' + aipsAuthorsL10n.edit + '</button>';
 				html += '</td></tr>';
-				
+
 				// Add collapsible detail row
 				html += '<tr class="aips-topic-detail-row" data-topic-id="' + topic.id + '" style="display:none;">';
 				html += '<td colspan="4" class="aips-topic-detail-cell">';
@@ -407,12 +428,12 @@
 
 		updateBulkActionDropdown: function (status) {
 			const $dropdowns = $('.aips-bulk-action-select');
-			
+
 			// Clear existing options except the default one
 			$dropdowns.each(function() {
 				const $dropdown = $(this);
 				$dropdown.find('option:not(:first)').remove();
-				
+
 				// Add options based on the active tab
 				if (status === 'pending') {
 					// Pending Review tab: Approve, Reject, Delete
@@ -520,7 +541,7 @@
 		loadFeedback: function () {
 			if (!this.currentAuthorId) {
 				$('#aips-topics-content').html('<p>No author selected.</p>');
-				
+
 				return;
 			}
 
@@ -764,19 +785,19 @@
 			html += '</tbody></table>';
 			$('#aips-topic-logs-content').html(html);
 		},
-		
+
 		viewTopicPosts: function (e) {
 			e.preventDefault();
 			e.stopPropagation();
-			
+
 			const topicId = $(e.currentTarget).data('topic-id');
-			
+
 			$('#aips-topic-posts-content').html('<p>' + aipsAuthorsL10n.loadingPosts + '</p>');
 			$('#aips-topic-posts-modal').fadeIn();
-			
+
 			this.loadTopicPosts(topicId);
 		},
-		
+
 		loadTopicPosts: function (topicId) {
 			$.ajax({
 				url: ajaxurl,
@@ -790,11 +811,11 @@
 					if (response.success) {
 						const topic = response.data.topic;
 						const posts = response.data.posts;
-						
+
 						$('#aips-topic-posts-modal-title').text(
 							aipsAuthorsL10n.postsGeneratedFrom + ': ' + this.escapeHtml(topic.topic_title)
 						);
-						
+
 						this.renderTopicPosts(posts);
 					} else {
 						$('#aips-topic-posts-content').html(
@@ -807,13 +828,13 @@
 				}
 			});
 		},
-		
+
 		renderTopicPosts: function (posts) {
 			if (!posts || posts.length === 0) {
 				$('#aips-topic-posts-content').html('<p>' + aipsAuthorsL10n.noPostsFound + '</p>');
 				return;
 			}
-			
+
 			let html = '<table class="wp-list-table widefat fixed striped"><thead><tr>';
 			html += '<th>' + aipsAuthorsL10n.postId + '</th>';
 			html += '<th>' + aipsAuthorsL10n.postTitle + '</th>';
@@ -821,7 +842,7 @@
 			html += '<th>' + aipsAuthorsL10n.datePublished + '</th>';
 			html += '<th>' + aipsAuthorsL10n.actions + '</th>';
 			html += '</tr></thead><tbody>';
-			
+
 			posts.forEach(post => {
 				html += '<tr>';
 				html += '<td>' + this.escapeHtml(post.post_id) + '</td>';
@@ -838,7 +859,7 @@
 				html += '</td>';
 				html += '</tr>';
 			});
-			
+
 			html += '</tbody></table>';
 			$('#aips-topic-posts-content').html(html);
 		},
@@ -880,7 +901,7 @@
 			}
 
 			if (ids.length === 0) {
-				const message = activeTab === 'feedback' 
+				const message = activeTab === 'feedback'
 					? (aipsAuthorsL10n.noFeedbackSelected || 'Please select at least one feedback item.')
 					: (aipsAuthorsL10n.noTopicsSelected || 'Please select at least one topic.');
 				showToast(message, 'warning');
@@ -975,7 +996,7 @@
 			const messages = {
 				approve: aipsAuthorsL10n.confirmBulkApprove || 'Are you sure you want to approve %d topics?',
 				reject: aipsAuthorsL10n.confirmBulkReject || 'Are you sure you want to reject %d topics?',
-				delete: activeTab === 'feedback' 
+				delete: activeTab === 'feedback'
 					? (aipsAuthorsL10n.confirmBulkDeleteFeedback || 'Are you sure you want to delete %d feedback items? This action cannot be undone.')
 					: (aipsAuthorsL10n.confirmBulkDelete || 'Are you sure you want to delete %d topics? This action cannot be undone.'),
 				generate_now: aipsAuthorsL10n.confirmBulkGenerate || 'Are you sure you want to generate posts for %d topics?'
@@ -995,10 +1016,10 @@
 				if (text === null || text === undefined) {
 					return '';
 				}
-				
+
 				// Convert to string if not already
 				const str = String(text);
-				
+
 				const map = {
 					'&': '&amp;',
 					'<': '&lt;',
@@ -1026,25 +1047,25 @@
 				if (!url) {
 					return '';
 				}
-				
+
 				// Convert to string and trim whitespace
 				const urlStr = String(url).trim();
-				
+
 				if (!urlStr) {
 					return '';
 				}
-				
+
 				// Check for dangerous protocols (case-insensitive)
 				const dangerousProtocols = ['javascript:', 'data:', 'vbscript:', 'file:'];
 				const lowerUrl = urlStr.toLowerCase();
-				
+
 				for (const protocol of dangerousProtocols) {
 					if (lowerUrl.startsWith(protocol)) {
 						console.warn('Dangerous URL protocol detected:', protocol);
 						return '';
 					}
 				}
-				
+
 				// For absolute URLs, validate with URL constructor
 				if (urlStr.startsWith('http://') || urlStr.startsWith('https://')) {
 					try {
@@ -1056,12 +1077,12 @@
 						return '';
 					}
 				}
-				
+
 				// For relative URLs (WordPress admin paths), return as-is after validation
 				if (urlStr.startsWith('/')) {
 					return urlStr;
 				}
-				
+
 				// Reject anything else
 				console.warn('URL does not match allowed patterns:', urlStr);
 				return '';
@@ -1069,9 +1090,71 @@
 				console.error('Error in sanitizeUrl:', error);
 				return '';
 			}
+		},
+
+		handleSearch: function (e) {
+			const query = $(e.currentTarget).val();
+
+			if (this.searchTimeout) {
+				clearTimeout(this.searchTimeout);
+			}
+
+			this.searchTimeout = setTimeout(() => {
+				this.searchQuery = query;
+				this.currentPage = 1;
+				const activeTab = $('.aips-tab-link.active').data('tab');
+				this.loadTopics(activeTab);
+			}, 500);
+		},
+
+		prevPage: function (e) {
+			e.preventDefault();
+			if (this.currentPage > 1) {
+				this.currentPage--;
+				const activeTab = $('.aips-tab-link.active').data('tab');
+				this.loadTopics(activeTab);
+			}
+		},
+
+		nextPage: function (e) {
+			e.preventDefault();
+			// Note: We don't have total pages stored in module, but the button disabled state handles it
+			const totalPages = parseInt($('#aips-total-pages').text());
+			if (this.currentPage < totalPages) {
+				this.currentPage++;
+				const activeTab = $('.aips-tab-link.active').data('tab');
+				this.loadTopics(activeTab);
+			}
+		},
+
+		renderPagination: function (total, pages, currentPage) {
+			$('#aips-current-page').text(currentPage);
+			$('#aips-total-pages').text(pages);
+
+			const $prevBtn = $('.aips-pagination-prev');
+			const $nextBtn = $('.aips-pagination-next');
+
+			if (currentPage <= 1) {
+				$prevBtn.prop('disabled', true);
+			} else {
+				$prevBtn.prop('disabled', false);
+			}
+
+			if (currentPage >= pages) {
+				$nextBtn.prop('disabled', true);
+			} else {
+				$nextBtn.prop('disabled', false);
+			}
+
+			// Show/hide pagination container based on total
+			if (total === 0) {
+				$('.aips-pagination').hide();
+			} else {
+				$('.aips-pagination').show();
+			}
 		}
 	};
-	
+
 	// Generation Queue Module
 	const GenerationQueueModule = {
 		init: function () {
@@ -1081,7 +1164,7 @@
 		bindEvents: function () {
 			// Main page tab switching
 			$(document).on('click', '.aips-authors-tab-link', this.switchMainTab.bind(this));
-			
+
 			// Queue-specific actions
 			$(document).on('click', '.aips-queue-bulk-action-execute', this.executeQueueBulkAction.bind(this));
 			$(document).on('click', '.aips-queue-select-all', this.toggleQueueSelectAll.bind(this));
@@ -1204,7 +1287,7 @@
 
 		generateNowFromQueue: function (topicIds) {
 			const confirmMessage = (aipsAuthorsL10n.confirmGenerateFromQueue || 'Generate posts now for %d selected topic(s)?').replace('%d', topicIds.length);
-			
+
 			if (!confirm(confirmMessage)) {
 				return;
 			}
@@ -1223,7 +1306,7 @@
 				success: (response) => {
 					if (response.success) {
 						showToast(response.data.message || aipsAuthorsL10n.postsGenerated || 'Posts generated successfully.', 'success');
-						
+
 						// Reload the queue
 						this.loadQueueTopics();
 					} else {

--- a/ai-post-scheduler/includes/class-aips-author-topics-repository.php
+++ b/ai-post-scheduler/includes/class-aips-author-topics-repository.php
@@ -41,24 +41,96 @@ class AIPS_Author_Topics_Repository {
 	}
 	
 	/**
-	 * Get all topics for an author.
+	 * Get topics for an author with optional filtering and pagination.
 	 *
 	 * @param int $author_id Author ID.
-	 * @param string $status Optional. Filter by status (pending, approved, rejected). Default null (all).
+	 * @param array $args Optional. Arguments for filtering and pagination.
+	 *                    - status: string (pending, approved, rejected)
+	 *                    - limit: int (number of items per page)
+	 *                    - offset: int (offset for pagination)
+	 *                    - search: string (search query for topic title)
 	 * @return array Array of topic objects.
 	 */
-	public function get_by_author($author_id, $status = null) {
-		if ($status) {
-			return $this->wpdb->get_results($this->wpdb->prepare(
-				"SELECT * FROM {$this->table_name} WHERE author_id = %d AND status = %s ORDER BY generated_at DESC",
-				$author_id,
-				$status
-			));
+	public function get_by_author($author_id, $args = array()) {
+		// Backward compatibility: if $args is a string, treat it as status
+		if (is_string($args)) {
+			$args = array('status' => $args);
 		}
-		return $this->wpdb->get_results($this->wpdb->prepare(
-			"SELECT * FROM {$this->table_name} WHERE author_id = %d ORDER BY generated_at DESC",
-			$author_id
-		));
+
+		$defaults = array(
+			'status' => null,
+			'limit'  => null,
+			'offset' => 0,
+			'search' => null,
+		);
+
+		$args = wp_parse_args($args, $defaults);
+
+		$sql = "SELECT * FROM {$this->table_name} WHERE author_id = %d";
+		$params = array($author_id);
+
+		// Status filter
+		if (!empty($args['status'])) {
+			$sql .= " AND status = %s";
+			$params[] = $args['status'];
+		}
+
+		// Search filter
+		if (!empty($args['search'])) {
+			$sql .= " AND topic_title LIKE %s";
+			$params[] = '%' . $this->wpdb->esc_like($args['search']) . '%';
+		}
+
+		// Order
+		$sql .= " ORDER BY generated_at DESC";
+
+		// Pagination
+		if (!empty($args['limit'])) {
+			$sql .= " LIMIT %d";
+			$params[] = $args['limit'];
+
+			if (!empty($args['offset'])) {
+				$sql .= " OFFSET %d";
+				$params[] = $args['offset'];
+			}
+		}
+
+		return $this->wpdb->get_results($this->wpdb->prepare($sql, $params));
+	}
+
+	/**
+	 * Get total count of topics for an author with optional filtering.
+	 *
+	 * @param int $author_id Author ID.
+	 * @param array $args Optional. Arguments for filtering.
+	 *                    - status: string (pending, approved, rejected)
+	 *                    - search: string (search query for topic title)
+	 * @return int Total count.
+	 */
+	public function count_by_author($author_id, $args = array()) {
+		$defaults = array(
+			'status' => null,
+			'search' => null,
+		);
+
+		$args = wp_parse_args($args, $defaults);
+
+		$sql = "SELECT COUNT(*) FROM {$this->table_name} WHERE author_id = %d";
+		$params = array($author_id);
+
+		// Status filter
+		if (!empty($args['status'])) {
+			$sql .= " AND status = %s";
+			$params[] = $args['status'];
+		}
+
+		// Search filter
+		if (!empty($args['search'])) {
+			$sql .= " AND topic_title LIKE %s";
+			$params[] = '%' . $this->wpdb->esc_like($args['search']) . '%';
+		}
+
+		return (int) $this->wpdb->get_var($this->wpdb->prepare($sql, $params));
 	}
 	
 	/**

--- a/ai-post-scheduler/includes/class-aips-authors-controller.php
+++ b/ai-post-scheduler/includes/class-aips-authors-controller.php
@@ -223,13 +223,32 @@ class AIPS_Authors_Controller {
 		}
 		
 		$author_id = isset($_POST['author_id']) ? absint($_POST['author_id']) : 0;
-		$status = isset($_POST['status']) ? sanitize_text_field($_POST['status']) : null;
+		$status    = isset($_POST['status']) ? sanitize_text_field($_POST['status']) : null;
+		$page      = isset($_POST['page']) ? absint($_POST['page']) : 1;
+		$search    = isset($_POST['search']) ? sanitize_text_field($_POST['search']) : '';
 		
 		if (!$author_id) {
 			wp_send_json_error(array('message' => __('Invalid author ID.', 'ai-post-scheduler')));
 		}
 		
-		$topics = $this->topics_repository->get_by_author($author_id, $status);
+		// Pagination settings
+		$per_page = 10;
+		$offset = ($page - 1) * $per_page;
+
+		// Build arguments
+		$args = array(
+			'status' => $status,
+			'limit'  => $per_page,
+			'offset' => $offset,
+			'search' => $search
+		);
+
+		// Get topics and count
+		$topics = $this->topics_repository->get_by_author($author_id, $args);
+		$total_count = $this->topics_repository->count_by_author($author_id, $args);
+		$total_pages = ceil($total_count / $per_page);
+
+		// Get general status counts (unfiltered by search, for the tabs)
 		$status_counts = $this->topics_repository->get_status_counts($author_id);
 		
 		// Add post count to each topic
@@ -245,8 +264,11 @@ class AIPS_Authors_Controller {
 		}
 		
 		wp_send_json_success(array(
-			'topics' => $topics,
-			'status_counts' => $status_counts
+			'topics'        => $topics,
+			'status_counts' => $status_counts,
+			'total'         => $total_count,
+			'pages'         => $total_pages,
+			'current_page'  => $page
 		));
 	}
 	

--- a/ai-post-scheduler/templates/admin/authors.php
+++ b/ai-post-scheduler/templates/admin/authors.php
@@ -321,6 +321,11 @@ if (isset($_GET['page']) && $_GET['page'] === 'aips-authors') {
                 </div>
         
                 <div class="aips-topics-list-container">
+                    <!-- Search Bar -->
+                    <div class="aips-filter-bar" style="margin-bottom: 15px;">
+                        <input type="search" id="aips-topic-search" class="aips-form-input" style="width: 100%; max-width: 400px;" placeholder="<?php esc_attr_e('Search topics...', 'ai-post-scheduler'); ?>">
+                    </div>
+
                     <div class="aips-bulk-actions">
                         <select class="aips-bulk-action-select">
                             <option value=""><?php esc_html_e('Bulk Actions', 'ai-post-scheduler'); ?></option>
@@ -333,6 +338,17 @@ if (isset($_GET['page']) && $_GET['page'] === 'aips-authors') {
         
                     <div id="aips-topics-content">
                         <p><?php esc_html_e('Loading topics...', 'ai-post-scheduler'); ?></p>
+                    </div>
+
+                    <!-- Pagination -->
+                    <div class="aips-pagination" style="margin-top: 15px; display: flex; justify-content: space-between; align-items: center;">
+                        <div class="aips-pagination-info">
+                            <?php esc_html_e('Page', 'ai-post-scheduler'); ?> <span id="aips-current-page">1</span> <?php esc_html_e('of', 'ai-post-scheduler'); ?> <span id="aips-total-pages">1</span>
+                        </div>
+                        <div class="aips-pagination-controls">
+                            <button class="button aips-pagination-prev" disabled>&laquo; <?php esc_html_e('Previous', 'ai-post-scheduler'); ?></button>
+                            <button class="button aips-pagination-next" disabled><?php esc_html_e('Next', 'ai-post-scheduler'); ?> &raquo;</button>
+                        </div>
                     </div>
         
                     <div class="aips-bulk-actions">


### PR DESCRIPTION
Implemented server-side pagination and search for the Author Topics list to improve scalability and usability.

Changes:
- Refactored `AIPS_Author_Topics_Repository` to support `limit`, `offset`, and `search` arguments in `get_by_author`.
- Added `count_by_author` method for total counts.
- Updated `AIPS_Authors_Controller` to process pagination and search parameters.
- Updated `authors.php` template with search bar and pagination UI.
- Updated `authors.js` to handle search input and pagination events.

---
*PR created automatically by Jules for task [4869027076431110877](https://jules.google.com/task/4869027076431110877) started by @rpnunez*