### PR TITLE
🧙‍♂️ Wizard: Add Clear Filters to Planner Search Bar

### DIFF
--- a/.jules/wizard.md
+++ b/.jules/wizard.md
@@ -35,3 +35,7 @@
 ## 2026-01-22 - Research Search Consistency
 **Learning:** The "Trending Topics Library" table lacked search functionality, which is a standard expectation established in other admin tables (Authors, Structures, etc.).
 **Action:** Implemented client-side search for Trending Topics with a "Clear" button and Empty State, ensuring "Select All" functionality respects the active filter.
+
+## 2026-01-23 - Add "Clear Filters" to Planner Search Bar
+**Learning:** Providing a clear way to reset search filters is essential for a good user experience and matches established UI patterns.
+**Action:** Added a "Clear" button (`#planner-topic-search-clear`) next to the search input in the Planner template. The JS logic was already present but just lacked the HTML element to act upon.

--- a/ai-post-scheduler/templates/admin/planner.php
+++ b/ai-post-scheduler/templates/admin/planner.php
@@ -67,6 +67,7 @@ $default_planner_frequency = 'daily';
                 </div>
                 <div class="aips-toolbar-right aips-planner-toolbar-right">
                     <input type="search" id="planner-topic-search" class="aips-form-input" placeholder="<?php esc_attr_e('Filter topics...', 'ai-post-scheduler'); ?>" class="aips-planner-topic-search">
+                    <button type="button" id="planner-topic-search-clear" class="aips-btn aips-btn-sm aips-btn-secondary" style="display: none;"><?php esc_html_e('Clear', 'ai-post-scheduler'); ?></button>
                     <button type="button" id="btn-copy-topics" class="aips-btn aips-btn-sm aips-btn-secondary"><?php echo esc_html__('Copy Selected', 'ai-post-scheduler'); ?></button>
                     <button type="button" id="btn-clear-topics" class="aips-btn aips-btn-sm aips-btn-ghost"><?php echo esc_html__('Clear List', 'ai-post-scheduler'); ?></button>
                 </div>


### PR DESCRIPTION
**What:** Added a "Clear" button to the topic search bar in the Planner interface (`ai-post-scheduler/templates/admin/planner.php`).

**Why:** The `Planner` interface had a search bar for filtering topics, but there was no explicit "Clear" button to easily reset the filter. Users were forced to manually delete their query. Other search inputs in the plugin (e.g., in `authors.php`, `schedule.php`, `templates.php`) have a clear button, so this brings consistency. The underlying JavaScript logic to handle the clear action (`clearTopicSearch`) and toggle button visibility (`filterTopics`) was already present in `admin-planner.js` but lacked the HTML element.

**Value:** Improves user experience by providing a quick, consistent way to reset search filters, matching established UI patterns across the plugin.

**Visuals:** A standard "Clear" button appears next to the search input when text is entered, and clicking it resets the search and shows all topics.

---
*PR created automatically by Jules for task [3764827182574286248](https://jules.google.com/task/3764827182574286248) started by @rpnunez*