### PR TITLE
🧙‍♂️ Wizard: Add "Clear" buttons to search bars in Sections and Planner

### DIFF
--- a/.jules/wizard.md
+++ b/.jules/wizard.md
@@ -35,3 +35,7 @@
 ## 2026-01-22 - Research Search Consistency
 **Learning:** The "Trending Topics Library" table lacked search functionality, which is a standard expectation established in other admin tables (Authors, Structures, etc.).
 **Action:** Implemented client-side search for Trending Topics with a "Clear" button and Empty State, ensuring "Select All" functionality respects the active filter.
+
+## 2024-05-19 - Add "Clear" buttons to search bars in Sections and Planner
+Learning: Consistent UX in search bars requires not just an input, but `screen-reader-text` labels and a hidden `Clear` button that can be toggled by JS. Wait to merge `class` attributes when copying elements to prevent duplicate attributes like `class="aips-form-input" class="aips-planner-topic-search"`.
+Action: Always check if the `admin.js` script handles specific clear button IDs even if they are missing from the PHP template, and add them proactively for completeness.

--- a/ai-post-scheduler/templates/admin/planner.php
+++ b/ai-post-scheduler/templates/admin/planner.php
@@ -66,7 +66,9 @@ $default_planner_frequency = 'daily';
                     <span class="selection-count aips-planner-selection-count"></span>
                 </div>
                 <div class="aips-toolbar-right aips-planner-toolbar-right">
-                    <input type="search" id="planner-topic-search" class="aips-form-input" placeholder="<?php esc_attr_e('Filter topics...', 'ai-post-scheduler'); ?>" class="aips-planner-topic-search">
+                    <label class="screen-reader-text" for="planner-topic-search"><?php esc_html_e('Filter topics:', 'ai-post-scheduler'); ?></label>
+                    <input type="search" id="planner-topic-search" class="aips-form-input aips-planner-topic-search" placeholder="<?php esc_attr_e('Filter topics...', 'ai-post-scheduler'); ?>">
+                    <button type="button" id="planner-topic-search-clear" class="aips-btn aips-btn-sm aips-btn-secondary" style="display: none;"><?php esc_html_e('Clear', 'ai-post-scheduler'); ?></button>
                     <button type="button" id="btn-copy-topics" class="aips-btn aips-btn-sm aips-btn-secondary"><?php echo esc_html__('Copy Selected', 'ai-post-scheduler'); ?></button>
                     <button type="button" id="btn-clear-topics" class="aips-btn aips-btn-sm aips-btn-ghost"><?php echo esc_html__('Clear List', 'ai-post-scheduler'); ?></button>
                 </div>

--- a/ai-post-scheduler/templates/admin/sections.php
+++ b/ai-post-scheduler/templates/admin/sections.php
@@ -30,7 +30,11 @@ if (!isset($sections) || !is_array($sections)) {
 			<?php if (!empty($sections)) : ?>
 			<!-- Filter Bar -->
 			<div class="aips-filter-bar">
-				<input type="search" id="aips-section-search" class="aips-form-input" placeholder="<?php esc_attr_e('Search sections...', 'ai-post-scheduler'); ?>">
+				<div class="aips-filter-right">
+					<label class="screen-reader-text" for="aips-section-search"><?php esc_html_e('Search Sections:', 'ai-post-scheduler'); ?></label>
+					<input type="search" id="aips-section-search" class="aips-form-input" placeholder="<?php esc_attr_e('Search sections...', 'ai-post-scheduler'); ?>">
+					<button type="button" id="aips-section-search-clear" class="aips-btn aips-btn-secondary" style="display: none;"><?php esc_html_e('Clear', 'ai-post-scheduler'); ?></button>
+				</div>
 			</div>
 
 			<!-- Table -->


### PR DESCRIPTION
**What**: Added `aips-filter-right` div wrappers, `.screen-reader-text` labels, and hidden "Clear" buttons to the search input bars in `sections.php` and `planner.php`. Merged duplicate `class` attributes on the `planner.php` search input.

**Why**: To match the existing UX pattern found in other pages (like Authors, Templates, and Schedules) which dynamically display a "Clear" button when the user types in the search bar, allowing for easy reset of filters.

**Value**: Improves accessibility by ensuring search bars have explicit labels, and enhances usability by standardizing the filtering experience across the plugin's admin dashboard.

**Visuals**: (Verified via headless dummy screenshot)

---
*PR created automatically by Jules for task [17014283392919962474](https://jules.google.com/task/17014283392919962474) started by @rpnunez*