### PR TITLE
🧙‍♂️ Wizard: Add Copy to Clipboard for System Status Details

### DIFF
--- a/.jules/wizard.md
+++ b/.jules/wizard.md
@@ -35,3 +35,9 @@
 ## 2026-01-22 - Research Search Consistency
 **Learning:** The "Trending Topics Library" table lacked search functionality, which is a standard expectation established in other admin tables (Authors, Structures, etc.).
 **Action:** Implemented client-side search for Trending Topics with a "Clear" button and Empty State, ensuring "Select All" functionality respects the active filter.
+
+## 2026-03-07 - Add Copy to Clipboard for System Status Details
+
+Learning: When implementing "Copy to Clipboard" features for large blocks of text (like system logs), avoid injecting the entire string into an HTML attribute like `data-clipboard-text` as it bloats the DOM. Also, always add `type="button"` to buttons within or near forms to prevent accidental submissions.
+
+Action: Wrote a dedicated JavaScript click handler using the modern `navigator.clipboard` API (with fallback) that reads directly from the adjacent `<textarea>` instead of a data attribute.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,3 +72,4 @@ All notable changes to this project will be documented in this file.
 - [2025-12-21 01:48:42] Added search functionality to the Generation History page to filter posts by title.
 - [2024-05-22 10:00:00] Refactored Scheduler: Extracted AJAX handlers to `AIPS_Schedule_Controller`, enhanced `AIPS_Scheduler` with better topic and next_run support, and updated `AIPS_Planner` to use the Scheduler service instead of direct SQL.
 - [2024-05-22 10:00:00] Made generated topic titles editable in the Planner before scheduling.
+- [2024-03-07] **Feature Wizard**: Added a "Copy to Clipboard" button to the System Status log details to improve developer productivity when troubleshooting issues.

--- a/ai-post-scheduler/templates/admin/system-status.php
+++ b/ai-post-scheduler/templates/admin/system-status.php
@@ -45,8 +45,11 @@ if (!defined('ABSPATH')) {
                                                 <a href="#" class="aips-toggle-log-details" data-target="log-details-<?php echo esc_attr($key); ?>" style="font-size: 13px;">
                                                     <?php esc_html_e('Show Details', 'ai-post-scheduler'); ?>
                                                 </a>
-                                                <div id="log-details-<?php echo esc_attr($key); ?>" class="aips-log-details" style="display:none; margin-top: 10px;">
-                                                    <textarea class="aips-form-input" rows="10" readonly style="font-family: monospace; font-size: 12px;"><?php echo esc_textarea(implode("\n", $check['details'])); ?></textarea>
+                                                <div id="log-details-<?php echo esc_attr($key); ?>" class="aips-log-details" style="display:none; margin-top: 10px; position: relative;">
+                                                    <button type="button" class="aips-btn aips-btn-sm aips-copy-log-btn" style="position: absolute; top: 10px; right: 10px;" aria-label="<?php esc_attr_e('Copy details to clipboard', 'ai-post-scheduler'); ?>">
+                                                        <span class="dashicons dashicons-clipboard"></span> <?php esc_html_e('Copy', 'ai-post-scheduler'); ?>
+                                                    </button>
+                                                    <textarea class="aips-form-input aips-log-textarea" rows="10" readonly style="font-family: monospace; font-size: 12px; padding-top: 35px;"><?php echo esc_textarea(implode("\n", $check['details'])); ?></textarea>
                                                 </div>
                                             <?php endif; ?>
                                         </td>
@@ -95,6 +98,39 @@ jQuery(document).ready(function($) {
             ? <?php echo wp_json_encode( __( 'Hide Details', 'ai-post-scheduler' ) ); ?>
             : <?php echo wp_json_encode( __( 'Show Details', 'ai-post-scheduler' ) ); ?>;
         $(this).text(text);
+    });
+
+    // Copy log details
+    $('.aips-copy-log-btn').on('click', function(e) {
+        e.preventDefault();
+        var $btn = $(this);
+        var $textarea = $btn.siblings('.aips-log-textarea');
+        var textToCopy = $textarea.val();
+        var originalHtml = $btn.html();
+
+        var showSuccess = function() {
+            $btn.html('<span class="dashicons dashicons-yes"></span> ' + <?php echo wp_json_encode( __( 'Copied!', 'ai-post-scheduler' ) ); ?>);
+            setTimeout(function() {
+                $btn.html(originalHtml);
+            }, 2000);
+        };
+
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(textToCopy).then(showSuccess).catch(function(err) {
+                console.error('Failed to copy text: ', err);
+            });
+        } else {
+            // Fallback
+            $textarea.select();
+            try {
+                document.execCommand('copy');
+                showSuccess();
+            } catch (err) {
+                console.error('Fallback copy failed: ', err);
+            }
+            // Deselect
+            window.getSelection().removeAllRanges();
+        }
     });
 });
 </script>


### PR DESCRIPTION
🧙‍♂️ Wizard: Add Copy to Clipboard for System Status Details

What:
- Added a "Copy" button to the log details textareas on the System Status page.
- Implemented a dedicated JavaScript handler using `navigator.clipboard` (with `document.execCommand` fallback) to safely and efficiently copy the contents of the adjacent textarea.

Why:
- Developers frequently need to share or analyze system logs when troubleshooting.
- Manually selecting and copying large blocks of text from a textarea is tedious and error-prone.

Value:
- Significantly improves developer productivity and UX by allowing one-click copying of log details.
- Avoids DOM bloat by reading the text directly from the textarea instead of injecting massive strings into HTML attributes.

---
*PR created automatically by Jules for task [5083283193209256939](https://jules.google.com/task/5083283193209256939) started by @rpnunez*