### PR TITLE
Fix Hunter & Atlas mode issues: author scheduler init and system status file reading

### DIFF
--- a/ai-post-scheduler/includes/class-aips-authors-controller.php
+++ b/ai-post-scheduler/includes/class-aips-authors-controller.php
@@ -115,8 +115,8 @@ class AIPS_Authors_Controller {
 		
 		// Calculate initial run times if creating new author
 		if (!$author_id) {
-			$data['topic_generation_next_run'] = $this->interval_calculator->calculate_next_run($data['topic_generation_frequency']);
-			$data['post_generation_next_run'] = $this->interval_calculator->calculate_next_run($data['post_generation_frequency']);
+			$data['topic_generation_next_run'] = current_time('mysql');
+			$data['post_generation_next_run'] = current_time('mysql');
 		}
 		
 		// Save or update

--- a/ai-post-scheduler/includes/class-aips-system-status.php
+++ b/ai-post-scheduler/includes/class-aips-system-status.php
@@ -238,7 +238,7 @@ class AIPS_System_Status {
         $file_lines = explode("\n", $content);
 
         // If we didn't read the whole file, the first line might be partial, so skip it
-        if ($offset > 0 && !empty($file_lines)) {
+        if ($offset > 0 && count($file_lines) > 1) {
             array_shift($file_lines);
         }
 


### PR DESCRIPTION
Implemented two critical fixes identified during an Engineering Lead sweep across the repository.

### Hunter Mode (Stability/Bug Fix)
Resolved a bug in `AIPS_Authors_Controller` where newly created scheduled tasks for post and topic generation would incorrectly skip their initial run. By directly assigning `current_time('mysql')` instead of calculating the next interval, tasks will now execute as expected immediately or at their designated first start time.

### Atlas Mode (Architecture/Refactoring)
Refactored the log reading logic in `AIPS_System_Status` to fix a logical error related to array evaluation. Replaced the `!empty($file_lines)` check (which is always true after an `explode("\n", ...)`) with a proper `count($file_lines) > 1` condition. This ensures that a partial first line is only shifted off if the file actually contains multiple lines, improving stability and resolving static analysis errors flagged by PHPStan.

---
*PR created automatically by Jules for task [13925840011036888694](https://jules.google.com/task/13925840011036888694) started by @rpnunez*