### PR TITLE
🧙‍♂️ Wizard: Add Copy to Clipboard for IDs

### DIFF
--- a/.jules/wizard.md
+++ b/.jules/wizard.md
@@ -35,3 +35,8 @@
 ## 2026-01-22 - Research Search Consistency
 **Learning:** The "Trending Topics Library" table lacked search functionality, which is a standard expectation established in other admin tables (Authors, Structures, etc.).
 **Action:** Implemented client-side search for Trending Topics with a "Clear" button and Empty State, ensuring "Select All" functionality respects the active filter.
+## 2025-02-17 - Add Copy to Clipboard for IDs
+
+Learning: Copy to Clipboard buttons are an effective and quick UX enhancement for items like IDs, especially when dealing with scheduling and integrations. The standard pattern in this plugin for admin tables uses a `.aips-table-meta-row` containing a neutral badge for the ID, and a small ghost button (`.aips-copy-btn-small`) tied to the clipboard logic.
+
+Action: Ensure the IDs are rendered clearly using the badge alongside the main entity name inside the primary cell of list tables, maintaining UI consistency with existing areas. Always use the provided helper classes like `.aips-copy-btn` and `data-clipboard-text` to plug into the existing JS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,3 +72,6 @@ All notable changes to this project will be documented in this file.
 - [2025-12-21 01:48:42] Added search functionality to the Generation History page to filter posts by title.
 - [2024-05-22 10:00:00] Refactored Scheduler: Extracted AJAX handlers to `AIPS_Schedule_Controller`, enhanced `AIPS_Scheduler` with better topic and next_run support, and updated `AIPS_Planner` to use the Scheduler service instead of direct SQL.
 - [2024-05-22 10:00:00] Made generated topic titles editable in the Planner before scheduling.
+
+### Enhanced
+- Added "Copy to Clipboard" functionality for IDs in admin tables (Authors, Templates, Schedules, Structures, Sections, Voices) to improve developer workflow and UX.

