### PR TITLE
🧙‍♂️ Wizard: Add "Clear Filters" to Topic Brainstorming search bar

### DIFF
--- a/.jules/wizard.md
+++ b/.jules/wizard.md
@@ -35,3 +35,7 @@
 ## 2026-01-22 - Research Search Consistency
 **Learning:** The "Trending Topics Library" table lacked search functionality, which is a standard expectation established in other admin tables (Authors, Structures, etc.).
 **Action:** Implemented client-side search for Trending Topics with a "Clear" button and Empty State, ensuring "Select All" functionality respects the active filter.
+
+## 2026-03-14 - Clear Planner Topic Search
+**Learning:** The Topic Brainstorming (Planner) page had a search bar to filter topics but no way to reset the filter easily. The "Clear List" button next to it could be mistakenly clicked, destroying user data.
+**Action:** Implemented the missing `#planner-topic-search-clear` button in the UI, matching other admin pages, allowing users to safely and easily clear their search filter.

--- a/ai-post-scheduler/assets/js/admin-planner.js
+++ b/ai-post-scheduler/assets/js/admin-planner.js
@@ -117,28 +117,6 @@
         },
 
         /**
-         * Show or hide `.topic-item` rows based on whether their text input
-         * value matches the current `#planner-topic-search` value.
-         *
-         * Only tests `.topic-item` elements that are currently visible.
-         * Calls `updateSelectionCount` after filtering to keep the count accurate.
-         *
-         * Bound to the first `keyup search` listener on `#planner-topic-search`.
-         */
-        filterTopics: function() {
-            var filter = $('#planner-topic-search').val().toLowerCase();
-            $('.topic-item').each(function() {
-                var text = $(this).find('.topic-text-input').val().toLowerCase();
-                if (text.indexOf(filter) > -1) {
-                    $(this).show();
-                } else {
-                    $(this).hide();
-                }
-            });
-            window.AIPS.updateSelectionCount();
-        },
-
-        /**
          * Sync all `.topic-checkbox` elements with the state of the
          * `#check-all-topics` "select all" checkbox.
          *
@@ -238,6 +216,8 @@
                 $(this).toggle(text.indexOf(term) > -1);
             });
             
+            window.AIPS.updateSelectionCount();
+
             // Show an empty state message when no topics match the filter
             var $topicsList = $('#topics-list');
             var visibleCount = $topicsList.find('.topic-item:visible').length;
@@ -419,7 +399,6 @@
         $(document).on('click', '#btn-bulk-schedule', window.AIPS.bulkSchedule);
         $(document).on('click', '#btn-clear-topics', window.AIPS.clearTopics);
         $(document).on('click', '#btn-copy-topics', window.AIPS.copySelectedTopics);
-        $(document).on('keyup search', '#planner-topic-search', window.AIPS.filterTopics);
         $(document).on('change', '#check-all-topics', window.AIPS.toggleAllTopics);
         $(document).on('change', '.topic-checkbox', window.AIPS.updateSelectionCount);
         $(document).on('keyup search', '#planner-topic-search', window.AIPS.filterTopics);

--- a/ai-post-scheduler/templates/admin/planner.php
+++ b/ai-post-scheduler/templates/admin/planner.php
@@ -67,6 +67,7 @@ $default_planner_frequency = 'daily';
                 </div>
                 <div class="aips-toolbar-right aips-planner-toolbar-right">
                     <input type="search" id="planner-topic-search" class="aips-form-input" placeholder="<?php esc_attr_e('Filter topics...', 'ai-post-scheduler'); ?>" class="aips-planner-topic-search">
+                    <button type="button" id="planner-topic-search-clear" class="aips-btn aips-btn-sm aips-btn-secondary" style="display: none;"><?php esc_html_e('Clear', 'ai-post-scheduler'); ?></button>
                     <button type="button" id="btn-copy-topics" class="aips-btn aips-btn-sm aips-btn-secondary"><?php echo esc_html__('Copy Selected', 'ai-post-scheduler'); ?></button>
                     <button type="button" id="btn-clear-topics" class="aips-btn aips-btn-sm aips-btn-ghost"><?php echo esc_html__('Clear List', 'ai-post-scheduler'); ?></button>
                 </div>


### PR DESCRIPTION
🧙‍♂️ Wizard: Add "Clear Filters" to Topic Brainstorming search bar

**What:**
Added a "Clear" button (`#planner-topic-search-clear`) next to the search input in the Topic Brainstorming (Planner) page, matching the pattern used in other admin pages (Templates, Structures, Authors, etc.). The button appears dynamically when text is entered and clears the search when clicked.

**Why:**
The Topic Brainstorming page had a search bar to filter topics but no easy way to reset the filter. The "Clear List" button next to it could be mistakenly clicked, which clears the *entire list* of generated topics, causing data loss and frustration.

**Value:**
Enhances usability, prevents destructive misclicks ("Clear List"), and aligns the UI with established patterns across the application.

**Visuals:**
Before: [Search Input] [Copy Selected] [Clear List]
After: [Search Input] [Clear] [Copy Selected] [Clear List] (Clear button only visible when search input has text)

---
*PR created automatically by Jules for task [10784843497115780388](https://jules.google.com/task/10784843497115780388) started by @rpnunez*