### PR TITLE
Atlas: Refactor Repositories to PSR-4 (Phase 1)

### DIFF
--- a/ai-post-scheduler/includes/class-aips-autoloader.php
+++ b/ai-post-scheduler/includes/class-aips-autoloader.php
@@ -36,6 +36,30 @@ class AIPS_Autoloader {
             return;
         }
 
+        // Aliases for PSR-4 migration
+        $aliases = array(
+            'AIPS_DB_Manager'                   => 'AIPS\\Repositories\\DBManager',
+            'AIPS_Article_Structure_Repository' => 'AIPS\\Repositories\\ArticleStructureRepository',
+            'AIPS_Author_Topic_Logs_Repository' => 'AIPS\\Repositories\\AuthorTopicLogsRepository',
+            'AIPS_Author_Topics_Repository'     => 'AIPS\\Repositories\\AuthorTopicsRepository',
+            'AIPS_Authors_Repository'           => 'AIPS\\Repositories\\AuthorsRepository',
+            'AIPS_Feedback_Repository'          => 'AIPS\\Repositories\\FeedbackRepository',
+            'AIPS_History_Repository'           => 'AIPS\\Repositories\\HistoryRepository',
+            'AIPS_Post_Review_Repository'       => 'AIPS\\Repositories\\PostReviewRepository',
+            'AIPS_Prompt_Section_Repository'    => 'AIPS\\Repositories\\PromptSectionRepository',
+            'AIPS_Schedule_Repository'          => 'AIPS\\Repositories\\ScheduleRepository',
+            'AIPS_Template_Repository'          => 'AIPS\\Repositories\\TemplateRepository',
+            'AIPS_Trending_Topics_Repository'   => 'AIPS\\Repositories\\TrendingTopicsRepository',
+            'AIPS_Voices_Repository'            => 'AIPS\\Repositories\\VoicesRepository',
+        );
+
+        if (isset($aliases[$class_name])) {
+            if (class_exists($aliases[$class_name])) {
+                class_alias($aliases[$class_name], $class_name);
+                return;
+            }
+        }
+
         // Convert class name to file names using helper methods
         $class_file = self::convert_class_name_to_filename($class_name);
         $base_name = self::convert_class_name_to_base($class_name);

--- a/ai-post-scheduler/src/Repositories/DBManager.php
+++ b/ai-post-scheduler/src/Repositories/DBManager.php
@@ -1,9 +1,11 @@
 <?php
+namespace AIPS\Repositories;
+
 if (!defined('ABSPATH')) {
     exit;
 }
 
-class AIPS_DB_Manager {
+class DBManager {
 
     private static $tables = array(
         'aips_history',

--- a/ai-post-scheduler/tests/bootstrap.php
+++ b/ai-post-scheduler/tests/bootstrap.php
@@ -879,12 +879,6 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
     $files = [
         'class-aips-logger.php',
         'class-aips-config.php',
-        'class-aips-db-manager.php',
-        'class-aips-history-repository.php',
-        'class-aips-schedule-repository.php',
-        'class-aips-template-repository.php',
-        'class-aips-article-structure-repository.php',
-        'class-aips-prompt-section-repository.php',
         'class-aips-template-processor.php',
         'class-aips-prompt-builder.php',
         'class-aips-article-structure-manager.php',
@@ -908,7 +902,6 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
         'class-aips-system-status.php',
         'class-aips-templates.php',
         'class-aips-upgrades.php',
-        'class-aips-voices-repository.php',
         'class-aips-voices.php',
         'class-aips-structures-controller.php',
         'class-aips-templates-controller.php',
@@ -918,6 +911,29 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
     foreach ($files as $file) {
         if (file_exists($includes_dir . $file)) {
             require_once $includes_dir . $file;
+        }
+    }
+
+    // Create class aliases for PSR-4 refactored classes
+    $aliases = array(
+        'AIPS_DB_Manager'                   => 'AIPS\\Repositories\\DBManager',
+        'AIPS_Article_Structure_Repository' => 'AIPS\\Repositories\\ArticleStructureRepository',
+        'AIPS_Author_Topic_Logs_Repository' => 'AIPS\\Repositories\\AuthorTopicLogsRepository',
+        'AIPS_Author_Topics_Repository'     => 'AIPS\\Repositories\\AuthorTopicsRepository',
+        'AIPS_Authors_Repository'           => 'AIPS\\Repositories\\AuthorsRepository',
+        'AIPS_Feedback_Repository'          => 'AIPS\\Repositories\\FeedbackRepository',
+        'AIPS_History_Repository'           => 'AIPS\\Repositories\\HistoryRepository',
+        'AIPS_Post_Review_Repository'       => 'AIPS\\Repositories\\PostReviewRepository',
+        'AIPS_Prompt_Section_Repository'    => 'AIPS\\Repositories\\PromptSectionRepository',
+        'AIPS_Schedule_Repository'          => 'AIPS\\Repositories\\ScheduleRepository',
+        'AIPS_Template_Repository'          => 'AIPS\\Repositories\\TemplateRepository',
+        'AIPS_Trending_Topics_Repository'   => 'AIPS\\Repositories\\TrendingTopicsRepository',
+        'AIPS_Voices_Repository'            => 'AIPS\\Repositories\\VoicesRepository',
+    );
+
+    foreach ($aliases as $old_name => $new_name) {
+        if (class_exists($new_name) && !class_exists($old_name, false)) {
+            class_alias($new_name, $old_name);
         }
     }
 }


### PR DESCRIPTION
This PR addresses Phase 1 of the PSR-4 Refactoring Plan outlined in `docs/PSR4_REFACTORING_PLAN.md`. 

### Changes
*   Added `"AIPS\\": "src/"` mapping to `composer.json` for PSR-4 autoloading.
*   Created the `src/Repositories/` directory and migrated all 13 repository-related classes into it.
*   Updated namespaces to `AIPS\Repositories` and renamed files/classes to conform to PSR-4 standard.
*   Added a compatibility layer in `class-aips-autoloader.php` and `tests/bootstrap.php` using `class_alias` to ensure existing code and tests referring to the legacy `AIPS_*` classes continue to function correctly.
*   Verified that the Composer autoloader handles the load and that the test suite runs without `Class not found` fatal errors.

---
*PR created automatically by Jules for task [4416474256618667909](https://jules.google.com/task/4416474256618667909) started by @rpnunez*