### PR TITLE
🐞 Hunter: Add type="button" to prevent unintended form submissions

### DIFF
--- a/.jules/hunter.md
+++ b/.jules/hunter.md
@@ -5,3 +5,7 @@
 ## 2024-05-25 - Time-Dependent Test Failures
 **Learning:** Unit tests for time-dependent logic (like scheduling calculators) that use hardcoded dates become "time bombs" when those dates pass. Catch-up logic for past dates can further obscure the interval calculation logic being tested.
 **Action:** Use relative future dates (e.g., `strtotime('+1 year')`) in tests to ensure they remain valid regardless of when they are run and to isolate the interval logic from catch-up mechanisms.
+
+## 2026-03-15 - Unintended Form Submissions in WordPress Admin
+**Learning:** WordPress admin pages are often wrapped in a `<form>` tag by default. Any `<button>` element inside these pages without an explicit `type` attribute defaults to `type="submit"`, causing unintended page reloads and form submissions when users interact with UI components meant to be handled by JavaScript (e.g., modals, AJAX actions).
+**Action:** Always specify `type="button"` for `<button>` elements in WordPress admin interfaces and forms to prevent unintended form submissions, unless the button is explicitly intended to submit a traditional form.

--- a/ai-post-scheduler/assets/js/admin-activity.js
+++ b/ai-post-scheduler/assets/js/admin-activity.js
@@ -89,7 +89,7 @@
 				
 				if (activity.post) {
 					if (activity.post.status === 'draft') {
-						$actions.append('<button class="button button-small aips-quick-publish">Publish</button>');
+						$actions.append('<button type="button" class="button button-small aips-quick-publish">Publish</button>');
 					}
 					if (activity.post.edit_url) {
 						$actions.append('<a href="' + activity.post.edit_url + '" class="button button-small" target="_blank">Edit</a>');

--- a/ai-post-scheduler/assets/js/admin-research.js
+++ b/ai-post-scheduler/assets/js/admin-research.js
@@ -205,7 +205,7 @@
                 html += '</div></td>';
                 html += '<td>' + new Date(topic.researched_at).toLocaleDateString() + '</td>';
                 html += '<td><div class="aips-topic-actions">';
-                html += '<button class="button button-small delete-topic" data-id="' + escapeHtml(topic.id) + '">' + aipsResearchL10n.delete + '</button>';
+                html += '<button type="button" class="button button-small delete-topic" data-id="' + escapeHtml(topic.id) + '">' + aipsResearchL10n.delete + '</button>';
                 html += '</div></td>';
                 html += '</tr>';
             });
@@ -492,7 +492,7 @@
                         <p class="aips-gap-reason">${escapeHtml(gap.reason)}</p>
                         <p class="aips-gap-intent">Intent: ${escapeHtml(gap.search_intent)}</p>
                         <div class="aips-gap-actions">
-                            <button class="button button-secondary generate-gap-ideas" data-topic="${escapeHtml(gap.missing_topic)}">
+                            <button type="button" class="button button-secondary generate-gap-ideas" data-topic="${escapeHtml(gap.missing_topic)}">
                                 Generate Ideas
                             </button>
                         </div>

--- a/ai-post-scheduler/assets/js/authors.js
+++ b/ai-post-scheduler/assets/js/authors.js
@@ -63,10 +63,10 @@
 			$(document).on('click', '.aips-select-all-topics', this.toggleSelectAll.bind(this));
 			$(document).on('click', '.aips-select-all-feedback', this.toggleSelectAllFeedback.bind(this));
 			$(document).on('click', '.aips-bulk-action-execute', this.executeBulkAction.bind(this));
-			
+
 			// View topic posts
 			$(document).on('click', '.aips-post-count-badge', this.viewTopicPosts.bind(this));
-			
+
 			// Topic detail expand/collapse
 			$(document).on('click', '.aips-topic-expand-btn', this.toggleTopicDetail.bind(this));
 		},
@@ -398,14 +398,14 @@
 
 				// Expand button is only shown when detail content exists.
 				if (hasDetailContent) {
-					html += '<button class="aips-topic-expand-btn" data-topic-id="' + topic.id + '" title="' + (aipsAuthorsL10n.viewDetails || 'View Details') + '" aria-expanded="false" aria-controls="aips-topic-details-' + topic.id + '">';
+					html += '<button type="button" class="aips-topic-expand-btn" data-topic-id="' + topic.id + '" title="' + (aipsAuthorsL10n.viewDetails || 'View Details') + '" aria-expanded="false" aria-controls="aips-topic-details-' + topic.id + '">';
 					html += '<span class="dashicons dashicons-arrow-right-alt2"></span>';
 					html += '</button>';
 				}
 
 				html += '<span class="topic-title">' + this.escapeHtml(topic.topic_title) + '</span>';
 				html += '<span class="aips-topic-similarity-slot" data-topic-id="' + topic.id + '"></span>';
-				
+
 				// Add post count badge if there are any posts
 				if (topic.post_count && topic.post_count > 0) {
 					html += ' <span class="aips-post-count-badge" data-topic-id="' + topic.id + '" title="' + aipsAuthorsL10n.viewPosts + '">';
@@ -436,7 +436,7 @@
 					html += ' <span class="aips-feedback-badge aips-feedback-badge-' + fbAction + '" title="' + fbTitle + '">';
 					html += '<span class="dashicons dashicons-admin-comments"></span> ' + this.escapeHtml(fbLabel) + '</span>';
 				}
-				
+
 				html += '<input type="text" class="topic-title-edit" style="display:none;" value="' + this.escapeHtml(topic.topic_title) + '">';
 				html += '</div>';
 
@@ -452,17 +452,17 @@
 				if (status === 'pending') {
 					// Pending actions: feedback actions and edit
 					html += '<div class="aips-btn-group">';
-					html += '<button class="aips-btn aips-btn-sm aips-btn-secondary aips-edit-topic" data-id="' + topic.id + '">' + this.escapeHtml(aipsAuthorsL10n.edit || 'Edit') + '</button>';
+					html += '<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-edit-topic" data-id="' + topic.id + '">' + this.escapeHtml(aipsAuthorsL10n.edit || 'Edit') + '</button>';
 					html += '</div>';
 					html += '<div class="aips-btn-group" style="margin-top: 6px;">';
-					html += '<button class="aips-btn aips-btn-sm aips-btn-secondary aips-approve-topic" data-id="' + topic.id + '">' + this.escapeHtml(aipsAuthorsL10n.approveWithFeedback || 'Approve with Feedback') + '</button>';
-					html += '<button class="aips-btn aips-btn-sm aips-btn-secondary aips-reject-topic" data-id="' + topic.id + '">' + this.escapeHtml(aipsAuthorsL10n.rejectWithFeedback || 'Reject with Feedback') + '</button>';
+					html += '<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-approve-topic" data-id="' + topic.id + '">' + this.escapeHtml(aipsAuthorsL10n.approveWithFeedback || 'Approve with Feedback') + '</button>';
+					html += '<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-reject-topic" data-id="' + topic.id + '">' + this.escapeHtml(aipsAuthorsL10n.rejectWithFeedback || 'Reject with Feedback') + '</button>';
 					html += '</div>';
 				} else if (status === 'approved') {
-					html += '<button class="aips-btn aips-btn-sm aips-btn-secondary aips-generate-post-now" data-id="' + topic.id + '">' + this.escapeHtml(aipsAuthorsL10n.generatePostNow || 'Generate Post Now') + '</button> ';
-					html += '<button class="aips-btn aips-btn-sm aips-btn-ghost aips-edit-topic" data-id="' + topic.id + '">' + this.escapeHtml(aipsAuthorsL10n.edit || 'Edit') + '</button>';
+					html += '<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-generate-post-now" data-id="' + topic.id + '">' + this.escapeHtml(aipsAuthorsL10n.generatePostNow || 'Generate Post Now') + '</button> ';
+					html += '<button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-edit-topic" data-id="' + topic.id + '">' + this.escapeHtml(aipsAuthorsL10n.edit || 'Edit') + '</button>';
 				} else {
-					html += '<button class="aips-btn aips-btn-sm aips-btn-ghost aips-edit-topic" data-id="' + topic.id + '">' + this.escapeHtml(aipsAuthorsL10n.edit || 'Edit') + '</button>';
+					html += '<button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-edit-topic" data-id="' + topic.id + '">' + this.escapeHtml(aipsAuthorsL10n.edit || 'Edit') + '</button>';
 				}
 
 				html += '</td></tr>';
