### PR TITLE
🧙‍♂️ Wizard: Add "Clear Search" to History

### DIFF
--- a/.jules/wizard.md
+++ b/.jules/wizard.md
@@ -35,3 +35,8 @@
 ## 2026-01-22 - Research Search Consistency
 **Learning:** The "Trending Topics Library" table lacked search functionality, which is a standard expectation established in other admin tables (Authors, Structures, etc.).
 **Action:** Implemented client-side search for Trending Topics with a "Clear" button and Empty State, ensuring "Select All" functionality respects the active filter.
+## 2025-03-08 - Added "Clear Search" to History
+
+Learning: Adding a dedicated clear button enhances UX for long forms/tables, especially when implemented cleanly without full-page reloads. Consistent patterns (found in templates, authors, etc.) help maintain predictability.
+
+Action: Always look for ways to make the UI simpler when filtering or searching, using client-side events like `keyup` or `search` to conditionally show interaction elements.

--- a/ai-post-scheduler/assets/js/admin.js
+++ b/ai-post-scheduler/assets/js/admin.js
@@ -112,6 +112,8 @@
             $(document).on('click', '#aips-reload-history-btn', this.reloadHistory);
             $(document).on('click', '.aips-history-page-link, .aips-history-page-prev, .aips-history-page-next', this.loadHistoryPage);
             $(document).on('keypress', '#aips-history-search-input', this.handleHistorySearchKeypress);
+            $(document).on('keyup search', '#aips-history-search-input', this.toggleHistorySearchClear);
+            $(document).on('click', '#aips-history-search-clear', this.clearHistorySearch);
             $(document).on('click', '.aips-view-details', this.viewDetails);
 
             // History Pagination
@@ -1958,6 +1960,31 @@
             if (e.which == 13) {
                 AIPS.filterHistory(e);
             }
+        },
+
+        /**
+         * Toggle the history search clear button based on input value length.
+         *
+         * Bound to the `keyup` and `search` events on `#aips-history-search-input`.
+         */
+        toggleHistorySearchClear: function() {
+            var search = $('#aips-history-search-input').val().trim();
+            if (search.length > 0) {
+                $('#aips-history-search-clear').show();
+            } else {
+                $('#aips-history-search-clear').hide();
+            }
+        },
+
+        /**
+         * Clear the history search input and reload the history.
+         *
+         * @param {Event} e - Click event from `#aips-history-search-clear`.
+         */
+        clearHistorySearch: function(e) {
+            e.preventDefault();
+            $('#aips-history-search-input').val('').trigger('keyup');
+            AIPS.filterHistory(e);
         },
 
         /**

--- a/ai-post-scheduler/templates/admin/history.php
+++ b/ai-post-scheduler/templates/admin/history.php
@@ -96,9 +96,7 @@ if (isset($history_handler)) {
                         <span class="dashicons dashicons-search"></span>
                         <?php esc_html_e('Search', 'ai-post-scheduler'); ?>
                     </button>
-                    <?php if (!empty($search_query)): ?>
-                        <a href="<?php echo esc_url(remove_query_arg('s')); ?>" class="aips-btn aips-btn-sm"><?php esc_html_e('Clear', 'ai-post-scheduler'); ?></a>
-                    <?php endif; ?>
+                    <button type="button" id="aips-history-search-clear" class="aips-btn aips-btn-sm aips-btn-secondary" style="<?php echo empty($search_query) ? 'display: none;' : ''; ?>"><?php esc_html_e('Clear', 'ai-post-scheduler'); ?></button>
                 </div>
             </div>
 


### PR DESCRIPTION
🧙‍♂️ Wizard: Add "Clear Search" to History

**What:** Replaces the server-rendered "Clear" link with a dynamic JS-managed button in the History search bar.

**Why:** Matches existing UI patterns (like templates) and improves UX by allowing instant input clearing without a full page reload.

**Value:** A more seamless, responsive filtering experience.

**Visuals:** The History search input now reveals a "Clear" button when typed into, mirroring standard search interfaces.

---
*PR created automatically by Jules for task [16812676736731588253](https://jules.google.com/task/16812676736731588253) started by @rpnunez*