### PR TITLE
🧙‍♂️ Wizard: Password Visibility Toggle for Unsplash Key

### DIFF
--- a/.jules/wizard.md
+++ b/.jules/wizard.md
@@ -35,3 +35,8 @@
 ## 2026-01-22 - Research Search Consistency
 **Learning:** The "Trending Topics Library" table lacked search functionality, which is a standard expectation established in other admin tables (Authors, Structures, etc.).
 **Action:** Implemented client-side search for Trending Topics with a "Clear" button and Empty State, ensuring "Select All" functionality respects the active filter.
+## 2026-01-23 - Password Visibility Toggle\n**Learning:** The Unsplash Access Key field lacked an eye toggle and  input type.\n**Action:** Updated the Settings page input  to a  field and added a Dashicon toggle, including  and  to meet accessibility constraints.
+
+## 2026-01-23 - Password Visibility Toggle
+**Learning:** The Unsplash Access Key field lacked an eye toggle and `password` input type, and previous implementations of toggles sometimes lacked proper `a11y` tags.
+**Action:** Updated the Settings page input `aips_unsplash_access_key` to a `password` field and added a Dashicon toggle, ensuring to include `aria-label` and `title` to meet accessibility constraints.

--- a/ai-post-scheduler/assets/js/admin.js
+++ b/ai-post-scheduler/assets/js/admin.js
@@ -98,6 +98,9 @@
 
             // History Bulk Actions
             $(document).on('change', '#cb-select-all-1', this.toggleAllHistory);
+
+            // Toggle Password Visibility
+            $(document).on('click', '.aips-toggle-password', this.togglePasswordVisibility);
             $(document).on('change', '.aips-history-table input[name="history[]"]', this.toggleHistorySelection);
             $(document).on('click', '#aips-delete-selected-btn', this.deleteSelectedHistory);
 
@@ -2335,6 +2338,21 @@
             var allChecked = $('.aips-history-table input[name="history[]"]').length === $('.aips-history-table input[name="history[]"]:checked').length;
             $('#cb-select-all-1').prop('checked', allChecked);
             AIPS.updateDeleteButton();
+        },
+
+        togglePasswordVisibility: function() {
+            var $btn = $(this);
+            var targetId = $btn.data('target');
+            var $input = $('#' + targetId);
+            var $icon = $btn.find('.dashicons');
+
+            if ($input.attr('type') === 'password') {
+                $input.attr('type', 'text');
+                $icon.removeClass('dashicons-visibility').addClass('dashicons-hidden');
+            } else {
+                $input.attr('type', 'password');
+                $icon.removeClass('dashicons-hidden').addClass('dashicons-visibility');
+            }
         },
 
         updateDeleteButton: function() {

--- a/ai-post-scheduler/includes/class-aips-settings.php
+++ b/ai-post-scheduler/includes/class-aips-settings.php
@@ -479,7 +479,12 @@ class AIPS_Settings {
     public function unsplash_access_key_field_callback() {
         $value = get_option('aips_unsplash_access_key', '');
         ?>
-        <input type="text" name="aips_unsplash_access_key" value="<?php echo esc_attr($value); ?>" class="regular-text" autocomplete="new-password">
+        <div class="aips-password-wrapper" style="position: relative; display: inline-block;">
+            <input type="password" name="aips_unsplash_access_key" id="aips_unsplash_access_key" value="<?php echo esc_attr($value); ?>" class="regular-text" autocomplete="new-password" style="padding-right: 30px;">
+            <button type="button" class="aips-toggle-password" data-target="aips_unsplash_access_key" aria-label="<?php esc_attr_e('Toggle password visibility', 'ai-post-scheduler'); ?>" title="<?php esc_attr_e('Toggle password visibility', 'ai-post-scheduler'); ?>" style="position: absolute; right: 5px; top: 50%; transform: translateY(-50%); background: none; border: none; padding: 0; cursor: pointer; color: #787c82;">
+                <span class="dashicons dashicons-visibility"></span>
+            </button>
+        </div>
         <p class="description"><?php esc_html_e('Required for fetching images from Unsplash. Generate a Client ID at unsplash.com/developers.', 'ai-post-scheduler'); ?></p>
         <?php
     }


### PR DESCRIPTION
## What
Implemented a "Password Visibility" toggle for the Unsplash Access Key field on the Settings page.

## Why
Currently, the Unsplash Access Key is displayed in plain text within a regular text input. This is a security risk for API keys, especially in shared admin environments. Adding a password field with a visibility toggle aligns with standard UX practices for sensitive credentials.

## Value
- **Security:** API keys are hidden by default, preventing shoulder surfing or accidental exposure during screen shares.
- **UX Polish:** Provides the expected interaction pattern for secret fields (view/hide).
- **Accessibility:** Included appropriate `aria-label` and `title` attributes for screen readers.

## Visuals
The Unsplash Access Key field is now an `input type="password"` with a button displaying the `dashicons-visibility` icon. Clicking it reveals the key and switches the icon to `dashicons-hidden`.

---
*PR created automatically by Jules for task [12884065555887403506](https://jules.google.com/task/12884065555887403506) started by @rpnunez*