--- a/ai-post-scheduler/templates/admin/authors.php
+++ b/ai-post-scheduler/templates/admin/authors.php
@@ -82,7 +82,15 @@ if (isset($_GET['page']) && $_GET['page'] === 'aips-authors') {
                             ?>
                                 <tr data-author-id="<?php echo esc_attr($author->id); ?>">
                                     <td>
-                                        <div class="cell-primary"><?php echo esc_html($author->name); ?></div>
+                                        <div class="cell-primary">
+                                            <?php echo esc_html($author->name); ?>
+                                            <div class="aips-table-meta-row">
+                                                <span class="aips-badge aips-badge-neutral">ID: <?php echo esc_html($author->id); ?></span>
+                                                <button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-copy-btn aips-copy-btn-small" data-clipboard-text="<?php echo esc_attr($author->id); ?>" title="<?php esc_attr_e('Copy ID', 'ai-post-scheduler'); ?>">
+                                                    <span class="dashicons dashicons-admin-page"></span>
+                                                </button>
+                                            </div>
+                                        </div>
                                     </td>
                                     <td>
                                         <?php echo esc_html($author->field_niche); ?>

--- a/ai-post-scheduler/templates/admin/schedule.php
+++ b/ai-post-scheduler/templates/admin/schedule.php
@@ -100,7 +100,15 @@ $rotation_patterns = $template_type_selector->get_rotation_patterns();
                             data-next-run="<?php echo esc_attr($schedule->next_run); ?>"
                             data-is-active="<?php echo esc_attr($schedule->is_active); ?>">
                             <td>
-                                <div class="cell-primary"><?php echo esc_html($schedule->template_name ?: __('Unknown Template', 'ai-post-scheduler')); ?></div>
+                                <div class="cell-primary">
+                                    <?php echo esc_html($schedule->template_name ?: __('Unknown Template', 'ai-post-scheduler')); ?>
+                                    <div class="aips-table-meta-row">
+                                        <span class="aips-badge aips-badge-neutral">ID: <?php echo esc_html($schedule->id); ?></span>
+                                        <button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-copy-btn aips-copy-btn-small" data-clipboard-text="<?php echo esc_attr($schedule->id); ?>" title="<?php esc_attr_e('Copy ID', 'ai-post-scheduler'); ?>">
+                                            <span class="dashicons dashicons-admin-page"></span>
+                                        </button>
+                                    </div>
+                                </div>
                             </td>
                             <td>
                                 <div>

--- a/ai-post-scheduler/templates/admin/sections.php
+++ b/ai-post-scheduler/templates/admin/sections.php
@@ -48,7 +48,17 @@ if (!isset($sections) || !is_array($sections)) {
 					<tbody>
 						<?php foreach ($sections as $section) : ?>
 						<tr data-section-id="<?php echo esc_attr($section->id); ?>">
-							<td class="column-name"><strong><?php echo esc_html($section->name); ?></strong></td>
+							<td class="column-name">
+								<div class="cell-primary">
+									<strong><?php echo esc_html($section->name); ?></strong>
+									<div class="aips-table-meta-row">
+										<span class="aips-badge aips-badge-neutral">ID: <?php echo esc_html($section->id); ?></span>
+										<button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-copy-btn aips-copy-btn-small" data-clipboard-text="<?php echo esc_attr($section->id); ?>" title="<?php esc_attr_e('Copy ID', 'ai-post-scheduler'); ?>">
+											<span class="dashicons dashicons-admin-page"></span>
+										</button>
+									</div>
+								</div>
+							</td>
 							<td class="column-key">
 								<div class="aips-variable-code-cell">
 									<code><?php echo esc_html($section->section_key); ?></code>

--- a/ai-post-scheduler/templates/admin/structures.php
+++ b/ai-post-scheduler/templates/admin/structures.php
@@ -68,7 +68,17 @@ if (!isset($sections) || !is_array($sections)) {
 				<tbody>
 					<?php foreach ($structures as $structure): ?>
 					<tr data-structure-id="<?php echo esc_attr($structure->id); ?>">
-						<td class="column-name"><?php echo esc_html($structure->name); ?></td>
+						<td class="column-name">
+							<div class="cell-primary">
+								<?php echo esc_html($structure->name); ?>
+								<div class="aips-table-meta-row">
+									<span class="aips-badge aips-badge-neutral">ID: <?php echo esc_html($structure->id); ?></span>
+									<button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-copy-btn aips-copy-btn-small" data-clipboard-text="<?php echo esc_attr($structure->id); ?>" title="<?php esc_attr_e('Copy ID', 'ai-post-scheduler'); ?>">
+										<span class="dashicons dashicons-admin-page"></span>
+									</button>
+								</div>
+							</div>
+						</td>
 						<td class="column-description"><?php echo esc_html($structure->description); ?></td>
 						<td class="column-active"><?php echo $structure->is_active ? esc_html__('Yes', 'ai-post-scheduler') : esc_html__('No', 'ai-post-scheduler'); ?></td>
 						<td class="column-default"><?php echo $structure->is_default ? esc_html__('Yes', 'ai-post-scheduler') : esc_html__('No', 'ai-post-scheduler'); ?></td>

--- a/ai-post-scheduler/templates/admin/templates.php
+++ b/ai-post-scheduler/templates/admin/templates.php
@@ -59,7 +59,15 @@ if (!defined('ABSPATH')) {
                         ?>
                         <tr data-template-id="<?php echo esc_attr($template->id); ?>">
                             <td>
-                                <div class="cell-primary"><?php echo esc_html($template->name); ?></div>
+                                <div class="cell-primary">
+                                    <?php echo esc_html($template->name); ?>
+                                    <div class="aips-table-meta-row">
+                                        <span class="aips-badge aips-badge-neutral">ID: <?php echo esc_html($template->id); ?></span>
+                                        <button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-copy-btn aips-copy-btn-small" data-clipboard-text="<?php echo esc_attr($template->id); ?>" title="<?php esc_attr_e('Copy ID', 'ai-post-scheduler'); ?>">
+                                            <span class="dashicons dashicons-admin-page"></span>
+                                        </button>
+                                    </div>
+                                </div>
                             </td>
                             <td>
                                 <span class="aips-badge aips-badge-neutral">

--- a/ai-post-scheduler/templates/admin/voices.php
+++ b/ai-post-scheduler/templates/admin/voices.php
@@ -56,6 +56,12 @@ if (!defined('ABSPATH')) {
                                 <td class="column-name">
                                     <div class="aips-table-primary">
                                         <strong><?php echo esc_html($voice->name); ?></strong>
+                                        <div class="aips-table-meta-row">
+                                            <span class="aips-badge aips-badge-neutral">ID: <?php echo esc_html($voice->id); ?></span>
+                                            <button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-copy-btn aips-copy-btn-small" data-clipboard-text="<?php echo esc_attr($voice->id); ?>" title="<?php esc_attr_e('Copy ID', 'ai-post-scheduler'); ?>">
+                                                <span class="dashicons dashicons-admin-page"></span>
+                                            </button>
+                                        </div>
                                     </div>
                                 </td>
                                 <td class="column-title-prompt">


### PR DESCRIPTION
**What:**
Added a "Copy to Clipboard" feature for entity IDs within the primary data columns of all main admin tables (Authors, Templates, Schedules, Structures, Sections, Voices).

**Why:**
Developers and power users often need IDs to use in shortcodes, configurations, or debugging. Without this, finding and copying the ID requires inspecting the URL, table row data attributes, or keeping external lists.

**Value:**
Small, high-impact UX enhancement. Saves time, eliminates friction, and adheres strictly to the existing design system without adding feature bloat or new backend logic.

**Visuals/Changes:**
IDs are now visible under the main name/title in a gray badge (`.aips-badge-neutral`) with a small copy icon (`.aips-copy-btn-small`), reusing the existing JavaScript handler.

---
*PR created automatically by Jules for task [1336023244021959989](https://jules.google.com/task/1336023244021959989) started by @rpnunez*