### PR TITLE
🧙‍♂️ Wizard: Add "Clear Filters" to Topic Planner & Sections Search

### DIFF
--- a/.jules/wizard.md
+++ b/.jules/wizard.md
@@ -35,3 +35,7 @@
 ## 2026-01-22 - Research Search Consistency
 **Learning:** The "Trending Topics Library" table lacked search functionality, which is a standard expectation established in other admin tables (Authors, Structures, etc.).
 **Action:** Implemented client-side search for Trending Topics with a "Clear" button and Empty State, ensuring "Select All" functionality respects the active filter.
+
+## 2025-02-17 - Clear Filters Spell
+Learning: Adding small UI elements like "Clear Filters" directly inside search fields significantly enhances workflow efficiency by preventing manual backspacing, thus avoiding user friction.
+Action: Continue to look for input fields that require manual, repeated text manipulation and enhance them with functional icons or buttons using existing CSS classes like `.aips-btn-secondary`.

--- a/ai-post-scheduler/templates/admin/planner.php
+++ b/ai-post-scheduler/templates/admin/planner.php
@@ -67,6 +67,7 @@ $default_planner_frequency = 'daily';
                 </div>
                 <div class="aips-toolbar-right aips-planner-toolbar-right">
                     <input type="search" id="planner-topic-search" class="aips-form-input" placeholder="<?php esc_attr_e('Filter topics...', 'ai-post-scheduler'); ?>" class="aips-planner-topic-search">
+                    <button type="button" id="planner-topic-search-clear" class="aips-btn aips-btn-secondary" style="display: none;"><?php esc_html_e('Clear', 'ai-post-scheduler'); ?></button>
                     <button type="button" id="btn-copy-topics" class="aips-btn aips-btn-sm aips-btn-secondary"><?php echo esc_html__('Copy Selected', 'ai-post-scheduler'); ?></button>
                     <button type="button" id="btn-clear-topics" class="aips-btn aips-btn-sm aips-btn-ghost"><?php echo esc_html__('Clear List', 'ai-post-scheduler'); ?></button>
                 </div>

--- a/ai-post-scheduler/templates/admin/sections.php
+++ b/ai-post-scheduler/templates/admin/sections.php
@@ -31,6 +31,7 @@ if (!isset($sections) || !is_array($sections)) {
 			<!-- Filter Bar -->
 			<div class="aips-filter-bar">
 				<input type="search" id="aips-section-search" class="aips-form-input" placeholder="<?php esc_attr_e('Search sections...', 'ai-post-scheduler'); ?>">
+				<button type="button" id="aips-section-search-clear" class="aips-btn aips-btn-secondary" style="display: none;"><?php esc_html_e('Clear', 'ai-post-scheduler'); ?></button>
 			</div>
 
 			<!-- Table -->


### PR DESCRIPTION
## What
Added the `#planner-topic-search-clear` and `#aips-section-search-clear` buttons to their respective admin templates (`planner.php` and `sections.php`).

## Why
The backend JavaScript files (`admin.js` and `admin-planner.js`) already contained event listeners and logic designed to clear the search filter using these buttons, but the HTML elements themselves were missing from the UI templates. 

## Value
This small UI enhancement eliminates workflow friction by allowing users to click a single "Clear" button to wipe out an active search filter, rather than repeatedly hitting the backspace key or manually deleting the text. This aligns perfectly with existing patterns in `structures.php` and `authors.php`.

## Visuals
Users now see a "Clear" button (`.aips-btn-secondary`) instantly appear next to the search box whenever they begin typing a search query in the Topic Planner or Prompt Sections page. Clicking it resets the input and immediately restores all hidden rows in the UI list.

---
*PR created automatically by Jules for task [10811830533244498718](https://jules.google.com/task/10811830533244498718) started by @rpnunez*