### PR TITLE
Add natural language schedule input and handling

### DIFF
--- a/ai-post-scheduler/assets/js/admin.js
+++ b/ai-post-scheduler/assets/js/admin.js
@@ -1028,6 +1028,7 @@
             e.preventDefault();
             $('#aips-schedule-form')[0].reset();
             $('#schedule_id').val('');
+            $('#schedule_natural_language').val('');
             $('#aips-schedule-modal-title').text('Add New Schedule');
             $('#aips-schedule-modal').show();
         },
@@ -1055,6 +1056,7 @@
             $('#schedule_id').val(scheduleId);
             $('#schedule_template').val(templateId);
             $('#schedule_frequency').val(frequency);
+            $('#schedule_natural_language').val('');
             $('#schedule_topic').val(topic || '');
             $('#article_structure_id').val(articleStructureId || '');
             $('#rotation_pattern').val(rotationPattern || '');
@@ -1101,6 +1103,7 @@
             // Populate form
             $('#schedule_template').val(templateId);
             $('#schedule_frequency').val(frequency);
+            $('#schedule_natural_language').val('');
             $('#schedule_topic').val(topic);
             $('#article_structure_id').val(articleStructureId);
             $('#rotation_pattern').val(rotationPattern);
@@ -1144,6 +1147,7 @@
                     schedule_id: $('#schedule_id').val(),
                     template_id: $('#schedule_template').val(),
                     frequency: $('#schedule_frequency').val(),
+                    natural_schedule: $('#schedule_natural_language').val(),
                     start_time: $('#schedule_start_time').val(),
                     topic: $('#schedule_topic').val(),
                     article_structure_id: $('#article_structure_id').val(),

--- a/ai-post-scheduler/includes/class-aips-interval-calculator.php
+++ b/ai-post-scheduler/includes/class-aips-interval-calculator.php
@@ -62,6 +62,12 @@ class AIPS_Interval_Calculator {
             'type' => 'fixed'
         );
 
