### PR TITLE
🧙‍♂️ Wizard: Add Copy to Clipboard for IDs

### DIFF
--- a/ai-post-scheduler/templates/admin/authors.php
+++ b/ai-post-scheduler/templates/admin/authors.php
@@ -83,6 +83,12 @@ if (isset($_GET['page']) && $_GET['page'] === 'aips-authors') {
                                 <tr data-author-id="<?php echo esc_attr($author->id); ?>">
                                     <td>
                                         <div class="cell-primary"><?php echo esc_html($author->name); ?></div>
+                                        <div class="aips-table-meta-row">
+                                            <span class="aips-badge-neutral">ID: <?php echo esc_html($author->id); ?></span>
+                                            <button type="button" class="aips-copy-btn aips-copy-btn-small" data-clipboard-text="<?php echo esc_attr($author->id); ?>" title="<?php esc_attr_e('Copy ID', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Copy ID', 'ai-post-scheduler'); ?>">
+                                                <span class="dashicons dashicons-admin-page"></span>
+                                            </button>
+                                        </div>
                                     </td>
                                     <td>
                                         <?php echo esc_html($author->field_niche); ?>

--- a/ai-post-scheduler/templates/admin/schedule.php
+++ b/ai-post-scheduler/templates/admin/schedule.php
@@ -101,6 +101,12 @@ $rotation_patterns = $template_type_selector->get_rotation_patterns();
                             data-is-active="<?php echo esc_attr($schedule->is_active); ?>">
                             <td>
                                 <div class="cell-primary"><?php echo esc_html($schedule->template_name ?: __('Unknown Template', 'ai-post-scheduler')); ?></div>
+                                <div class="aips-table-meta-row">
+                                    <span class="aips-badge-neutral">ID: <?php echo esc_html($schedule->id); ?></span>
+                                    <button type="button" class="aips-copy-btn aips-copy-btn-small" data-clipboard-text="<?php echo esc_attr($schedule->id); ?>" title="<?php esc_attr_e('Copy ID', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Copy ID', 'ai-post-scheduler'); ?>">
+                                        <span class="dashicons dashicons-admin-page"></span>
+                                    </button>
+                                </div>
                             </td>
                             <td>
                                 <div>

--- a/ai-post-scheduler/templates/admin/sections.php
+++ b/ai-post-scheduler/templates/admin/sections.php
@@ -48,7 +48,15 @@ if (!isset($sections) || !is_array($sections)) {
 					<tbody>
 						<?php foreach ($sections as $section) : ?>
 						<tr data-section-id="<?php echo esc_attr($section->id); ?>">
-							<td class="column-name"><strong><?php echo esc_html($section->name); ?></strong></td>
+							<td class="column-name">
+								<strong><?php echo esc_html($section->name); ?></strong>
+								<div class="aips-table-meta-row" style="margin-top: 5px;">
+									<span class="aips-badge-neutral">ID: <?php echo esc_html($section->id); ?></span>
+									<button type="button" class="aips-copy-btn aips-copy-btn-small" data-clipboard-text="<?php echo esc_attr($section->id); ?>" title="<?php esc_attr_e('Copy ID', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Copy ID', 'ai-post-scheduler'); ?>">
+										<span class="dashicons dashicons-admin-page"></span>
+									</button>
+								</div>
+							</td>
 							<td class="column-key">
 								<div class="aips-variable-code-cell">
 									<code><?php echo esc_html($section->section_key); ?></code>

--- a/ai-post-scheduler/templates/admin/structures.php
+++ b/ai-post-scheduler/templates/admin/structures.php
@@ -68,7 +68,15 @@ if (!isset($sections) || !is_array($sections)) {
 				<tbody>
 					<?php foreach ($structures as $structure): ?>
 					<tr data-structure-id="<?php echo esc_attr($structure->id); ?>">
-						<td class="column-name"><?php echo esc_html($structure->name); ?></td>
+						<td class="column-name">
+							<?php echo esc_html($structure->name); ?>
+							<div class="aips-table-meta-row" style="margin-top: 5px;">
+								<span class="aips-badge-neutral">ID: <?php echo esc_html($structure->id); ?></span>
+								<button type="button" class="aips-copy-btn aips-copy-btn-small" data-clipboard-text="<?php echo esc_attr($structure->id); ?>" title="<?php esc_attr_e('Copy ID', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Copy ID', 'ai-post-scheduler'); ?>">
+									<span class="dashicons dashicons-admin-page"></span>
+								</button>
+							</div>
+						</td>
 						<td class="column-description"><?php echo esc_html($structure->description); ?></td>
 						<td class="column-active"><?php echo $structure->is_active ? esc_html__('Yes', 'ai-post-scheduler') : esc_html__('No', 'ai-post-scheduler'); ?></td>
 						<td class="column-default"><?php echo $structure->is_default ? esc_html__('Yes', 'ai-post-scheduler') : esc_html__('No', 'ai-post-scheduler'); ?></td>

--- a/ai-post-scheduler/templates/admin/templates.php
+++ b/ai-post-scheduler/templates/admin/templates.php
@@ -60,6 +60,12 @@ if (!defined('ABSPATH')) {
                         <tr data-template-id="<?php echo esc_attr($template->id); ?>">
                             <td>
                                 <div class="cell-primary"><?php echo esc_html($template->name); ?></div>
+                                <div class="aips-table-meta-row">
+                                    <span class="aips-badge-neutral">ID: <?php echo esc_html($template->id); ?></span>
+                                    <button type="button" class="aips-copy-btn aips-copy-btn-small" data-clipboard-text="<?php echo esc_attr($template->id); ?>" title="<?php esc_attr_e('Copy ID', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Copy ID', 'ai-post-scheduler'); ?>">
+                                        <span class="dashicons dashicons-admin-page"></span>
+                                    </button>
+                                </div>
                             </td>
                             <td>
                                 <span class="aips-badge aips-badge-neutral">

--- a/ai-post-scheduler/templates/admin/voices.php
+++ b/ai-post-scheduler/templates/admin/voices.php
@@ -57,6 +57,12 @@ if (!defined('ABSPATH')) {
                                     <div class="aips-table-primary">
                                         <strong><?php echo esc_html($voice->name); ?></strong>
                                     </div>
+                                    <div class="aips-table-meta-row">
+                                        <span class="aips-badge-neutral">ID: <?php echo esc_html($voice->id); ?></span>
+                                        <button type="button" class="aips-copy-btn aips-copy-btn-small" data-clipboard-text="<?php echo esc_attr($voice->id); ?>" title="<?php esc_attr_e('Copy ID', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Copy ID', 'ai-post-scheduler'); ?>">
+                                            <span class="dashicons dashicons-admin-page"></span>
+                                        </button>
+                                    </div>
                                 </td>
                                 <td class="column-title-prompt">
                                     <div class="aips-table-meta">


### PR DESCRIPTION
### What
Added a "Copy to Clipboard" button next to the primary entity ID across all major admin list views:
- Authors
- Templates
- Schedules
- Voices
- Structures
- Sections

### Why
Users frequently need to copy IDs for troubleshooting, reference, or use in other parts of the application. Finding and selecting the exact text without picking up surrounding spaces can be tedious.

### Value
Improves user productivity by providing a one-click action to copy IDs reliably, preventing manual selection errors, and standardizing the UI across the plugin.

### Visuals
The ID is now displayed below the primary column name (e.g. Template Name) inside an `.aips-table-meta-row` container. It features a neutral badge for the text and a small copy icon that triggers a toast notification upon success (managed via existing JS).

---
*PR created automatically by Jules for task [17708019420004616301](https://jules.google.com/task/17708019420004616301) started by @rpnunez*