### PR TITLE
🧙‍♂️ Wizard: Add "Clear Search" button to Prompt Sections

### DIFF
--- a/.jules/wizard.md
+++ b/.jules/wizard.md
@@ -35,3 +35,7 @@
 ## 2026-01-22 - Research Search Consistency
 **Learning:** The "Trending Topics Library" table lacked search functionality, which is a standard expectation established in other admin tables (Authors, Structures, etc.).
 **Action:** Implemented client-side search for Trending Topics with a "Clear" button and Empty State, ensuring "Select All" functionality respects the active filter.
+
+## 2025-03-04 - Add "Clear Search" button to Prompt Sections
+Learning: Adding clear search buttons to search inputs improves UX by allowing users to quickly clear filters.
+Action: Always include clear buttons for search inputs to maintain consistency across the UI.

--- a/ai-post-scheduler/templates/admin/sections.php
+++ b/ai-post-scheduler/templates/admin/sections.php
@@ -31,11 +31,12 @@ if (!isset($sections) || !is_array($sections)) {
 			<!-- Filter Bar -->
 			<div class="aips-filter-bar">
 				<input type="search" id="aips-section-search" class="aips-form-input" placeholder="<?php esc_attr_e('Search sections...', 'ai-post-scheduler'); ?>">
+				<button type="button" id="aips-section-search-clear" class="aips-btn aips-btn-secondary" style="display: none;"><?php esc_html_e('Clear', 'ai-post-scheduler'); ?></button>
 			</div>
 
 			<!-- Table -->
 			<div class="aips-panel-body no-padding">
-				<table class="aips-table">
+				<table class="aips-table aips-sections-list">
 					<thead>
 						<tr>
 							<th class="column-name"><?php esc_html_e('Name', 'ai-post-scheduler'); ?></th>


### PR DESCRIPTION
**What:** Added a "Clear Search" button to the Prompt Sections search bar.
**Why:** To allow users to quickly clear filters when searching prompt sections.
**Value:** Improves UX by providing a convenient way to reset the search input.
**Visuals:** Added `Clear` button inside the filter bar next to the search input, styled consistently.

---
*PR created automatically by Jules for task [3737113835402632053](https://jules.google.com/task/3737113835402632053) started by @rpnunez*