### PR TITLE
Fix initial schedule bug in Authors Controller

### DIFF
--- a/ai-post-scheduler/includes/class-aips-authors-controller.php
+++ b/ai-post-scheduler/includes/class-aips-authors-controller.php
@@ -115,8 +115,9 @@ class AIPS_Authors_Controller {
 		
 		// Calculate initial run times if creating new author
 		if (!$author_id) {
-			$data['topic_generation_next_run'] = $this->interval_calculator->calculate_next_run($data['topic_generation_frequency']);
-			$data['post_generation_next_run'] = $this->interval_calculator->calculate_next_run($data['post_generation_frequency']);
+				// Use current time as explicit start time for the first run, instead of calculating start_time + interval.
+				$data['topic_generation_next_run'] = current_time('mysql');
+				$data['post_generation_next_run'] = current_time('mysql');
 		}
 		
 		// Save or update


### PR DESCRIPTION
In the `AIPS_Authors_Controller`, creating a new Author improperly initialized the `topic_generation_next_run` and `post_generation_next_run` by using the `calculate_next_run()` method instead of passing the initial explicit start time.

As per `.jules/hunter.md`, this incorrectly causes the scheduler to skip the first run since it adds an interval interval *before* running. This commit fixes it by initializing those dates directly to `current_time('mysql')` during the creation of a new author, allowing the first execution to happen immediately, and subsequent executions will be calculated normally after that.

---
*PR created automatically by Jules for task [15115249880358152790](https://jules.google.com/task/15115249880358152790) started by @rpnunez*