+        $intervals['weekdays'] = array(
+            'interval' => 86400, // Calendar-based; actual next run skips weekends.
+            'display' => __('Every Weekday', 'ai-post-scheduler'),
+            'type' => 'calendar'
+        );
+
         $intervals['weekly'] = array(
             'interval' => 604800,
             'display' => __('Once Weekly', 'ai-post-scheduler'),
@@ -209,6 +215,9 @@ class AIPS_Interval_Calculator {
                 
             case 'daily':
                 return strtotime('+1 day', $base_time);
+
+            case 'weekdays':
+                return $this->calculate_next_weekday_timestamp($base_time);
                 
             case 'weekly':
                 return strtotime('+1 week', $base_time);
@@ -224,6 +233,23 @@ class AIPS_Interval_Calculator {
         }
     }
     
+    /**
+     * Calculate next run time for weekday-only schedules (Monday-Friday).
+     *
+     * @param int $base_time The base timestamp to calculate from.
+     * @return int The next weekday timestamp, preserving time.
+     */
+    private function calculate_next_weekday_timestamp($base_time) {
+        $next = strtotime('+1 day', $base_time);
+
+        // Skip Saturday (6) and Sunday (7).
+        while (in_array((int) date('N', $next), array(6, 7), true)) {
+            $next = strtotime('+1 day', $next);
+        }
+
+        return $next;
+    }
+
     /**
      * Calculate next run time for day-specific intervals (e.g., "every_monday").
      *

--- a/ai-post-scheduler/includes/class-aips-natural-schedule-parser.php
+++ b/ai-post-scheduler/includes/class-aips-natural-schedule-parser.php
@@ -31,6 +31,14 @@ class AIPS_Natural_Schedule_Parser {
         $reference_timestamp = $reference_timestamp ?: current_time('timestamp');
         $time_parts = $this->extract_time_parts($normalized);
 
+        // If the input appears to specify a time but we could not parse it,
+        // return an explicit error instead of silently falling back to the reference time.
+        if ($time_parts === null && preg_match('/\b(?:at\s+\d{1,2}(?::\d{2})?\s*(?:am|pm)?|at\s+(?:noon|midnight)|noon|midnight)\b/', $normalized)) {
+            return new WP_Error(
+                'invalid_schedule_time',
+                __('The time in your schedule phrase could not be understood. Please use a time like "8am" or "14:30".', 'ai-post-scheduler')
+            );
+        }
         $days = array(
             'monday' => 1,
             'tuesday' => 2,

--- a/ai-post-scheduler/includes/class-aips-natural-schedule-parser.php
+++ b/ai-post-scheduler/includes/class-aips-natural-schedule-parser.php
@@ -1,0 +1,212 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Parse natural-language schedule phrases into scheduler frequency/start_time.
+ *
+ * Supported examples:
+ * - every weekday at 8 AM
+ * - every monday at 9:30
+ * - daily at 14:00
+ * - every 6 hours
+ */
+class AIPS_Natural_Schedule_Parser {
+
+    /**
+     * Parse a natural-language schedule.
+     *
+     * @param string   $input               Natural-language schedule text.
+     * @param int|null $reference_timestamp Optional timestamp to parse relative to.
+     * @return array|WP_Error
+     */
+    public function parse($input, $reference_timestamp = null) {
+        $input = is_string($input) ? trim($input) : '';
+        if ($input == '') {
+            return new WP_Error('invalid_schedule_text', __('Please enter a schedule phrase.', 'ai-post-scheduler'));
+        }
+
+        $normalized = strtolower(preg_replace('/\s+/', ' ', $input));
+        $reference_timestamp = $reference_timestamp ?: current_time('timestamp');
+        $time_parts = $this->extract_time_parts($normalized);
+
+        $days = array(
+            'monday' => 1,
+            'tuesday' => 2,
+            'wednesday' => 3,
+            'thursday' => 4,
+            'friday' => 5,
+            'saturday' => 6,
+            'sunday' => 7,
+        );
+
+        if (preg_match('/\b(every\s+weekday|weekdays?)\b/', $normalized)) {
+            $start = $this->next_weekday_at_time($reference_timestamp, $time_parts);
+            return array('frequency' => 'weekdays', 'start_time' => date('Y-m-d H:i:s', $start));
+        }
+
+        foreach ($days as $day_name => $day_number) {
+            if (preg_match('/\b(every\s+' . preg_quote($day_name, '/') . '|on\s+' . preg_quote($day_name, '/') . ')\b/', $normalized)) {
+                $start = $this->next_day_of_week_at_time($reference_timestamp, $day_number, $time_parts);
+                return array('frequency' => 'every_' . $day_name, 'start_time' => date('Y-m-d H:i:s', $start));
+            }
+        }
+
+        if (preg_match('/\b(every\s+4\s+hours?|every\s+four\s+hours?)\b/', $normalized)) {
+            return $this->parse_fixed_interval_result('every_4_hours', $reference_timestamp, $time_parts);
+        }
+
+        if (preg_match('/\b(every\s+6\s+hours?|every\s+six\s+hours?)\b/', $normalized)) {
+            return $this->parse_fixed_interval_result('every_6_hours', $reference_timestamp, $time_parts);
+        }
+
+        if (preg_match('/\b(every\s+12\s+hours?|every\s+twelve\s+hours?)\b/', $normalized)) {
+            return $this->parse_fixed_interval_result('every_12_hours', $reference_timestamp, $time_parts);
+        }
+
+        if (preg_match('/\b(every\s+hour|hourly)\b/', $normalized)) {
+            return $this->parse_fixed_interval_result('hourly', $reference_timestamp, $time_parts);
+        }
+
+        if (preg_match('/\b(bi\s*weekly|every\s+2\s+weeks?)\b/', $normalized)) {
+            return $this->parse_fixed_interval_result('bi_weekly', $reference_timestamp, $time_parts);
+        }
+
+        if (preg_match('/\b(weekly|every\s+week)\b/', $normalized)) {
+            return $this->parse_fixed_interval_result('weekly', $reference_timestamp, $time_parts);
+        }
+
+        if (preg_match('/\b(monthly|every\s+month)\b/', $normalized)) {
+            return $this->parse_fixed_interval_result('monthly', $reference_timestamp, $time_parts);
+        }
+
+        if (preg_match('/\b(once|one\s*time|one-time|onetime)\b/', $normalized)) {
+            return array(
+                'frequency' => 'once',
+                'start_time' => date('Y-m-d H:i:s', $this->next_time_at_or_after($reference_timestamp, $time_parts)),
+            );
+        }
+
+        if (preg_match('/\b(daily|every\s+day|each\s+day)\b/', $normalized)) {
+            return $this->parse_fixed_interval_result('daily', $reference_timestamp, $time_parts);
+        }
+
+        return new WP_Error(
+            'unsupported_schedule_text',
+            __('Could not parse schedule text. Try phrases like "every weekday at 8 AM" or "every monday at 9:30".', 'ai-post-scheduler')
+        );
+    }
+
+    /**
+     * Build result array for fixed-interval frequencies.
+     */
+    private function parse_fixed_interval_result($frequency, $reference_timestamp, $time_parts) {
+        return array(
+            'frequency' => $frequency,
+            'start_time' => date('Y-m-d H:i:s', $this->next_time_at_or_after($reference_timestamp, $time_parts)),
+        );
+    }
+
+    /**
+     * Extract a time component from text.
+     *
+     * @return array|null Array with keys hour/minute or null when omitted.
+     */
+    private function extract_time_parts($normalized) {
+        if (preg_match('/\bmidnight\b/', $normalized)) {
+            return array('hour' => 0, 'minute' => 0);
+        }
+
+        if (preg_match('/\bnoon\b/', $normalized)) {
+            return array('hour' => 12, 'minute' => 0);
+        }
+
+        if (preg_match('/\bat\s+([0-1]?\d|2[0-3])(?::([0-5]\d))?\s*(am|pm)\b/', $normalized, $m)) {
+            $hour = (int) $m[1];
+            $minute = isset($m[2]) && $m[2] !== '' ? (int) $m[2] : 0;
+            $ampm = $m[3];
+
+            if ($ampm === 'am' && $hour === 12) {
+                $hour = 0;
+            } elseif ($ampm === 'pm' && $hour < 12) {
+                $hour += 12;
+            }
+
+            return array('hour' => $hour, 'minute' => $minute);
+        }
+
+        if (preg_match('/\bat\s+([0-1]?\d|2[0-3]):([0-5]\d)\b/', $normalized, $m)) {
+            return array('hour' => (int) $m[1], 'minute' => (int) $m[2]);
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the next occurrence of a day/time (or immediate reference when no time specified).
+     */
+    private function next_time_at_or_after($reference_timestamp, $time_parts) {
+        if ($time_parts === null) {
+            return $reference_timestamp;
+        }
+
+        $candidate = $this->timestamp_for_date_and_time($reference_timestamp, $time_parts);
+        if ($candidate <= $reference_timestamp) {
+            $candidate = strtotime('+1 day', $candidate);
+        }
+
+        return $candidate;
+    }
+
+    /**
+     * Get next weekday occurrence at requested time.
+     */
+    private function next_weekday_at_time($reference_timestamp, $time_parts) {
+        $candidate = $this->timestamp_for_date_and_time($reference_timestamp, $time_parts);
+        $day = (int) date('N', $candidate);
+
+        if ($day <= 5 && $candidate > $reference_timestamp) {
+            return $candidate;
+        }
+
+        do {
+            $candidate = strtotime('+1 day', $candidate);
+            $day = (int) date('N', $candidate);
+        } while ($day > 5);
+
+        return $candidate;
+    }
+
+    /**
+     * Get next requested day-of-week occurrence at requested time.
+     */
+    private function next_day_of_week_at_time($reference_timestamp, $target_day, $time_parts) {
+        $candidate = $this->timestamp_for_date_and_time($reference_timestamp, $time_parts);
+
+        for ($i = 0; $i < 8; $i++) {
+            $day = (int) date('N', $candidate);
+            if ($day === (int) $target_day && $candidate > $reference_timestamp) {
+                return $candidate;
+            }
+            $candidate = strtotime('+1 day', $candidate);
+        }
+
+        return $candidate;
+    }
+
+    /**
+     * Build a timestamp on the reference date with provided time.
+     */
+    private function timestamp_for_date_and_time($reference_timestamp, $time_parts) {
+        if ($time_parts === null) {
+            return $reference_timestamp;
+        }
+
+        $date = date('Y-m-d', $reference_timestamp);
+        $hour = (int) $time_parts['hour'];
+        $minute = (int) $time_parts['minute'];
+
+        return strtotime(sprintf('%s %02d:%02d:00', $date, $hour, $minute));
+    }
+}

--- a/ai-post-scheduler/includes/class-aips-natural-schedule-parser.php
+++ b/ai-post-scheduler/includes/class-aips-natural-schedule-parser.php
@@ -31,9 +31,16 @@ class AIPS_Natural_Schedule_Parser {
         $reference_timestamp = $reference_timestamp ?: current_time('timestamp');
         $time_parts = $this->extract_time_parts($normalized);
 
+        // Propagate any validation error (e.g. out-of-range AM/PM hour) from extract_time_parts.
+        if (is_wp_error($time_parts)) {
+            return $time_parts;
+        }
+
         // If the input appears to specify a time but we could not parse it,
         // return an explicit error instead of silently falling back to the reference time.
-        if ($time_parts === null && preg_match('/\b(?:at\s+\d{1,2}(?::\d{2})?\s*(?:am|pm)?|at\s+(?:noon|midnight)|noon|midnight)\b/', $normalized)) {
+        // Detect any "at" followed by a structured time pattern (digits with optional colon/digits and optional am/pm),
+        // or the literal words noon/midnight, to catch malformed inputs like "at 14:3" or "at 25:00".
+        if ($time_parts === null && preg_match('/\bat\s+\d{1,2}(?::\d{1,2})?(?:\s*(?:am|pm))?\b|\bnoon\b|\bmidnight\b/', $normalized)) {
             return new WP_Error(
                 'invalid_schedule_time',
                 __('The time in your schedule phrase could not be understood. Please use a time like "8am" or "14:30".', 'ai-post-scheduler')
@@ -119,7 +126,7 @@ class AIPS_Natural_Schedule_Parser {
     /**
      * Extract a time component from text.
      *
-     * @return array|null Array with keys hour/minute or null when omitted.
+     * @return array|WP_Error|null Array with keys hour/minute, WP_Error on invalid input, or null when omitted.
      */
     private function extract_time_parts($normalized) {
         if (preg_match('/\bmidnight\b/', $normalized)) {
@@ -130,10 +137,19 @@ class AIPS_Natural_Schedule_Parser {
             return array('hour' => 12, 'minute' => 0);
         }
 
-        if (preg_match('/\bat\s+([0-1]?\d|2[0-3])(?::([0-5]\d))?\s*(am|pm)\b/', $normalized, $m)) {
+        // AM/PM branch: capture any 1-2 digit hour so we can validate the range explicitly.
+        if (preg_match('/\bat\s+(\d{1,2})(?::([0-5]\d))?\s*(am|pm)\b/', $normalized, $m)) {
             $hour = (int) $m[1];
             $minute = isset($m[2]) && $m[2] !== '' ? (int) $m[2] : 0;
             $ampm = $m[3];
+
+            // AM/PM is only meaningful for hours 1-12.
+            if ($hour < 1 || $hour > 12) {
+                return new WP_Error(
+                    'invalid_schedule_time',
+                    __('The time in your schedule phrase could not be understood. Please use a time like "8am" or "14:30".', 'ai-post-scheduler')
+                );
+            }
 
             if ($ampm === 'am' && $hour === 12) {
                 $hour = 0;

--- a/ai-post-scheduler/includes/class-aips-schedule-controller.php
+++ b/ai-post-scheduler/includes/class-aips-schedule-controller.php
@@ -36,10 +36,23 @@ class AIPS_Schedule_Controller {
             'topic' => isset($_POST['topic']) ? sanitize_text_field($_POST['topic']) : '',
             'article_structure_id' => isset($_POST['article_structure_id']) && $_POST['article_structure_id'] !== '' ? absint($_POST['article_structure_id']) : null,
             'rotation_pattern' => isset($_POST['rotation_pattern']) && $_POST['rotation_pattern'] !== '' ? sanitize_text_field($_POST['rotation_pattern']) : null,
+            'natural_schedule' => isset($_POST['natural_schedule']) ? sanitize_text_field($_POST['natural_schedule']) : '',
         );
 
         if (empty($data['template_id'])) {
             wp_send_json_error(array('message' => __('Please select a template.', 'ai-post-scheduler')));
+        }
+
+        if (!empty($data['natural_schedule'])) {
+            $natural_parser = new AIPS_Natural_Schedule_Parser();
+            $parsed_schedule = $natural_parser->parse($data['natural_schedule']);
+
+            if (is_wp_error($parsed_schedule)) {
+                wp_send_json_error(array('message' => $parsed_schedule->get_error_message()));
+            }
+
+            $data['frequency'] = $parsed_schedule['frequency'];
+            $data['start_time'] = $parsed_schedule['start_time'];
         }
 
         $interval_calculator = new AIPS_Interval_Calculator();

--- a/ai-post-scheduler/templates/admin/schedule.php
+++ b/ai-post-scheduler/templates/admin/schedule.php
@@ -294,6 +294,12 @@ $preselect_template_id = isset($_GET['schedule_template']) ? absint($_GET['sched
                     </div>
                     
                     <div class="aips-form-row">
+                        <label for="schedule_natural_language"><?php esc_html_e('Natural Language (Optional)', 'ai-post-scheduler'); ?></label>
+                        <input type="text" id="schedule_natural_language" name="natural_schedule" class="regular-text" placeholder="<?php esc_attr_e('e.g., every weekday at 8 AM', 'ai-post-scheduler'); ?>">
+                        <p class="description"><?php esc_html_e('If provided, this overrides Frequency and Start Time.', 'ai-post-scheduler'); ?></p>
+                    </div>
+                    
+                    <div class="aips-form-row">
                         <label for="schedule_start_time"><?php esc_html_e('Start Time', 'ai-post-scheduler'); ?></label>
                         <input type="datetime-local" id="schedule_start_time" name="start_time">
                         <p class="description"><?php esc_html_e('Leave empty to start from now', 'ai-post-scheduler'); ?></p>

--- a/ai-post-scheduler/tests/bootstrap.php
+++ b/ai-post-scheduler/tests/bootstrap.php
@@ -926,6 +926,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
         'class-aips-topic-expansion-service.php',
         'class-aips-author-post-generator.php',
         'class-aips-author-topics-controller.php',
+        'class-aips-natural-schedule-parser.php',
     ];
     
     foreach ($files as $file) {

--- a/ai-post-scheduler/tests/test-interval-calculator.php
+++ b/ai-post-scheduler/tests/test-interval-calculator.php
@@ -290,4 +290,25 @@ class Test_AIPS_Interval_Calculator extends WP_UnitTestCase {
         $expected = date('Y-m-d 10:00:00', strtotime('+1 day', strtotime($start)));
         $this->assertEquals($expected, $next);
     }
+    /**
+     * Test weekdays interval exists.
+     */
+    public function test_weekdays_interval_exists() {
+        $intervals = $this->calculator->get_intervals();
+
+        $this->assertArrayHasKey('weekdays', $intervals);
+        $this->assertEquals(86400, $intervals['weekdays']['interval']);
+        $this->assertEquals('calendar', $intervals['weekdays']['type']);
+    }
+
+    /**
+     * Test calculate_next_run for weekdays skips weekend.
+     */
+    public function test_calculate_next_run_weekdays_skips_weekend() {
+        // Friday June 14, 2030 10:00:00 -> Monday June 17, 2030 10:00:00
+        $start = '2030-06-14 10:00:00';
+        $next = $this->calculator->calculate_next_run('weekdays', $start);
+
+        $this->assertEquals('2030-06-17 10:00:00', $next);
+    }
 }

--- a/ai-post-scheduler/tests/test-natural-schedule-parser.php
+++ b/ai-post-scheduler/tests/test-natural-schedule-parser.php
@@ -14,6 +14,10 @@ class Test_AIPS_Natural_Schedule_Parser extends WP_UnitTestCase {
             require_once dirname( __DIR__ ) . '/includes/class-aips-natural-schedule-parser.php';
         }
 
+        if ( ! class_exists( 'AIPS_Natural_Schedule_Parser' ) ) {
+            require_once dirname( __DIR__ ) . '/includes/class-aips-natural-schedule-parser.php';
+        }
+
         $this->parser = new AIPS_Natural_Schedule_Parser();
     }
 

--- a/ai-post-scheduler/tests/test-natural-schedule-parser.php
+++ b/ai-post-scheduler/tests/test-natural-schedule-parser.php
@@ -9,6 +9,11 @@ class Test_AIPS_Natural_Schedule_Parser extends WP_UnitTestCase {
 
     public function setUp(): void {
         parent::setUp();
+
+        if ( ! class_exists( 'AIPS_Natural_Schedule_Parser' ) ) {
+            require_once dirname( __DIR__ ) . '/includes/class-aips-natural-schedule-parser.php';
+        }
+
         $this->parser = new AIPS_Natural_Schedule_Parser();
     }
 
@@ -47,5 +52,51 @@ class Test_AIPS_Natural_Schedule_Parser extends WP_UnitTestCase {
 
         $this->assertInstanceOf('WP_Error', $parsed);
         $this->assertEquals('unsupported_schedule_text', $parsed->get_error_code());
+    }
+
+    public function test_parse_out_of_range_ampm_hour_returns_error() {
+        $parsed = $this->parser->parse('daily at 13 pm');
+
+        $this->assertInstanceOf('WP_Error', $parsed);
+        $this->assertEquals('invalid_schedule_time', $parsed->get_error_code());
+    }
+
+    public function test_parse_zero_hour_ampm_returns_error() {
+        $parsed = $this->parser->parse('weekly at 0 am');
+
+        $this->assertInstanceOf('WP_Error', $parsed);
+        $this->assertEquals('invalid_schedule_time', $parsed->get_error_code());
+    }
+
+    public function test_parse_malformed_minute_returns_error() {
+        $parsed = $this->parser->parse('daily at 14:3');
+
+        $this->assertInstanceOf('WP_Error', $parsed);
+        $this->assertEquals('invalid_schedule_time', $parsed->get_error_code());
+    }
+
+    public function test_parse_out_of_range_24h_hour_returns_error() {
+        $parsed = $this->parser->parse('weekly at 25:00');
+
+        $this->assertInstanceOf('WP_Error', $parsed);
+        $this->assertEquals('invalid_schedule_time', $parsed->get_error_code());
+    }
+
+    public function test_parse_12_am_is_midnight() {
+        $reference = strtotime('2030-06-12 06:00:00');
+        $parsed = $this->parser->parse('daily at 12 AM', $reference);
+
+        $this->assertIsArray($parsed);
+        $this->assertEquals('daily', $parsed['frequency']);
+        $this->assertEquals('00:00:00', date('H:i:s', strtotime($parsed['start_time'])));
+    }
+
+    public function test_parse_12_pm_is_noon() {
+        $reference = strtotime('2030-06-12 06:00:00');
+        $parsed = $this->parser->parse('daily at 12 PM', $reference);
+
+        $this->assertIsArray($parsed);
+        $this->assertEquals('daily', $parsed['frequency']);
+        $this->assertEquals('12:00:00', date('H:i:s', strtotime($parsed['start_time'])));
     }
 }

--- a/ai-post-scheduler/tests/test-natural-schedule-parser.php
+++ b/ai-post-scheduler/tests/test-natural-schedule-parser.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Tests for natural-language schedule parsing.
+ */
+class Test_AIPS_Natural_Schedule_Parser extends WP_UnitTestCase {
+
+    /** @var AIPS_Natural_Schedule_Parser */
+    private $parser;
+
+    public function setUp(): void {
+        parent::setUp();
+        $this->parser = new AIPS_Natural_Schedule_Parser();
+    }
+
+    public function test_parse_every_weekday_at_eight_am() {
+        $reference = strtotime('2030-06-14 10:00:00'); // Friday
+        $parsed = $this->parser->parse('every weekday at 8 AM', $reference);
+
+        $this->assertIsArray($parsed);
+        $this->assertEquals('weekdays', $parsed['frequency']);
+        $this->assertEquals('08:00:00', date('H:i:s', strtotime($parsed['start_time'])));
+        $this->assertEquals(1, (int) date('N', strtotime($parsed['start_time']))); // Monday
+    }
+
+    public function test_parse_every_monday_at_930() {
+        $reference = strtotime('2030-06-12 10:00:00'); // Wednesday
+        $parsed = $this->parser->parse('every monday at 9:30 AM', $reference);
+
+        $this->assertIsArray($parsed);
+        $this->assertEquals('every_monday', $parsed['frequency']);
+        $this->assertEquals('09:30:00', date('H:i:s', strtotime($parsed['start_time'])));
+        $this->assertEquals(1, (int) date('N', strtotime($parsed['start_time'])));
+    }
+
+    public function test_parse_daily_at_8pm() {
+        $reference = strtotime('2030-06-12 10:00:00');
+        $parsed = $this->parser->parse('daily at 8 PM', $reference);
+
+        $this->assertIsArray($parsed);
+        $this->assertEquals('daily', $parsed['frequency']);
+        $this->assertEquals('20:00:00', date('H:i:s', strtotime($parsed['start_time'])));
+        $this->assertEquals('2030-06-12', date('Y-m-d', strtotime($parsed['start_time'])));
+    }
+
+    public function test_parse_unsupported_phrase_returns_error() {
+        $parsed = $this->parser->parse('sometime maybe next-ish');
+
+        $this->assertInstanceOf('WP_Error', $parsed);
+        $this->assertEquals('unsupported_schedule_text', $parsed->get_error_code());
+    }
+}


### PR DESCRIPTION
## Summary
- add a natural language field to the schedule UI and include it in form submissions
- parse natural-language phrases server-side and override frequency/start time when provided
- add weekday interval handling plus parser unit tests

## Testing
- Not run (not requested)