### PR TITLE
🧙‍♂️ Wizard: Add Copy Error and Clear Filter Buttons

### DIFF
--- a/.jules/wizard.md
+++ b/.jules/wizard.md
@@ -35,3 +35,7 @@
 ## 2026-01-22 - Research Search Consistency
 **Learning:** The "Trending Topics Library" table lacked search functionality, which is a standard expectation established in other admin tables (Authors, Structures, etc.).
 **Action:** Implemented client-side search for Trending Topics with a "Clear" button and Empty State, ensuring "Select All" functionality respects the active filter.
+## 2024-05-18 - Added Copy Error button to API Details & Clear Filter to Planner
+
+Learning: Some search filters were missing clear buttons that were already bound in javascript (e.g. #planner-topic-search-clear in planner.php). Also, copying API error text wasn't implemented despite copying responses being implemented.
+Action: Add missing buttons if the javascript logic already exists for it to improve UX consistency. Always add copy functionality to raw logs output (both success and errors).

--- a/ai-post-scheduler/assets/js/admin.js
+++ b/ai-post-scheduler/assets/js/admin.js
@@ -2713,6 +2713,8 @@
                     callsHtml += '<h4>Response</h4>';
                     if (call.response.success) {
                         callsHtml += '<button class="button button-small aips-copy-btn" data-clipboard-text="' + AIPS.escapeAttribute(call.response.content || '') + '"><span class="dashicons dashicons-admin-page"></span> Copy</button>';
+                    } else if (call.response.error) {
+                        callsHtml += '<button class="button button-small aips-copy-btn" data-clipboard-text="' + AIPS.escapeAttribute(call.response.error) + '"><span class="dashicons dashicons-admin-page"></span> Copy Error</button>';
                     }
                     callsHtml += '</div>';
                     if (call.response.success) {

--- a/ai-post-scheduler/templates/admin/planner.php
+++ b/ai-post-scheduler/templates/admin/planner.php
@@ -67,6 +67,7 @@ $default_planner_frequency = 'daily';
                 </div>
                 <div class="aips-toolbar-right aips-planner-toolbar-right">
                     <input type="search" id="planner-topic-search" class="aips-form-input" placeholder="<?php esc_attr_e('Filter topics...', 'ai-post-scheduler'); ?>" class="aips-planner-topic-search">
+                    <button type="button" id="planner-topic-search-clear" class="aips-btn aips-btn-sm aips-btn-secondary" style="display: none;"><?php esc_html_e('Clear', 'ai-post-scheduler'); ?></button>
                     <button type="button" id="btn-copy-topics" class="aips-btn aips-btn-sm aips-btn-secondary"><?php echo esc_html__('Copy Selected', 'ai-post-scheduler'); ?></button>
                     <button type="button" id="btn-clear-topics" class="aips-btn aips-btn-sm aips-btn-ghost"><?php echo esc_html__('Clear List', 'ai-post-scheduler'); ?></button>
                 </div>


### PR DESCRIPTION
Wizard: Added Copy Error button to API Details & Clear Filter to Planner

What:
- Added a "Copy Error" button to the API calls history view when an API call fails.
- Added a "Clear" button to the search filter in `planner.php`.

Why:
- API errors are often long and difficult to read or copy manually. A dedicated copy button improves debugging and support.
- The `planner.php` search filter lacked a "Clear" button, despite the Javascript logic already existing for it. This brings it in line with other search filters in the application.

Value:
- Improved UX consistency and usability.

Visuals:
- "Copy Error" button appears next to the error message in the History UI.
- "Clear" button appears in the Planner search filter.

---
*PR created automatically by Jules for task [10950775895129284075](https://jules.google.com/task/10950775895129284075) started by @rpnunez*