@@ -592,12 +592,12 @@
 		 */
 		updateBulkActionDropdown: function (status) {
 			const $dropdowns = $('.aips-bulk-action-select');
-			
+
 			// Clear existing options except the default one
 			$dropdowns.each(function() {
 				const $dropdown = $(this);
 				$dropdown.find('option:not(:first)').remove();
-				
+
 				// Add options based on the active tab
 				if (status === 'pending') {
 					// Pending Review tab: Approve, Reject, Delete
@@ -751,7 +751,7 @@
 		loadFeedback: function () {
 			if (!this.currentAuthorId) {
 				$('#aips-topics-content').html('<p>No author selected.</p>');
-				
+
 				return;
 			}
 
@@ -887,8 +887,8 @@
 
 			$btn.hide();
 			$row.find('.topic-actions').append(
-				'<button class="button aips-save-topic">' + aipsAuthorsL10n.save + '</button> ' +
-				'<button class="button aips-cancel-edit-topic">' + aipsAuthorsL10n.cancel + '</button>'
+				'<button type="button" class="button aips-save-topic">' + aipsAuthorsL10n.save + '</button> ' +
+				'<button type="button" class="button aips-cancel-edit-topic">' + aipsAuthorsL10n.cancel + '</button>'
 			);
 		},
 
@@ -1091,7 +1091,7 @@
 			html += '</tbody></table>';
 			$('#aips-topic-logs-content').html(html);
 		},
-		
+
 		/**
 		 * Open the topic-posts modal and start loading posts for the given topic.
 		 *
@@ -1104,15 +1104,15 @@
 		viewTopicPosts: function (e) {
 			e.preventDefault();
 			e.stopPropagation();
-			
+
 			const topicId = $(e.currentTarget).data('topic-id');
-			
+
 			$('#aips-topic-posts-content').html('<p>' + aipsAuthorsL10n.loadingPosts + '</p>');
 			$('#aips-topic-posts-modal').fadeIn();
-			
+
 			this.loadTopicPosts(topicId);
 		},
-		
+
 		/**
 		 * Fetch posts generated from a topic via `aips_get_topic_posts`.
 		 *
@@ -1134,11 +1134,11 @@
 					if (response.success) {
 						const topic = response.data.topic;
 						const posts = response.data.posts;
-						
+
 						$('#aips-topic-posts-modal-title').text(
 							aipsAuthorsL10n.postsGeneratedFrom + ': ' + this.escapeHtml(topic.topic_title)
 						);
-						
+
 						this.renderTopicPosts(posts);
 					} else {
 						$('#aips-topic-posts-content').html(
@@ -1151,7 +1151,7 @@
 				}
 			});
 		},
-		
+
 		/**
 		 * Build and inject the topic-posts HTML table into `#aips-topic-posts-content`.
 		 *
@@ -1166,7 +1166,7 @@
 				$('#aips-topic-posts-content').html('<p>' + aipsAuthorsL10n.noPostsFound + '</p>');
 				return;
 			}
-			
+
 			let html = '<table class="wp-list-table widefat fixed striped"><thead><tr>';
 			html += '<th>' + aipsAuthorsL10n.postId + '</th>';
 			html += '<th>' + aipsAuthorsL10n.postTitle + '</th>';
@@ -1174,7 +1174,7 @@
 			html += '<th>' + aipsAuthorsL10n.datePublished + '</th>';
 			html += '<th>' + aipsAuthorsL10n.actions + '</th>';
 			html += '</tr></thead><tbody>';
-			
+
 			posts.forEach(post => {
 				html += '<tr>';
 				html += '<td>' + this.escapeHtml(post.post_id) + '</td>';
@@ -1191,7 +1191,7 @@
 				html += '</td>';
 				html += '</tr>';
 			});
-			
+
 			html += '</tbody></table>';
 			$('#aips-topic-posts-content').html(html);
 		},
@@ -1256,7 +1256,7 @@
 			}
 
 			if (ids.length === 0) {
-				const message = activeTab === 'feedback' 
+				const message = activeTab === 'feedback'
 					? (aipsAuthorsL10n.noFeedbackSelected || 'Please select at least one feedback item.')
 					: (aipsAuthorsL10n.noTopicsSelected || 'Please select at least one topic.');
 				AIPS.Utilities.showToast(message, 'warning');
@@ -1383,7 +1383,7 @@
 			const messages = {
 				approve: aipsAuthorsL10n.confirmBulkApprove || 'Are you sure you want to approve %d topics?',
 				reject: aipsAuthorsL10n.confirmBulkReject || 'Are you sure you want to reject %d topics?',
-				delete: activeTab === 'feedback' 
+				delete: activeTab === 'feedback'
 					? (aipsAuthorsL10n.confirmBulkDeleteFeedback || 'Are you sure you want to delete %d feedback items? This action cannot be undone.')
 					: (aipsAuthorsL10n.confirmBulkDelete || 'Are you sure you want to delete %d topics? This action cannot be undone.'),
 				generate_now: aipsAuthorsL10n.confirmBulkGenerate || 'Are you sure you want to generate posts for %d topics?'
@@ -1522,10 +1522,10 @@
 				if (text === null || text === undefined) {
 					return '';
 				}
-				
+
 				// Convert to string if not already
 				const str = String(text);
-				
+
 				const map = {
 					'&': '&amp;',
 					'<': '&lt;',
@@ -1553,25 +1553,25 @@
 				if (!url) {
 					return '';
 				}
-				
+
 				// Convert to string and trim whitespace
 				const urlStr = String(url).trim();
-				
+
 				if (!urlStr) {
 					return '';
 				}
-				
+
 				// Check for dangerous protocols (case-insensitive)
 				const dangerousProtocols = ['javascript:', 'data:', 'vbscript:', 'file:'];
 				const lowerUrl = urlStr.toLowerCase();
-				
+
 				for (const protocol of dangerousProtocols) {
 					if (lowerUrl.startsWith(protocol)) {
 						console.warn('Dangerous URL protocol detected:', protocol);
 						return '';
 					}
 				}
-				
+
 				// For absolute URLs, validate with URL constructor
 				if (urlStr.startsWith('http://') || urlStr.startsWith('https://')) {
 					try {
@@ -1583,12 +1583,12 @@
 						return '';
 					}
 				}
-				
+
 				// For relative URLs (WordPress admin paths), return as-is after validation
 				if (urlStr.startsWith('/')) {
 					return urlStr;
 				}
-				
+
 				// Reject anything else
 				console.warn('URL does not match allowed patterns:', urlStr);
 				return '';
@@ -1598,7 +1598,7 @@
 			}
 		}
 	};
-	
+
 	// Generation Queue Module
 	const GenerationQueueModule = {
 		/**
@@ -1616,7 +1616,7 @@
 		bindEvents: function () {
 			// Main page tab switching
 			$(document).on('click', '.aips-authors-tab-link', this.switchMainTab.bind(this));
-			
+
 			// Queue-specific actions
 			$(document).on('click', '.aips-queue-bulk-action-execute', this.executeQueueBulkAction.bind(this));
 			$(document).on('click', '.aips-queue-select-all', this.toggleQueueSelectAll.bind(this));
@@ -1837,7 +1837,7 @@
 			]);
 		}
 	};
-  
+
 	// Initialize when document is ready
 	$(document).ready(function () {
 		AuthorsModule.init();

--- a/ai-post-scheduler/assets/js/utilities.js
+++ b/ai-post-scheduler/assets/js/utilities.js
@@ -59,7 +59,7 @@
             var $toast = $('<div class="aips-toast ' + type + '">')
               .append('<span class="aips-toast-icon">' + iconMap[type] + '</span>')
               .append('<div class="aips-toast-message">' + safeMessage + '</div>')
-              .append($('<button class="aips-toast-close">&times;</button>').attr('aria-label', closeLabel));
+              .append($('<button type="button" class="aips-toast-close">&times;</button>').attr('aria-label', closeLabel));
 
             $container.append($toast);
 

--- a/ai-post-scheduler/includes/class-aips-admin-bar.php
+++ b/ai-post-scheduler/includes/class-aips-admin-bar.php
@@ -165,7 +165,7 @@ class AIPS_Admin_Bar {
 				'title'  => '<span class="aips-toolbar-notif-heading">'
 					. esc_html__('Notifications', 'ai-post-scheduler')
 					. '</span>'
-					. '<button class="aips-mark-all-read" data-nonce="' . esc_attr(wp_create_nonce('aips_admin_bar_nonce')) . '">'
+					. '<button type="button" class="aips-mark-all-read" data-nonce="' . esc_attr(wp_create_nonce('aips_admin_bar_nonce')) . '">'
 					. esc_html__('Mark all as read', 'ai-post-scheduler')
 					. '</button>',
 				'href'   => false,
@@ -182,7 +182,7 @@ class AIPS_Admin_Bar {
 				}
 
 				$node_title .= '</span>'
-					. '<button class="aips-mark-read" data-id="' . esc_attr($notif->id) . '" data-nonce="' . esc_attr(wp_create_nonce('aips_admin_bar_nonce')) . '" title="' . esc_attr__('Mark as read', 'ai-post-scheduler') . '">'
+					. '<button type="button" class="aips-mark-read" data-id="' . esc_attr($notif->id) . '" data-nonce="' . esc_attr(wp_create_nonce('aips_admin_bar_nonce')) . '" title="' . esc_attr__('Mark as read', 'ai-post-scheduler') . '">'
 					. '<span class="dashicons dashicons-yes-alt"></span>'
 					. '</button>';
 

--- a/ai-post-scheduler/templates/admin/activity.php
+++ b/ai-post-scheduler/templates/admin/activity.php
@@ -19,16 +19,16 @@ if (!defined('ABSPATH')) {
 			<!-- Filter Bar -->
 			<div class="aips-filter-bar">
 				<div class="aips-filter-group" style="display: flex; gap: 8px;">
-					<button class="aips-btn aips-btn-secondary aips-filter-btn active" data-filter="all">
+					<button type="button" class="aips-btn aips-btn-secondary aips-filter-btn active" data-filter="all">
 						<?php esc_html_e('All Activity', 'ai-post-scheduler'); ?>
 					</button>
-					<button class="aips-btn aips-btn-secondary aips-filter-btn" data-filter="published">
+					<button type="button" class="aips-btn aips-btn-secondary aips-filter-btn" data-filter="published">
 						<?php esc_html_e('Published', 'ai-post-scheduler'); ?>
 					</button>
-					<button class="aips-btn aips-btn-secondary aips-filter-btn" data-filter="drafts">
+					<button type="button" class="aips-btn aips-btn-secondary aips-filter-btn" data-filter="drafts">
 						<?php esc_html_e('Drafts', 'ai-post-scheduler'); ?>
 					</button>
-					<button class="aips-btn aips-btn-secondary aips-filter-btn" data-filter="failed">
+					<button type="button" class="aips-btn aips-btn-secondary aips-filter-btn" data-filter="failed">
 						<?php esc_html_e('Failed', 'ai-post-scheduler'); ?>
 					</button>
 				</div>
@@ -65,7 +65,7 @@ if (!defined('ABSPATH')) {
 	<div class="aips-modal-content aips-modal-large">
 		<div class="aips-modal-header">
 			<h2 id="aips-activity-modal-title"><?php esc_html_e('Post Details', 'ai-post-scheduler'); ?></h2>
-			<button class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
+			<button type="button" class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
 		</div>
 		<div class="aips-modal-body">
 			<div class="aips-activity-detail-loading">

--- a/ai-post-scheduler/templates/admin/author-topics.php
+++ b/ai-post-scheduler/templates/admin/author-topics.php
@@ -86,7 +86,7 @@ $posts_count        = $logs_repository->count_generated_posts_by_author($author_
 						<span class="dashicons dashicons-edit"></span>
 						<?php esc_html_e('Edit Author', 'ai-post-scheduler'); ?>
 					</a>
-					<button class="aips-btn aips-btn-primary aips-generate-topics-now" data-id="<?php echo esc_attr($author->id); ?>">
+					<button type="button" class="aips-btn aips-btn-primary aips-generate-topics-now" data-id="<?php echo esc_attr($author->id); ?>">
 						<span class="dashicons dashicons-update"></span>
 						<?php esc_html_e('Generate Topics', 'ai-post-scheduler'); ?>
 					</button>
@@ -126,19 +126,19 @@ $posts_count        = $logs_repository->count_generated_posts_by_author($author_
 		<div class="aips-content-panel" id="aips-author-topics-panel">
 			<!-- Tabs -->
 			<div class="aips-topics-tabs aips-page-tabs">
-				<button class="aips-tab-link active" data-tab="pending">
+				<button type="button" class="aips-tab-link active" data-tab="pending">
 					<?php esc_html_e('Pending Review', 'ai-post-scheduler'); ?>
 					<span class="aips-tab-count" id="pending-count"><?php echo esc_html($status_counts['pending']); ?></span>
 				</button>
-				<button class="aips-tab-link" data-tab="approved">
+				<button type="button" class="aips-tab-link" data-tab="approved">
 					<?php esc_html_e('Approved', 'ai-post-scheduler'); ?>
 					<span class="aips-tab-count" id="approved-count"><?php echo esc_html($status_counts['approved']); ?></span>
 				</button>
-				<button class="aips-tab-link" data-tab="rejected">
+				<button type="button" class="aips-tab-link" data-tab="rejected">
 					<?php esc_html_e('Rejected', 'ai-post-scheduler'); ?>
 					<span class="aips-tab-count" id="rejected-count"><?php echo esc_html($status_counts['rejected']); ?></span>
 				</button>
-				<button class="aips-tab-link" data-tab="feedback">
+				<button type="button" class="aips-tab-link" data-tab="feedback">
 					<?php esc_html_e('Feedback', 'ai-post-scheduler'); ?>
 				</button>
 			</div>
@@ -152,7 +152,7 @@ $posts_count        = $logs_repository->count_generated_posts_by_author($author_
 						<option value="reject"><?php esc_html_e('Reject', 'ai-post-scheduler'); ?></option>
 						<option value="delete"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></option>
 					</select>
-					<button class="aips-btn aips-btn-sm aips-btn-secondary aips-bulk-action-execute"><?php esc_html_e('Execute', 'ai-post-scheduler'); ?></button>
+					<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-bulk-action-execute"><?php esc_html_e('Execute', 'ai-post-scheduler'); ?></button>
 				</div>
 			</div>
 
@@ -171,7 +171,7 @@ $posts_count        = $logs_repository->count_generated_posts_by_author($author_
 							<option value="reject"><?php esc_html_e('Reject', 'ai-post-scheduler'); ?></option>
 							<option value="delete"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></option>
 						</select>
-						<button class="aips-btn aips-btn-sm aips-btn-secondary aips-bulk-action-execute"><?php esc_html_e('Execute', 'ai-post-scheduler'); ?></button>
+						<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-bulk-action-execute"><?php esc_html_e('Execute', 'ai-post-scheduler'); ?></button>
 					</div>
 				</div>
 			</div>
@@ -235,5 +235,3 @@ $posts_count        = $logs_repository->count_generated_posts_by_author($author_
 		</form>
 	</div>
 </div>
-
-

--- a/ai-post-scheduler/templates/admin/authors.php
+++ b/ai-post-scheduler/templates/admin/authors.php
@@ -39,7 +39,7 @@ if (isset($_GET['page']) && $_GET['page'] === 'aips-authors') {
                     <p class="aips-page-description"><?php esc_html_e('Manage AI author profiles, generate topics, and create authentic content from different perspectives.', 'ai-post-scheduler'); ?></p>
                 </div>
                 <div class="aips-page-actions">
-                    <button class="aips-btn aips-btn-primary aips-add-author-btn">
+                    <button type="button" class="aips-btn aips-btn-primary aips-add-author-btn">
                         <span class="dashicons dashicons-plus-alt"></span>
                         <?php esc_html_e('Add Author', 'ai-post-scheduler'); ?>
                     </button>
@@ -49,8 +49,8 @@ if (isset($_GET['page']) && $_GET['page'] === 'aips-authors') {
 
         <!-- Add tabs for Authors List and Generation Queue -->
         <div class="aips-authors-tabs" style="margin-bottom: 20px;">
-            <button class="aips-authors-tab-link active" data-tab="authors-list"><?php esc_html_e('Authors List', 'ai-post-scheduler'); ?></button>
-            <button class="aips-authors-tab-link" data-tab="generation-queue"><?php esc_html_e('Generation Queue', 'ai-post-scheduler'); ?></button>
+            <button type="button" class="aips-authors-tab-link active" data-tab="authors-list"><?php esc_html_e('Authors List', 'ai-post-scheduler'); ?></button>
+            <button type="button" class="aips-authors-tab-link" data-tab="generation-queue"><?php esc_html_e('Generation Queue', 'ai-post-scheduler'); ?></button>
         </div>
 
         <!-- Authors List Tab Content -->
@@ -222,13 +222,13 @@ if (isset($_GET['page']) && $_GET['page'] === 'aips-authors') {
                                                 <span class="dashicons dashicons-admin-post"></span>
                                                 <?php esc_html_e("View Author's Posts", 'ai-post-scheduler'); ?>
                                             </a>
-                                            <button class="aips-btn aips-btn-sm aips-btn-ghost aips-edit-author" data-id="<?php echo esc_attr($author->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Edit author', 'ai-post-scheduler'); ?>">
+                                            <button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-edit-author" data-id="<?php echo esc_attr($author->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Edit author', 'ai-post-scheduler'); ?>">
                                                 <span class="dashicons dashicons-edit"></span>
                                             </button>
-                                            <button class="aips-btn aips-btn-sm aips-btn-ghost aips-generate-topics-now" data-id="<?php echo esc_attr($author->id); ?>" title="<?php esc_attr_e('Generate Topics', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Generate topics', 'ai-post-scheduler'); ?>">
+                                            <button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-generate-topics-now" data-id="<?php echo esc_attr($author->id); ?>" title="<?php esc_attr_e('Generate Topics', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Generate topics', 'ai-post-scheduler'); ?>">
                                                 <span class="dashicons dashicons-update"></span>
                                             </button>
-                                            <button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-author" data-id="<?php echo esc_attr($author->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Delete author', 'ai-post-scheduler'); ?>">
+                                            <button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-author" data-id="<?php echo esc_attr($author->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Delete author', 'ai-post-scheduler'); ?>">
                                                 <span class="dashicons dashicons-trash"></span>
                                             </button>
                                         </div>
@@ -237,7 +237,7 @@ if (isset($_GET['page']) && $_GET['page'] === 'aips-authors') {
                             <?php endforeach; ?>
                         </tbody>
                     </table>
-                    
+
                     <!-- No Search Results State -->
                     <div id="aips-author-search-no-results" class="aips-empty-state" style="display: none; padding: 60px 20px;">
                         <div class="dashicons dashicons-search aips-empty-state-icon" aria-hidden="true"></div>
@@ -260,7 +260,7 @@ if (isset($_GET['page']) && $_GET['page'] === 'aips-authors') {
                         <h3 class="aips-empty-state-title"><?php esc_html_e('No Authors Yet', 'ai-post-scheduler'); ?></h3>
                         <p class="aips-empty-state-description"><?php esc_html_e('Create your first author to start generating topically diverse blog posts.', 'ai-post-scheduler'); ?></p>
                         <div class="aips-empty-state-actions">
-                            <button class="aips-btn aips-btn-primary aips-add-author-btn">
+                            <button type="button" class="aips-btn aips-btn-primary aips-add-author-btn">
                                 <span class="dashicons dashicons-plus-alt"></span>
                                 <?php esc_html_e('Add Author', 'ai-post-scheduler'); ?>
                             </button>
@@ -278,14 +278,14 @@ if (isset($_GET['page']) && $_GET['page'] === 'aips-authors') {
                     <p class="description" style="margin-bottom: 20px;">
                         <?php esc_html_e('This queue shows all approved topics across all authors, ready for post generation. Topics are prioritized by score (highest first), then by approval date.', 'ai-post-scheduler'); ?>
                     </p>
-                    
+
                     <!-- Bulk Actions -->
                     <div class="aips-bulk-actions" style="margin-bottom: 15px;">
                         <select id="aips-queue-bulk-action-select" class="aips-form-select aips-queue-bulk-action-select">
                             <option value=""><?php esc_html_e('Bulk Actions', 'ai-post-scheduler'); ?></option>
                     <option value="generate_now"><?php esc_html_e('Generate Now', 'ai-post-scheduler'); ?></option>
                 </select>
-                <button class="button aips-queue-bulk-action-execute"><?php esc_html_e('Execute', 'ai-post-scheduler'); ?></button>
+                <button type="button" class="button aips-queue-bulk-action-execute"><?php esc_html_e('Execute', 'ai-post-scheduler'); ?></button>
             </div>
 
             <!-- Queue Topics List -->
@@ -408,10 +408,3 @@ if (isset($_GET['page']) && $_GET['page'] === 'aips-authors') {
         </form>
     </div>
 </div>
-
-
-
-
-
-
-

--- a/ai-post-scheduler/templates/admin/calendar.php
+++ b/ai-post-scheduler/templates/admin/calendar.php
@@ -33,31 +33,31 @@ if (!defined('ABSPATH')) {
 				<!-- Calendar Header with Navigation -->
 				<div class="aips-calendar-header">
 					<div class="aips-calendar-nav">
-						<button class="aips-btn aips-btn-sm aips-btn-secondary aips-calendar-prev" title="<?php esc_attr_e('Previous Month', 'ai-post-scheduler'); ?>">
+						<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-calendar-prev" title="<?php esc_attr_e('Previous Month', 'ai-post-scheduler'); ?>">
 							<span class="dashicons dashicons-arrow-left-alt2"></span>
 						</button>
 						<h2 class="aips-calendar-title">
 							<span class="aips-calendar-month-year"></span>
 						</h2>
-						<button class="aips-btn aips-btn-sm aips-btn-secondary aips-calendar-next" title="<?php esc_attr_e('Next Month', 'ai-post-scheduler'); ?>">
+						<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-calendar-next" title="<?php esc_attr_e('Next Month', 'ai-post-scheduler'); ?>">
 							<span class="dashicons dashicons-arrow-right-alt2"></span>
 						</button>
 					</div>
 					
 					<div class="aips-calendar-view-switcher">
-						<button class="aips-btn aips-btn-sm aips-calendar-view-btn active" data-view="month">
+						<button type="button" class="aips-btn aips-btn-sm aips-calendar-view-btn active" data-view="month">
 							<?php esc_html_e('Month', 'ai-post-scheduler'); ?>
 						</button>
-						<button class="aips-btn aips-btn-sm aips-calendar-view-btn" data-view="week">
+						<button type="button" class="aips-btn aips-btn-sm aips-calendar-view-btn" data-view="week">
 							<?php esc_html_e('Week', 'ai-post-scheduler'); ?>
 						</button>
-						<button class="aips-btn aips-btn-sm aips-calendar-view-btn" data-view="day">
+						<button type="button" class="aips-btn aips-btn-sm aips-calendar-view-btn" data-view="day">
 							<?php esc_html_e('Day', 'ai-post-scheduler'); ?>
 						</button>
 					</div>
 					
 					<div class="aips-calendar-today">
-						<button class="aips-btn aips-btn-secondary aips-calendar-today-btn">
+						<button type="button" class="aips-btn aips-btn-secondary aips-calendar-today-btn">
 							<?php esc_html_e('Today', 'ai-post-scheduler'); ?>
 						</button>
 					</div>

--- a/ai-post-scheduler/templates/admin/generated-posts.php
+++ b/ai-post-scheduler/templates/admin/generated-posts.php
@@ -139,14 +139,14 @@ if (!defined('ABSPATH')) {
 											<span class="dashicons dashicons-edit"></span>
 											<?php esc_html_e('Edit', 'ai-post-scheduler'); ?>
 										</a>
-										<button class="aips-btn aips-btn-sm aips-btn-secondary aips-ai-edit-btn" 
+										<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-ai-edit-btn"
 										        data-post-id="<?php echo esc_attr($post_data['post_id']); ?>"
 										        data-history-id="<?php echo esc_attr($post_data['history_id']); ?>"
 										        title="<?php esc_attr_e('AI Edit', 'ai-post-scheduler'); ?>">
 											<span class="dashicons dashicons-admin-customizer"></span>
 											<?php esc_html_e('AI Edit', 'ai-post-scheduler'); ?>
 										</button>
-										<button class="aips-btn aips-btn-sm aips-btn-ghost aips-view-session" 
+										<button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-view-session"
 										        data-history-id="<?php echo esc_attr($post_data['history_id']); ?>"
 										        title="<?php esc_attr_e('View Session', 'ai-post-scheduler'); ?>">
 											<span class="dashicons dashicons-visibility"></span>
@@ -306,14 +306,14 @@ if (!defined('ABSPATH')) {
 											<span class="dashicons dashicons-edit"></span>
 											<?php esc_html_e('Edit', 'ai-post-scheduler'); ?>
 										</a>
-										<button class="aips-btn aips-btn-sm aips-btn-secondary aips-ai-edit-btn"
+										<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-ai-edit-btn"
 											data-post-id="<?php echo esc_attr($post_data['post_id']); ?>"
 											data-history-id="<?php echo esc_attr($post_data['history_id']); ?>"
 											title="<?php esc_attr_e('AI Edit', 'ai-post-scheduler'); ?>">
 											<span class="dashicons dashicons-admin-customizer"></span>
 											<?php esc_html_e('AI Edit', 'ai-post-scheduler'); ?>
 										</button>
-										<button class="aips-btn aips-btn-sm aips-btn-ghost aips-view-session"
+										<button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-view-session"
 											data-history-id="<?php echo esc_attr($post_data['history_id']); ?>"
 											title="<?php esc_attr_e('View Session', 'ai-post-scheduler'); ?>">
 											<span class="dashicons dashicons-visibility"></span>

--- a/ai-post-scheduler/templates/admin/history.php
+++ b/ai-post-scheduler/templates/admin/history.php
@@ -31,7 +31,7 @@ $total_items = isset($history['total']) ? (int) $history['total'] : 0;
                     <p class="aips-page-description"><?php esc_html_e('View generation history containers and inspect every logged step, AI call, and error for each run.', 'ai-post-scheduler'); ?></p>
                 </div>
                 <div class="aips-page-actions">
-                    <button class="aips-btn aips-btn-secondary" id="aips-export-history-btn">
+                    <button type="button" class="aips-btn aips-btn-secondary" id="aips-export-history-btn">
                         <span class="dashicons dashicons-download"></span>
                         <?php esc_html_e('Export CSV', 'ai-post-scheduler'); ?>
                     </button>
@@ -109,7 +109,7 @@ $total_items = isset($history['total']) ? (int) $history['total'] : 0;
                         <option value="failed" <?php selected($status_filter, 'failed'); ?>><?php esc_html_e('Failed', 'ai-post-scheduler'); ?></option>
                         <option value="processing" <?php selected($status_filter, 'processing'); ?>><?php esc_html_e('Processing', 'ai-post-scheduler'); ?></option>
                     </select>
-                    <button class="aips-btn aips-btn-sm aips-btn-secondary" id="aips-filter-btn">
+                    <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary" id="aips-filter-btn">
                         <span class="dashicons dashicons-filter"></span>
                         <?php esc_html_e('Filter', 'ai-post-scheduler'); ?>
                     </button>
@@ -124,21 +124,21 @@ $total_items = isset($history['total']) ? (int) $history['total'] : 0;
             <!-- Toolbar (bulk actions) -->
             <div class="aips-panel-toolbar">
                 <div class="aips-toolbar-left">
-                    <button class="aips-btn aips-btn-sm aips-btn-danger aips-btn-danger-solid" id="aips-delete-selected-btn" disabled>
+                    <button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-btn-danger-solid" id="aips-delete-selected-btn" disabled>
                         <span class="dashicons dashicons-trash"></span>
                         <?php esc_html_e('Delete Selected', 'ai-post-scheduler'); ?>
                     </button>
-                    <button class="aips-btn aips-btn-sm aips-btn-secondary" id="aips-reload-history-btn">
+                    <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary" id="aips-reload-history-btn">
                         <span class="dashicons dashicons-update"></span>
                         <?php esc_html_e('Reload', 'ai-post-scheduler'); ?>
                     </button>
                 </div>
                 <div class="aips-toolbar-right">
-                    <button class="aips-btn aips-btn-sm aips-btn-danger aips-btn-danger-solid aips-clear-history" data-status="failed">
+                    <button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-btn-danger-solid aips-clear-history" data-status="failed">
                         <span class="dashicons dashicons-dismiss"></span>
                         <?php esc_html_e('Clear Failed', 'ai-post-scheduler'); ?>
                     </button>
-                    <button class="aips-btn aips-btn-sm aips-btn-danger aips-btn-danger-solid aips-clear-history" data-status="">
+                    <button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-btn-danger-solid aips-clear-history" data-status="">
                         <span class="dashicons dashicons-trash"></span>
                         <?php esc_html_e('Clear All', 'ai-post-scheduler'); ?>
                     </button>

--- a/ai-post-scheduler/templates/admin/schedule.php
+++ b/ai-post-scheduler/templates/admin/schedule.php
@@ -27,7 +27,7 @@ $rotation_patterns = $template_type_selector->get_rotation_patterns();
                     <p class="aips-page-description"><?php esc_html_e('Automate post generation by setting up recurring schedules for your templates.', 'ai-post-scheduler'); ?></p>
                 </div>
                 <div class="aips-page-actions">
-                    <button class="aips-btn aips-btn-primary aips-add-schedule-btn" <?php echo empty($templates) ? 'disabled' : ''; ?>>
+                    <button type="button" class="aips-btn aips-btn-primary aips-add-schedule-btn" <?php echo empty($templates) ? 'disabled' : ''; ?>>
                         <span class="dashicons dashicons-plus-alt"></span>
                         <?php esc_html_e('Add Schedule', 'ai-post-scheduler'); ?>
                     </button>
@@ -195,19 +195,19 @@ $rotation_patterns = $template_type_selector->get_rotation_patterns();
                             </td>
                             <td>
                                 <div class="cell-actions">
-                                    <button class="aips-btn aips-btn-sm aips-btn-ghost aips-edit-schedule" aria-label="<?php esc_attr_e('Edit schedule', 'ai-post-scheduler'); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
+                                    <button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-edit-schedule" aria-label="<?php esc_attr_e('Edit schedule', 'ai-post-scheduler'); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
                                         <span class="dashicons dashicons-edit"></span>
                                     </button>
-                                    <button class="aips-btn aips-btn-sm aips-btn-ghost aips-run-now-schedule" data-id="<?php echo esc_attr($schedule->id); ?>" aria-label="<?php esc_attr_e('Run now', 'ai-post-scheduler'); ?>" title="<?php esc_attr_e('Run Now', 'ai-post-scheduler'); ?>">
+                                    <button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-run-now-schedule" data-id="<?php echo esc_attr($schedule->id); ?>" aria-label="<?php esc_attr_e('Run now', 'ai-post-scheduler'); ?>" title="<?php esc_attr_e('Run Now', 'ai-post-scheduler'); ?>">
                                         <span class="dashicons dashicons-controls-play"></span>
                                     </button>
-                                    <button class="aips-btn aips-btn-sm aips-btn-ghost aips-view-schedule-history" data-id="<?php echo esc_attr($schedule->id); ?>" data-name="<?php echo esc_attr($schedule->template_name ?: $schedule->id); ?>" aria-label="<?php esc_attr_e('View history', 'ai-post-scheduler'); ?>" title="<?php esc_attr_e('View History', 'ai-post-scheduler'); ?>">
+                                    <button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-view-schedule-history" data-id="<?php echo esc_attr($schedule->id); ?>" data-name="<?php echo esc_attr($schedule->template_name ?: $schedule->id); ?>" aria-label="<?php esc_attr_e('View history', 'ai-post-scheduler'); ?>" title="<?php esc_attr_e('View History', 'ai-post-scheduler'); ?>">
                                         <span class="dashicons dashicons-backup"></span>
                                     </button>
-                                    <button class="aips-btn aips-btn-sm aips-btn-ghost aips-clone-schedule" aria-label="<?php esc_attr_e('Clone schedule', 'ai-post-scheduler'); ?>" title="<?php esc_attr_e('Clone', 'ai-post-scheduler'); ?>">
+                                    <button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-clone-schedule" aria-label="<?php esc_attr_e('Clone schedule', 'ai-post-scheduler'); ?>" title="<?php esc_attr_e('Clone', 'ai-post-scheduler'); ?>">
                                         <span class="dashicons dashicons-admin-page"></span>
                                     </button>
-                                    <button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-schedule" data-id="<?php echo esc_attr($schedule->id); ?>" aria-label="<?php esc_attr_e('Delete schedule', 'ai-post-scheduler'); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
+                                    <button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-schedule" data-id="<?php echo esc_attr($schedule->id); ?>" aria-label="<?php esc_attr_e('Delete schedule', 'ai-post-scheduler'); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
                                         <span class="dashicons dashicons-trash"></span>
                                     </button>
                                 </div>
@@ -241,7 +241,7 @@ $rotation_patterns = $template_type_selector->get_rotation_patterns();
                     <p class="aips-empty-state-description"><?php esc_html_e('Create a schedule to automatically generate posts on a regular basis using your templates.', 'ai-post-scheduler'); ?></p>
                     <?php if (!empty($templates)): ?>
                     <div class="aips-empty-state-actions">
-                        <button class="aips-btn aips-btn-primary aips-add-schedule-btn">
+                        <button type="button" class="aips-btn aips-btn-primary aips-add-schedule-btn">
                             <span class="dashicons dashicons-plus-alt"></span>
                             <?php esc_html_e('Create Schedule', 'ai-post-scheduler'); ?>
                         </button>
@@ -263,7 +263,7 @@ $preselect_structure_id = isset($_GET['schedule_structure']) ? absint($_GET['sch
         <div class="aips-modal-content">
             <div class="aips-modal-header">
                 <h2 id="aips-schedule-modal-title"><?php esc_html_e('Add New Schedule', 'ai-post-scheduler'); ?></h2>
-                <button class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
+                <button type="button" class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
             </div>
             <div class="aips-modal-body">
                 <form id="aips-schedule-form">
@@ -355,7 +355,7 @@ $preselect_structure_id = isset($_GET['schedule_structure']) ? absint($_GET['sch
     <div class="aips-modal-content aips-modal-large">
         <div class="aips-modal-header">
             <h2 id="aips-schedule-history-modal-title"><?php esc_html_e('Schedule History', 'ai-post-scheduler'); ?></h2>
-            <button class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
+            <button type="button" class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
         </div>
         <div class="aips-modal-body">
             <div id="aips-schedule-history-loading" style="text-align: center; padding: 20px;">

--- a/ai-post-scheduler/templates/admin/sections.php
+++ b/ai-post-scheduler/templates/admin/sections.php
@@ -17,7 +17,7 @@ if (!isset($sections) || !is_array($sections)) {
 					<p class="aips-page-description"><?php esc_html_e('Create and manage reusable prompt sections that can be inserted into your templates using placeholders.', 'ai-post-scheduler'); ?></p>
 				</div>
 				<div class="aips-page-actions">
-					<button class="aips-btn aips-btn-primary aips-add-section-btn">
+					<button type="button" class="aips-btn aips-btn-primary aips-add-section-btn">
 						<span class="dashicons dashicons-plus-alt"></span>
 						<?php esc_html_e('Add Section', 'ai-post-scheduler'); ?>
 					</button>
@@ -72,10 +72,10 @@ if (!isset($sections) || !is_array($sections)) {
 								<?php endif; ?>
 							</td>
 							<td class="column-actions">
-								<button class="aips-btn aips-btn-sm aips-btn-ghost aips-edit-section" data-id="<?php echo esc_attr($section->id); ?>" aria-label="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
+								<button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-edit-section" data-id="<?php echo esc_attr($section->id); ?>" aria-label="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
 									<span class="dashicons dashicons-edit"></span>
 								</button>
-								<button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-section" data-id="<?php echo esc_attr($section->id); ?>" aria-label="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
+								<button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-section" data-id="<?php echo esc_attr($section->id); ?>" aria-label="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
 									<span class="dashicons dashicons-trash"></span>
 								</button>
 							</td>
@@ -100,7 +100,7 @@ if (!isset($sections) || !is_array($sections)) {
 				<span class="dashicons dashicons-editor-table" style="font-size: 64px; width: 64px; height: 64px;"></span>
 				<h3><?php esc_html_e('No Prompt Sections', 'ai-post-scheduler'); ?></h3>
 				<p><?php esc_html_e('Create reusable prompt sections that can be inserted into your article structures using placeholders like {{section:key}}.', 'ai-post-scheduler'); ?></p>
-				<button class="aips-btn aips-btn-primary aips-add-section-btn">
+				<button type="button" class="aips-btn aips-btn-primary aips-add-section-btn">
 					<span class="dashicons dashicons-plus-alt"></span>
 					<?php esc_html_e('Create First Section', 'ai-post-scheduler'); ?>
 				</button>
@@ -113,7 +113,7 @@ if (!isset($sections) || !is_array($sections)) {
 		<div class="aips-modal-content">
 			<div class="aips-modal-header">
 				<h2 id="aips-section-modal-title"><?php esc_html_e('Add New Prompt Section', 'ai-post-scheduler'); ?></h2>
-				<button class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
+				<button type="button" class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
 			</div>
 			<div class="aips-modal-body">
 				<form id="aips-section-form">

--- a/ai-post-scheduler/templates/admin/structures.php
+++ b/ai-post-scheduler/templates/admin/structures.php
@@ -103,7 +103,7 @@ if (!isset($sections) || !is_array($sections)) {
 						</td>
 						<td class="column-actions">
 							<div class="aips-action-buttons">
-								<button class="aips-btn aips-btn-sm aips-edit-structure" data-id="<?php echo esc_attr($structure->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
+								<button type="button" class="aips-btn aips-btn-sm aips-edit-structure" data-id="<?php echo esc_attr($structure->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
 									<span class="dashicons dashicons-edit"></span>
 									<span class="screen-reader-text"><?php esc_html_e('Edit', 'ai-post-scheduler'); ?></span>
 								</button>
@@ -111,7 +111,7 @@ if (!isset($sections) || !is_array($sections)) {
 									<span class="dashicons dashicons-calendar-alt"></span>
 									<span class="screen-reader-text"><?php esc_html_e('Schedule', 'ai-post-scheduler'); ?></span>
 								</a>
-								<button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-structure" data-id="<?php echo esc_attr($structure->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
+								<button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-structure" data-id="<?php echo esc_attr($structure->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
 									<span class="dashicons dashicons-trash"></span>
 									<span class="screen-reader-text"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></span>
 								</button>
@@ -136,7 +136,7 @@ if (!isset($sections) || !is_array($sections)) {
 				<span class="dashicons dashicons-layout" aria-hidden="true"></span>
 				<h3><?php esc_html_e('No Article Structures', 'ai-post-scheduler'); ?></h3>
 				<p><?php esc_html_e('Create article structures to customize how templates assemble content.', 'ai-post-scheduler'); ?></p>
-				<button class="aips-btn aips-btn-primary aips-add-structure-btn"><?php esc_html_e('Create Structure', 'ai-post-scheduler'); ?></button>
+				<button type="button" class="aips-btn aips-btn-primary aips-add-structure-btn"><?php esc_html_e('Create Structure', 'ai-post-scheduler'); ?></button>
 			</div>
 			<?php endif; ?>
 		</div>
@@ -192,11 +192,11 @@ if (!isset($sections) || !is_array($sections)) {
 						</td>
 						<td>
 							<div class="aips-action-buttons">
-								<button class="aips-btn aips-btn-sm aips-edit-section" data-id="<?php echo esc_attr($section->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
+								<button type="button" class="aips-btn aips-btn-sm aips-edit-section" data-id="<?php echo esc_attr($section->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
 									<span class="dashicons dashicons-edit"></span>
 									<span class="screen-reader-text"><?php esc_html_e('Edit', 'ai-post-scheduler'); ?></span>
 								</button>
-								<button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-section" data-id="<?php echo esc_attr($section->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
+								<button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-section" data-id="<?php echo esc_attr($section->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
 									<span class="dashicons dashicons-trash"></span>
 									<span class="screen-reader-text"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></span>
 								</button>
@@ -221,7 +221,7 @@ if (!isset($sections) || !is_array($sections)) {
 				<span class="dashicons dashicons-editor-table" aria-hidden="true"></span>
 				<h3><?php esc_html_e('No Prompt Sections', 'ai-post-scheduler'); ?></h3>
 				<p><?php esc_html_e('Create prompt sections to reuse across article structures.', 'ai-post-scheduler'); ?></p>
-				<button class="aips-btn aips-btn-primary aips-add-section-btn"><?php esc_html_e('Create Section', 'ai-post-scheduler'); ?></button>
+				<button type="button" class="aips-btn aips-btn-primary aips-add-section-btn"><?php esc_html_e('Create Section', 'ai-post-scheduler'); ?></button>
 			</div>
 			<?php endif; ?>
 		</div>
@@ -232,7 +232,7 @@ if (!isset($sections) || !is_array($sections)) {
 		<div class="aips-modal-content">
 			<div class="aips-modal-header">
 				<h2 id="aips-structure-modal-title"><?php esc_html_e('Add New Article Structure', 'ai-post-scheduler'); ?></h2>
-				<button class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
+				<button type="button" class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
 			</div>
 			<div class="aips-modal-body">
 				<form id="aips-structure-form">
@@ -291,7 +291,7 @@ if (!isset($sections) || !is_array($sections)) {
 		<div class="aips-modal-content">
 			<div class="aips-modal-header">
 				<h2 id="aips-section-modal-title"><?php esc_html_e('Add New Prompt Section', 'ai-post-scheduler'); ?></h2>
-				<button class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
+				<button type="button" class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
 			</div>
 			<div class="aips-modal-body">
 				<form id="aips-section-form">
@@ -334,4 +334,3 @@ if (!isset($sections) || !is_array($sections)) {
 	</div>
 	</div><!-- .aips-page-container -->
 </div><!-- .wrap -->
-

--- a/ai-post-scheduler/templates/admin/templates.php
+++ b/ai-post-scheduler/templates/admin/templates.php
@@ -13,7 +13,7 @@ if (!defined('ABSPATH')) {
                     <p class="aips-page-description"><?php esc_html_e('Create and manage AI post generation templates with custom prompts and settings.', 'ai-post-scheduler'); ?></p>
                 </div>
                 <div class="aips-page-actions">
-                    <button class="aips-btn aips-btn-primary aips-add-template-btn">
+                    <button type="button" class="aips-btn aips-btn-primary aips-add-template-btn">
                         <span class="dashicons dashicons-plus-alt"></span>
                         <?php esc_html_e('Add Template', 'ai-post-scheduler'); ?>
                     </button>
@@ -128,11 +128,11 @@ if (!defined('ABSPATH')) {
                             </td>
                             <td>
                                 <div class="cell-actions">
-                                    <button class="aips-btn aips-btn-sm aips-btn-secondary aips-edit-template" data-id="<?php echo esc_attr($template->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
+                                    <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-edit-template" data-id="<?php echo esc_attr($template->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
                                         <span class="dashicons dashicons-edit"></span>
                                         <?php esc_html_e('Edit', 'ai-post-scheduler'); ?>
                                     </button>
-                                    <button class="aips-btn aips-btn-sm aips-btn-secondary aips-run-now" data-id="<?php echo esc_attr($template->id); ?>" title="<?php esc_attr_e('Run Now', 'ai-post-scheduler'); ?>">
+                                    <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-run-now" data-id="<?php echo esc_attr($template->id); ?>" title="<?php esc_attr_e('Run Now', 'ai-post-scheduler'); ?>">
                                         <span class="dashicons dashicons-controls-play"></span>
                                         <?php esc_html_e('Run Now', 'ai-post-scheduler'); ?>
                                     </button>
@@ -140,11 +140,11 @@ if (!defined('ABSPATH')) {
                                         <span class="dashicons dashicons-calendar-alt"></span>
                                         <span class="screen-reader-text"><?php esc_html_e('Schedule', 'ai-post-scheduler'); ?></span>
                                     </a>
-                                    <button class="aips-btn aips-btn-sm aips-btn-ghost aips-clone-template" data-id="<?php echo esc_attr($template->id); ?>" title="<?php esc_attr_e('Clone', 'ai-post-scheduler'); ?>">
+                                    <button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-clone-template" data-id="<?php echo esc_attr($template->id); ?>" title="<?php esc_attr_e('Clone', 'ai-post-scheduler'); ?>">
                                         <span class="dashicons dashicons-admin-page"></span>
                                         <span class="screen-reader-text"><?php esc_html_e('Clone', 'ai-post-scheduler'); ?></span>
                                     </button>
-                                    <button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-template" data-id="<?php echo esc_attr($template->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
+                                    <button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-template" data-id="<?php echo esc_attr($template->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
                                         <span class="dashicons dashicons-trash"></span>
                                         <span class="screen-reader-text"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></span>
                                     </button>
@@ -178,7 +178,7 @@ if (!defined('ABSPATH')) {
                     <h3 class="aips-empty-state-title"><?php esc_html_e('No Templates Yet', 'ai-post-scheduler'); ?></h3>
                     <p class="aips-empty-state-description"><?php esc_html_e('Templates define how your AI-generated posts are structured. Create your first template to start generating content automatically.', 'ai-post-scheduler'); ?></p>
                     <div class="aips-empty-state-actions">
-                        <button class="aips-btn aips-btn-primary aips-add-template-btn">
+                        <button type="button" class="aips-btn aips-btn-primary aips-add-template-btn">
                             <span class="dashicons dashicons-plus-alt"></span>
                             <?php esc_html_e('Create Template', 'ai-post-scheduler'); ?>
                         </button>
@@ -195,7 +195,7 @@ if (!defined('ABSPATH')) {
         <div class="aips-modal-content aips-modal-large">
             <div class="aips-modal-header">
                 <h2 id="aips-modal-title"><?php esc_html_e('Add New Template', 'ai-post-scheduler'); ?></h2>
-                <button class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
+                <button type="button" class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
             </div>
             
             <!-- Wizard Progress Indicator -->
@@ -609,7 +609,7 @@ if (!defined('ABSPATH')) {
         <div class="aips-modal-content aips-modal-large">
             <div class="aips-modal-header">
                 <h2><?php esc_html_e('Test Generation Result', 'ai-post-scheduler'); ?></h2>
-                <button class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
+                <button type="button" class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
             </div>
             <div class="aips-modal-body">
                 <div id="aips-test-result-container">
@@ -644,7 +644,7 @@ if (!defined('ABSPATH')) {
         <div class="aips-modal-content">
             <div class="aips-modal-header">
                 <h2><?php esc_html_e('Post Successfully Generated', 'ai-post-scheduler'); ?></h2>
-                <button class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
+                <button type="button" class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
             </div>
             <div class="aips-modal-body">
                 <div style="text-align: center; padding: 20px;">

--- a/ai-post-scheduler/templates/admin/voices.php
+++ b/ai-post-scheduler/templates/admin/voices.php
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
                     </p>
                 </div>
                 <div class="aips-page-actions">
-                    <button class="aips-btn aips-btn-primary aips-add-voice-btn">
+                    <button type="button" class="aips-btn aips-btn-primary aips-add-voice-btn">
                         <span class="dashicons dashicons-plus-alt2"></span>
                         <?php esc_html_e('Add Voice', 'ai-post-scheduler'); ?>
                     </button>
@@ -78,11 +78,11 @@ if (!defined('ABSPATH')) {
                                 </td>
                                 <td class="column-actions">
                                     <div class="aips-action-buttons">
-                                        <button class="aips-btn aips-btn-sm aips-edit-voice" data-id="<?php echo esc_attr($voice->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
+                                        <button type="button" class="aips-btn aips-btn-sm aips-edit-voice" data-id="<?php echo esc_attr($voice->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
                                             <span class="dashicons dashicons-edit"></span>
                                             <span class="screen-reader-text"><?php esc_html_e('Edit', 'ai-post-scheduler'); ?></span>
                                         </button>
-                                        <button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-voice" data-id="<?php echo esc_attr($voice->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
+                                        <button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-voice" data-id="<?php echo esc_attr($voice->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
                                             <span class="dashicons dashicons-trash"></span>
                                             <span class="screen-reader-text"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></span>
                                         </button>
@@ -114,7 +114,7 @@ if (!defined('ABSPATH')) {
                     </div>
                     <h3 class="aips-empty-title"><?php esc_html_e('No Voices Yet', 'ai-post-scheduler'); ?></h3>
                     <p class="aips-empty-description"><?php esc_html_e('Create a voice to establish consistent tone and style for your generated posts.', 'ai-post-scheduler'); ?></p>
-                    <button class="aips-btn aips-btn-primary aips-btn-lg aips-add-voice-btn">
+                    <button type="button" class="aips-btn aips-btn-primary aips-btn-lg aips-add-voice-btn">
                         <span class="dashicons dashicons-plus-alt2"></span>
                         <?php esc_html_e('Create Voice', 'ai-post-scheduler'); ?>
                     </button>
@@ -128,7 +128,7 @@ if (!defined('ABSPATH')) {
         <div class="aips-modal-content">
             <div class="aips-modal-header">
                 <h2 id="aips-voice-modal-title"><?php esc_html_e('Add New Voice', 'ai-post-scheduler'); ?></h2>
-                <button class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
+                <button type="button" class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
             </div>
             <div class="aips-modal-body">
                 <form id="aips-voice-form">

--- a/ai-post-scheduler/templates/partials/history-row.php
+++ b/ai-post-scheduler/templates/partials/history-row.php
@@ -70,7 +70,7 @@ if (!defined('ABSPATH')) {
     <td class="column-actions">
         <div class="aips-btn-group aips-btn-group-inline">
 
-        <button class="aips-btn aips-btn-sm aips-btn-primary aips-view-history-logs" data-id="<?php echo esc_attr($item->id); ?>" title="<?php esc_attr_e('View Logs', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('View Logs', 'ai-post-scheduler'); ?>">
+        <button type="button" class="aips-btn aips-btn-sm aips-btn-primary aips-view-history-logs" data-id="<?php echo esc_attr($item->id); ?>" title="<?php esc_attr_e('View Logs', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('View Logs', 'ai-post-scheduler'); ?>">
             <span class="dashicons dashicons-list-view"></span>
             <?php esc_html_e('View Logs', 'ai-post-scheduler'); ?>
         </button>
@@ -81,14 +81,14 @@ if (!defined('ABSPATH')) {
                 <?php esc_html_e('View', 'ai-post-scheduler'); ?>
             </a>
         <?php elseif ($item->status === 'processing'): ?>
-            <button class="aips-btn aips-btn-sm aips-btn-secondary aips-view-session" data-history-id="<?php echo esc_attr($item->id); ?>" title="<?php esc_attr_e('View Session', 'ai-post-scheduler'); ?>">
+            <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-view-session" data-history-id="<?php echo esc_attr($item->id); ?>" title="<?php esc_attr_e('View Session', 'ai-post-scheduler'); ?>">
                 <span class="dashicons dashicons-visibility"></span>
                 <?php esc_html_e('View Session', 'ai-post-scheduler'); ?>
             </button>
         <?php endif; ?>
 
         <?php if ($item->status === 'failed' && $item->template_id): ?>
-            <button class="aips-btn aips-btn-sm aips-btn-secondary aips-retry-generation" data-id="<?php echo esc_attr($item->id); ?>" title="<?php esc_attr_e('Retry Generation', 'ai-post-scheduler'); ?>">
+            <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-retry-generation" data-id="<?php echo esc_attr($item->id); ?>" title="<?php esc_attr_e('Retry Generation', 'ai-post-scheduler'); ?>">
                 <span class="dashicons dashicons-update"></span>
                 <?php esc_html_e('Retry', 'ai-post-scheduler'); ?>
             </button>

--- a/ai-post-scheduler/templates/partials/view-session-modal.php
+++ b/ai-post-scheduler/templates/partials/view-session-modal.php
@@ -21,13 +21,13 @@ if (!defined('ABSPATH')) {
 		<div class="aips-modal-header">
 			<h2><?php esc_html_e('View Session', 'ai-post-scheduler'); ?></h2>
 			<div class="aips-modal-header-actions">
-				<button class="button button-primary aips-copy-session-json">
+				<button type="button" class="button button-primary aips-copy-session-json">
 					<?php esc_html_e('Copy Session JSON', 'ai-post-scheduler'); ?>
 				</button>
-				<button class="button aips-download-session-json">
+				<button type="button" class="button aips-download-session-json">
 					<?php esc_html_e('Download Session JSON', 'ai-post-scheduler'); ?>
 				</button>
-				<button class="aips-modal-close" aria-label="<?php esc_attr_e('Close', 'ai-post-scheduler'); ?>">
+				<button type="button" class="aips-modal-close" aria-label="<?php esc_attr_e('Close', 'ai-post-scheduler'); ?>">
 					<span class="dashicons dashicons-no"></span>
 				</button>
 			</div>

--- a/fix_buttons.py
+++ b/fix_buttons.py
@@ -1,0 +1,36 @@
+import os
+import re
+
+def process_file(filepath):
+    with open(filepath, 'r') as f:
+        content = f.read()
+
+    # Find all <button ...> tags
+    # regex to match <button followed by attributes until >
+
+    def replacer(match):
+        tag = match.group(0)
+        # Check if type= is in the tag (case insensitive)
+        if re.search(r'\btype\s*=', tag, re.IGNORECASE):
+            return tag
+
+        # Replace <button with <button type="button"
+        # We need to make sure we don't match <button-group etc.
+        if tag.startswith('<button ') or tag == '<button>':
+            return tag.replace('<button', '<button type="button"', 1)
+        return tag
+
+    new_content = re.sub(r'<button(?:\s+[^>]*?)?>', replacer, content, flags=re.IGNORECASE)
+
+    if new_content != content:
+        with open(filepath, 'w') as f:
+            f.write(new_content)
+        print(f"Fixed buttons in {filepath}")
+
+for root, dirs, files in os.walk('ai-post-scheduler'):
+    if 'vendor' in root or 'node_modules' in root or '.git' in root:
+        continue
+    for file in files:
+        if file.endswith('.php') or file.endswith('.js'):
+            filepath = os.path.join(root, file)
+            process_file(filepath)


### PR DESCRIPTION
🐛 **Bug:** Clicking various UI buttons (like "View Session", "Edit Voice", "Add Template", modal close buttons, etc.) in the WordPress admin interface could cause unintended full-page reloads and form submissions, instead of just executing their JavaScript handlers.

🔍 **Root Cause:** WordPress admin pages are often wrapped in a `<form>` element by default. In HTML, any `<button>` element inside a form without an explicit `type` attribute defaults to `type="submit"`. 

🛠️ **Fix:** Added `type="button"` to all `<button>` elements in the admin templates and JavaScript files that are strictly meant for UI interactions and should not submit a form. This overrides the default `submit` behavior and ensures they only trigger their bound JS events.

🧪 **Verification:** 
1. Run `composer test` to ensure no syntax errors were introduced.
2. In a WordPress environment, navigate to any admin page (e.g., Templates, Voices). Click on UI buttons (like closing a modal or clicking 'Edit'). They will no longer cause a page reload.

---
*PR created automatically by Jules for task [9596882944118254686](https://jules.google.com/task/9596882944118254686) started by @rpnunez*