### PR TITLE
Add story package generation workflow and review UI

### DIFF
--- a/ai-post-scheduler/assets/js/admin-view-session.js
+++ b/ai-post-scheduler/assets/js/admin-view-session.js
@@ -21,6 +21,7 @@
 	// Session state
 	var currentHistoryId = null;
 	var currentLogCount = 0;
+	var preferredSessionTab = 'logs';
 	
 	/**
 	 * Initialize View Session functionality
@@ -51,6 +52,8 @@
 		
 		// Toggle AI component details
 		$(document).on('click', '.aips-ai-component:not(.expanded)', handleAIComponentClick);
+		$(document).on('click', '.aips-package-item-toggle', handlePackageToggle);
+		$(document).on('click', '.aips-regenerate-package-artifact', handlePackageRegeneration);
 		
 		// ESC key to close modal
 		$(document).on('keydown', function(e) {
@@ -66,6 +69,7 @@
 	function handleViewSession(e) {
 		e.preventDefault();
 		var historyId = $(e.currentTarget).data('history-id');
+		preferredSessionTab = $(e.currentTarget).data('session-tab') || 'logs';
 		
 		if (!historyId) {
 			console.error('No history ID provided');
@@ -128,6 +132,7 @@
 		$('#aips-session-completed').text('');
 		$('#aips-logs-list').html('<p>Loading logs...</p>');
 		$('#aips-ai-list').html('<p>Loading AI calls...</p>');
+		$('#aips-package-list').html('<p>Loading package artifacts...</p>');
 	}
 	
 	/**
@@ -139,6 +144,7 @@
 		currentLogCount = Array.isArray(data.logs) ? data.logs.length : 0;
 
 		// Update session info
+		$('#aips-session-modal').data('post-id', data.history.post_id || 0);
 		$('#aips-session-title').text(data.history.generated_title || 'N/A');
 		$('#aips-session-created').text(data.history.created_at || 'N/A');
 		$('#aips-session-completed').text(data.history.completed_at || 'N/A');
@@ -148,11 +154,32 @@
 		
 		// Display AI calls (including regenerations)
 		renderAICalls(data.ai_calls, data.component_revisions || {});
+		renderStoryPackage(data.story_package || {}, data.story_package_revisions || {});
 		
 		// Show modal
 		$('#aips-session-modal').show();
+		activateTab(preferredSessionTab);
 	}
 	
+	/**
+	 * Activate a modal tab by name.
+	 *
+	 * @param {string} tabName Tab slug.
+	 */
+	function activateTab(tabName) {
+		var selectorMap = {
+			logs: '#aips-tab-logs',
+			ai: '#aips-tab-ai',
+			package: '#aips-tab-package'
+		};
+		var target = selectorMap[tabName] || selectorMap.logs;
+		var $tabs = $('#aips-session-modal .aips-tabs');
+		$tabs.find('.aips-tab-nav a').removeClass('active');
+		$tabs.find('.aips-tab-nav a[href="' + target + '"]').addClass('active');
+		$tabs.find('.aips-tab-content').hide();
+		$tabs.find(target).show();
+	}
+
 	/**
 	 * Render logs tab content
 	 */
@@ -285,6 +312,126 @@
 		$('#aips-ai-list').html(aiHtml);
 	}
 	
+	/**
+	 * Render story package tab content.
+	 *
+	 * @param {Object} storyPackage Story package payload.
+	 * @param {Object} storyPackageRevisions Revisions keyed by artifact slug.
+	 */
+	function renderStoryPackage(storyPackage, storyPackageRevisions) {
+		var outputs = Array.isArray(storyPackage.outputs) ? storyPackage.outputs : [];
+		var artifacts = storyPackage.artifacts || {};
+		var $container = $('#aips-package-list');
+		$container.empty();
+
+		if (!outputs.length) {
+			$container.html('<p class="aips-no-data">No story package artifacts were stored for this session.</p>');
+			return;
+		}
+
+		outputs.forEach(function(outputKey) {
+			var artifact = artifacts[outputKey] || {};
+			var label = artifact.label || outputKey;
+			var revisions = (storyPackageRevisions && storyPackageRevisions[outputKey]) ? storyPackageRevisions[outputKey] : [];
+			var content = artifact.content || '';
+			var displayContent = '';
+
+			if (outputKey === 'full_article' && content && typeof content === 'object') {
+				displayContent = 'Title: ' + (content.title || '') + '\n\nExcerpt: ' + (content.excerpt || '') + '\n\nContent:\n' + (content.content || '');
+			} else if (typeof content === 'object') {
+				displayContent = JSON.stringify(content, null, 2);
+			} else {
+				displayContent = String(content || '');
+			}
+
+			var $item = $('<div class="aips-ai-component aips-package-item expanded"></div>').attr('data-artifact', outputKey);
+			var $header = $('<div class="aips-package-item-toggle"></div>');
+			$header.append($('<h4></h4>').text(label));
+			$header.append($('<p class="aips-ai-hint"></p>').text('Review the current artifact and regenerate it if needed.'));
+			$item.append($header);
+
+			var $details = $('<div class="aips-ai-details"></div>');
+			var $contentSection = $('<div class="aips-ai-section"></div>');
+			$contentSection.append($('<h5></h5>').text('Current artifact'));
+			$contentSection.append($('<div class="aips-json-viewer"><pre></pre></div>').find('pre').text(displayContent || '(empty)').end());
+			if (outputKey !== 'full_article') {
+				$contentSection.append($('<button type="button" class="button button-secondary aips-regenerate-package-artifact"></button>').attr('data-artifact', outputKey).text('Regenerate artifact'));
+			}
+			$details.append($contentSection);
+
+			var $revisionsSection = $('<div class="aips-ai-section"></div>');
+			$revisionsSection.append($('<h5></h5>').text('Artifact revisions'));
+			if (Array.isArray(revisions) && revisions.length) {
+				var $list = $('<div class="aips-ai-revisions"></div>');
+				revisions.forEach(function(revision) {
+					var value = revision.value;
+					if (typeof value !== 'string') {
+						value = JSON.stringify(value || '', null, 2);
+					}
+					$list.append(
+						$('<div class="aips-ai-revision-item"></div>')
+							.append($('<div class="aips-ai-revision-meta"></div>').text(revision.timestamp || ''))
+							.append($('<div class="aips-ai-revision-value"></div>').text(value || '(empty)'))
+					);
+				});
+				$revisionsSection.append($list);
+			} else {
+				$revisionsSection.append($('<p class="aips-no-data"></p>').text('No regenerations found.'));
+			}
+			$details.append($revisionsSection);
+			$item.append($details);
+			$container.append($item);
+		});
+	}
+
+	function handlePackageToggle(e) {
+		$(e.currentTarget).closest('.aips-package-item').toggleClass('expanded');
+	}
+
+	function handlePackageRegeneration(e) {
+		e.preventDefault();
+		e.stopPropagation();
+
+		var artifact = $(e.currentTarget).data('artifact');
+		if (!artifact) {
+			return;
+		}
+
+		var component = 'story_package_' + artifact;
+		var postId = currentHistoryId ? ($('#aips-session-modal').data('post-id') || 0) : 0;
+		if (!postId) {
+			return;
+		}
+
+		var ajaxUrl = window.ajaxurl;
+		var nonce = window.aipsAjaxNonce;
+		var $button = $(e.currentTarget);
+		$button.prop('disabled', true).text('Regenerating...');
+
+		preferredSessionTab = 'package';
+
+		$.post(ajaxUrl, {
+			action: 'aips_regenerate_component',
+			nonce: nonce,
+			history_id: currentHistoryId,
+			post_id: postId,
+			component: component,
+			current_value: '',
+			current_source: 'session_review',
+			current_reason: 'story_package_regeneration'
+		}).done(function(response) {
+			if (response && response.success) {
+				loadSessionData(currentHistoryId);
+			} else {
+				showModalNotification((response && response.data && response.data.message) ? response.data.message : 'Failed to regenerate package artifact.', 'error');
+			}
+		}).fail(function() {
+			showModalNotification('Failed to regenerate package artifact.', 'error');
+		}).always(function() {
+			$button.prop('disabled', false).text('Regenerate artifact');
+		});
+	}
+
 	/**
 	 * Handle tab switching
 	 */

--- a/ai-post-scheduler/assets/js/admin.js
+++ b/ai-post-scheduler/assets/js/admin.js
@@ -79,6 +79,7 @@
 
             // Toggle source groups panel when Include Sources? checkbox changes.
             $(document).on('change', '#include_sources', this.toggleSourceGroupsSelector);
+            $(document).on('change', '#story_package_enabled', this.toggleStoryPackageOptions);
 
             // Wizard navigation
             $(document).on('click', '.aips-wizard-next', this.wizardNext);
@@ -438,6 +439,38 @@
         },
 
         /**
+         * Get the selected story package outputs.
+         *
+         * @return {Array<string>}
+         */
+        getSelectedStoryPackageOutputs: function() {
+            var outputs = [];
+
+            $('.aips-story-package-output:checked').each(function() {
+                outputs.push($(this).val());
+            });
+
+            if (outputs.indexOf('full_article') === -1) {
+                outputs.unshift('full_article');
+            }
+
+            return outputs;
+        },
+
+        /**
+         * Toggle the story package configuration panel.
+         *
+         * @return {void}
+         */
+        toggleStoryPackageOptions: function() {
+            var enabled = $('#story_package_enabled').is(':checked');
+
+            $('#aips-story-package-options').toggle(enabled);
+            $('.aips-story-package-output').not('[value="full_article"]').prop('disabled', !enabled);
+            $('.aips-story-package-output[value="full_article"]').prop('checked', true);
+        },
+
+        /**
          * Reset and open the template modal in "Add New" mode.
          *
          * Clears the form, resets the media selection and AI variables panel,
@@ -459,6 +492,10 @@
             // Reset source groups
             $('.aips-template-source-group-cb').prop('checked', false);
             $('#template-source-groups-selector').hide();
+            $('#story_package_enabled').prop('checked', false);
+            $('.aips-story-package-output').prop('checked', false);
+            $('.aips-story-package-output[value="full_article"]').prop('checked', true);
+            AIPS.toggleStoryPackageOptions();
             // Initialize wizard to step 1
             AIPS.wizardGoToStep(1, $('#aips-template-modal'));
             $('#aips-template-modal').show();
@@ -524,6 +561,21 @@
                         sgIds.forEach(function(tid) {
                             $('.aips-template-source-group-cb[value="' + tid + '"]').prop('checked', true);
                         });
+
+                        var storyPackageEnabled = t.story_package_enabled == 1;
+                        $('#story_package_enabled').prop('checked', storyPackageEnabled);
+                        $('.aips-story-package-output').prop('checked', false);
+                        var storyPackageOutputs = [];
+                        try {
+                            storyPackageOutputs = JSON.parse(t.story_package_outputs || '["full_article"]');
+                        } catch (storyPackageParseErr) {
+                            storyPackageOutputs = ['full_article'];
+                        }
+                        storyPackageOutputs.forEach(function(outputKey) {
+                            $('.aips-story-package-output[value="' + outputKey + '"]').prop('checked', true);
+                        });
+                        $('.aips-story-package-output[value="full_article"]').prop('checked', true);
+                        AIPS.toggleStoryPackageOptions();
 
                         // Scan for AI Variables after loading template data
                         AIPS.initAIVariablesScanner();
@@ -713,6 +765,8 @@
                         $('.aips-template-source-group-cb:checked').each(function() { ids.push($(this).val()); });
                         return ids;
                     }()),
+                    story_package_enabled: $('#story_package_enabled').is(':checked') ? 1 : 0,
+                    story_package_outputs: AIPS.getSelectedStoryPackageOutputs(),
                     is_active: $('#is_active').is(':checked') ? 1 : 0
                 },
                 success: function(response) {
@@ -786,6 +840,8 @@
                         $('.aips-template-source-group-cb:checked').each(function() { ids.push($(this).val()); });
                         return ids;
                     }()),
+                    story_package_enabled: $('#story_package_enabled').is(':checked') ? 1 : 0,
+                    story_package_outputs: AIPS.getSelectedStoryPackageOutputs(),
                     is_active: 0 // Save as inactive draft
                 },
                 success: function(response) {
@@ -855,6 +911,8 @@
                 post_category: $('#post_category').val(),
                 post_tags: $('#post_tags').val(),
                 post_author: $('#post_author').val(),
+                story_package_enabled: $('#story_package_enabled').is(':checked') ? 1 : 0,
+                story_package_outputs: AIPS.getSelectedStoryPackageOutputs()
             };
 
             $.ajax({
@@ -3733,6 +3791,16 @@
             } else {
                 $modal.find('#summary_featured_image').text(aipsAdminL10n.featuredImageNo);
             }
+
+            if ($('#story_package_enabled').is(':checked')) {
+                var selectedOutputs = AIPS.getSelectedStoryPackageOutputs().map(function(output) {
+                    var $label = $('.aips-story-package-output[value="' + output + '"]').closest('label').find('strong').first();
+                    return $label.length ? $label.text() : output;
+                });
+                $modal.find('#summary_story_package').text(selectedOutputs.join(', '));
+            } else {
+                $modal.find('#summary_story_package').text('Article only');
+            }
         },
 
         /**
@@ -3905,7 +3973,9 @@
                     var ids = [];
                     $('.aips-template-source-group-cb:checked').each(function() { ids.push($(this).val()); });
                     return ids;
-                }())
+                }()),
+                story_package_enabled: $('#story_package_enabled').is(':checked') ? 1 : 0,
+                story_package_outputs: AIPS.getSelectedStoryPackageOutputs()
             };
             
             $.ajax({

--- a/ai-post-scheduler/includes/class-aips-ai-edit-controller.php
+++ b/ai-post-scheduler/includes/class-aips-ai-edit-controller.php
@@ -159,8 +159,13 @@ class AIPS_AI_Edit_Controller {
 		}
 		
 		// Validate component type
-		$valid_components = array('title', 'excerpt', 'content', 'featured_image');
-		if (!in_array($component, $valid_components)) {
+		$story_package_map = array();
+		foreach (AIPS_Story_Package::get_output_definitions() as $artifact_key => $definition) {
+			$story_package_map[$definition['component']] = $artifact_key;
+		}
+
+		$valid_components = array_merge(array('title', 'excerpt', 'content', 'featured_image'), array_keys($story_package_map));
+		if (!in_array($component, $valid_components, true)) {
 			wp_send_json_error(array('message' => __('Invalid component type.', 'ai-post-scheduler')));
 		}
 		
@@ -222,6 +227,11 @@ class AIPS_AI_Edit_Controller {
 				break;
 			case 'featured_image':
 				$result = $this->service->regenerate_featured_image($context);
+				break;
+			default:
+				if (isset($story_package_map[$component])) {
+					$result = $this->service->regenerate_story_package_artifact($context, $story_package_map[$component]);
+				}
 				break;
 		}
 		
@@ -489,7 +499,11 @@ class AIPS_AI_Edit_Controller {
 				);
 
 			default:
-				return '';
+				if (is_array($value)) {
+					return $value;
+				}
+
+				return sanitize_textarea_field((string) $value);
 		}
 	}
 }

--- a/ai-post-scheduler/includes/class-aips-component-regeneration-service.php
+++ b/ai-post-scheduler/includes/class-aips-component-regeneration-service.php
@@ -309,6 +309,66 @@ class AIPS_Component_Regeneration_Service {
 	}
 
 	/**
+	 * Regenerate a story package artifact.
+	 *
+	 * @param array  $context Generation context with post and history IDs.
+	 * @param string $artifact_key Story package artifact key.
+	 * @return array|WP_Error
+	 */
+	public function regenerate_story_package_artifact($context, $artifact_key) {
+		if (!isset($context['generation_context']) || !($context['generation_context'] instanceof AIPS_Generation_Context)) {
+			return new WP_Error('missing_context', __('Generation context is required.', 'ai-post-scheduler'));
+		}
+
+		$post_id = isset($context['post_id']) ? absint($context['post_id']) : 0;
+		$history_id = isset($context['history_id']) ? absint($context['history_id']) : 0;
+		if (!$post_id || !$history_id) {
+			return new WP_Error('missing_history_context', __('Post and history IDs are required.', 'ai-post-scheduler'));
+		}
+
+		$definitions = AIPS_Story_Package::get_output_definitions();
+		$artifact_key = sanitize_key($artifact_key);
+		if (!isset($definitions[$artifact_key])) {
+			return new WP_Error('invalid_story_package_artifact', __('Invalid story package artifact.', 'ai-post-scheduler'));
+		}
+
+		$history_container = AIPS_History_Container::resolve_existing($this->history_repository, $post_id, $history_id);
+		if (is_wp_error($history_container)) {
+			return $history_container;
+		}
+
+		$this->generator->set_history_container($history_container);
+		$shared_context = $this->prompt_builder->build_story_package_shared_context($context['generation_context'], array(
+			'title' => isset($context['current_title']) ? $context['current_title'] : '',
+			'excerpt' => isset($context['current_excerpt']) ? $context['current_excerpt'] : '',
+			'content' => isset($context['current_content']) ? $context['current_content'] : '',
+			'featured_image_prompt' => $context['generation_context']->get_image_prompt(),
+		));
+
+		$prompt = $this->prompt_builder->build_story_package_prompt($artifact_key, $context['generation_context'], $shared_context);
+		if ('' === trim($prompt)) {
+			return new WP_Error('missing_story_package_prompt', __('No story package prompt is available for this artifact.', 'ai-post-scheduler'));
+		}
+
+		$result = $this->generator->generate_content($prompt, array(), $definitions[$artifact_key]['component']);
+		if (is_wp_error($result)) {
+			return $result;
+		}
+
+		$artifact = array(
+			'content' => is_string($result) ? trim($result) : $result,
+			'generated_at' => current_time('mysql'),
+			'label' => $definitions[$artifact_key]['label'],
+			'component' => $definitions[$artifact_key]['component'],
+			'format' => $definitions[$artifact_key]['format'],
+		);
+
+		AIPS_Story_Package::update_post_artifact($post_id, $artifact_key, $artifact);
+
+		return $artifact;
+	}
+
+	/**
 	 * Capture the current component value as a revision snapshot.
 	 *
 	 * This enables immediate restore of the value that existed before a new
@@ -327,7 +387,7 @@ class AIPS_Component_Regeneration_Service {
 		$source = sanitize_key($source);
 		$reason = sanitize_key($reason);
 
-		$valid_components = array('title', 'excerpt', 'content', 'featured_image');
+		$valid_components = array_merge(array('title', 'excerpt', 'content', 'featured_image'), array_values(wp_list_pluck(AIPS_Story_Package::get_output_definitions(), 'component')));
 		if (!in_array($component, $valid_components, true)) {
 			return new WP_Error('invalid_component', __('Invalid component type.', 'ai-post-scheduler'));
 		}

--- a/ai-post-scheduler/includes/class-aips-db-manager.php
+++ b/ai-post-scheduler/includes/class-aips-db-manager.php
@@ -130,6 +130,8 @@ class AIPS_DB_Manager {
             post_author bigint(20) DEFAULT NULL,
             include_sources tinyint(1) DEFAULT 0,
             source_group_ids text DEFAULT NULL,
+            story_package_enabled tinyint(1) DEFAULT 0,
+            story_package_outputs longtext DEFAULT NULL,
             is_active tinyint(1) DEFAULT 1,
             created_at datetime DEFAULT CURRENT_TIMESTAMP,
             updated_at datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/ai-post-scheduler/includes/class-aips-generated-posts-controller.php
+++ b/ai-post-scheduler/includes/class-aips-generated-posts-controller.php
@@ -113,6 +113,7 @@ class AIPS_Generated_Posts_Controller {
 			$posts_data[] = array(
 				'history_id' => $item->id,
 				'post_id' => $item->post_id,
+				'has_story_package' => AIPS_Story_Package::post_has_package($item->post_id),
 				'title' => $post->post_title,
 				'date_generated' => $item->created_at,
 				'date_published' => $post->post_date,
@@ -151,6 +152,7 @@ class AIPS_Generated_Posts_Controller {
 			$partial_posts_data[] = array(
 				'history_id' => $item->id,
 				'post_id' => $item->post_id,
+				'has_story_package' => AIPS_Story_Package::post_has_package($item->post_id),
 				'title' => $post->post_title,
 				'date_generated' => $item->created_at,
 				'date_updated' => $item->post_modified,
@@ -309,12 +311,27 @@ class AIPS_Generated_Posts_Controller {
 		
 		// Collect regenerations / revisions per component
 		$component_revisions = array();
+		$story_package = array();
+		$story_package_revisions = array();
 		if ($history_item->post_id) {
 			$components = array('title', 'excerpt', 'content', 'featured_image');
 			foreach ($components as $component) {
 				$component_revisions[$component] = $this->history_repository->get_component_revisions(
 					absint($history_item->post_id),
 					$component,
+					20
+				);
+			}
+
+			$story_package = AIPS_Story_Package::get_post_package($history_item->post_id);
+			foreach (AIPS_Story_Package::get_output_definitions() as $artifact_key => $definition) {
+				if ('full_article' === $artifact_key) {
+					continue;
+				}
+
+				$story_package_revisions[$artifact_key] = $this->history_repository->get_component_revisions(
+					absint($history_item->post_id),
+					$definition['component'],
 					20
 				);
 			}
@@ -332,6 +349,8 @@ class AIPS_Generated_Posts_Controller {
 			'logs' => $logs,
 			'ai_calls' => $ai_calls,
 			'component_revisions' => $component_revisions,
+			'story_package' => $story_package,
+			'story_package_revisions' => $story_package_revisions,
 		));
 	}
 	

--- a/ai-post-scheduler/includes/class-aips-generator.php
+++ b/ai-post-scheduler/includes/class-aips-generator.php
@@ -549,6 +549,8 @@ class AIPS_Generator {
             'featured_image' => !$context->should_generate_featured_image(),
             'post_content'   => false,
         );
+        $story_package_config = $this->get_story_package_config($context);
+        $story_package_artifacts = array();
 
         // Dispatch post generation started event
         do_action('aips_post_generation_started', $context->get_id(), $context->get_topic() ? $context->get_topic() : '');
@@ -672,9 +674,21 @@ class AIPS_Generator {
         $excerpt = $this->generate_excerpt_from_context($title, $excerpt_content, $context, array(), $excerpt_success);
         $component_statuses['post_excerpt'] = (bool) $excerpt_success;
 
+        if (!empty($story_package_config['enabled'])) {
+            $story_package_artifacts = $this->generate_story_package_artifacts($context, $story_package_config['outputs'], array(
+                'title' => $title,
+                'excerpt' => $excerpt,
+                'content' => $content,
+                'featured_image_prompt' => $context->get_image_prompt(),
+            ));
+        }
+
         $generation_incomplete = in_array(false, $component_statuses, true);
 
         // Use Post Manager Service to save the generated post in WP
+        $package_seo_title = $this->extract_story_package_seo_title($story_package_artifacts, $title);
+        $package_meta_description = $this->extract_story_package_meta_description($story_package_artifacts, $excerpt);
+
         $post_creation_data = array(
             'title' => $title,
             'content' => $content,
@@ -682,8 +696,8 @@ class AIPS_Generator {
             'context' => $context,
             // Provide SEO context for downstream plugins.
             'focus_keyword' => $context->get_topic() ? $context->get_topic() : $title,
-            'meta_description' => $excerpt,
-            'seo_title' => $title,
+            'meta_description' => $package_meta_description,
+            'seo_title' => $package_seo_title,
             'generation_incomplete' => $generation_incomplete,
             'component_statuses' => $component_statuses,
         );
@@ -712,6 +726,11 @@ class AIPS_Generator {
         $generation_incomplete = in_array(false, $component_statuses, true);
         $this->post_manager->update_generation_status_meta($post_id, $component_statuses, $generation_incomplete);
 
+        if (!empty($story_package_config['enabled'])) {
+            $story_package_artifacts = $this->finalize_story_package_payload($story_package_config['outputs'], $story_package_artifacts, $title, $excerpt, $content);
+            AIPS_Story_Package::save_post_package($post_id, $story_package_artifacts);
+        }
+
         if ($generation_incomplete) {
             do_action('aips_post_generation_incomplete', $post_id, $component_statuses, $context, $this->current_history ? $this->current_history->get_id() : 0);
         }
@@ -723,6 +742,7 @@ class AIPS_Generator {
             'generated_content' => $content,
             'generation_incomplete' => $generation_incomplete,
             'component_statuses' => $component_statuses,
+            'story_package' => $story_package_artifacts,
         ));
 
         // Log activity
@@ -915,6 +935,127 @@ class AIPS_Generator {
         }
 
         return wp_kses_post($normalized_content);
+    }
+
+    /**
+     * Get story package configuration for a generation context.
+     *
+     * @param AIPS_Generation_Context $context Generation context.
+     * @return array
+     */
+    private function get_story_package_config($context) {
+        if ($context instanceof AIPS_Template_Context && method_exists($context, 'get_template')) {
+            return AIPS_Story_Package::normalize_template_config($context->get_template());
+        }
+
+        return array(
+            'enabled' => false,
+            'outputs' => array('full_article'),
+        );
+    }
+
+    /**
+     * Generate the configured story package artifacts.
+     *
+     * @param AIPS_Generation_Context $context Generation context.
+     * @param array                   $outputs Selected outputs.
+     * @param array                   $seed Shared content seed.
+     * @return array
+     */
+    private function generate_story_package_artifacts($context, $outputs, $seed) {
+        $outputs = AIPS_Story_Package::normalize_outputs($outputs);
+        $artifacts = array();
+        $shared_context = $this->prompt_builder->build_story_package_shared_context($context, $seed);
+        $definitions = AIPS_Story_Package::get_output_definitions();
+
+        foreach ($outputs as $output_key) {
+            if ('full_article' === $output_key || !isset($definitions[$output_key])) {
+                continue;
+            }
+
+            $prompt = $this->prompt_builder->build_story_package_prompt($output_key, $context, $shared_context);
+            if ('' === trim($prompt)) {
+                continue;
+            }
+
+            $options = array('max_tokens' => 'meta_description' === $output_key ? 120 : 500);
+            $result = $this->generate_content($prompt, $options, $definitions[$output_key]['component']);
+
+            if (is_wp_error($result)) {
+                if ($this->current_history) {
+                    $this->current_history->record_error($result->get_error_message(), array(
+                        'component' => $definitions[$output_key]['component'],
+                        'story_package_output' => $output_key,
+                    ), $result);
+                }
+                continue;
+            }
+
+            $artifacts[$output_key] = array(
+                'content' => is_string($result) ? trim($result) : $result,
+                'generated_at' => current_time('mysql'),
+                'label' => $definitions[$output_key]['label'],
+                'component' => $definitions[$output_key]['component'],
+                'format' => $definitions[$output_key]['format'],
+            );
+        }
+
+        return $artifacts;
+    }
+
+    /**
+     * Finalize the full story package payload before persistence.
+     *
+     * @param array  $outputs Selected outputs.
+     * @param array  $artifacts Generated artifacts.
+     * @param string $title Generated title.
+     * @param string $excerpt Generated excerpt.
+     * @param string $content Generated content.
+     * @return array
+     */
+    private function finalize_story_package_payload($outputs, $artifacts, $title, $excerpt, $content) {
+        $artifacts['full_article'] = array(
+            'content' => array(
+                'title' => $title,
+                'excerpt' => $excerpt,
+                'content' => $content,
+            ),
+            'generated_at' => current_time('mysql'),
+        );
+
+        return AIPS_Story_Package::build_package_payload($outputs, $artifacts);
+    }
+
+    /**
+     * Extract an SEO title from story package artifacts when available.
+     *
+     * @param array  $story_package Story package payload.
+     * @param string $fallback Default title.
+     * @return string
+     */
+    private function extract_story_package_seo_title($story_package, $fallback) {
+        if (!empty($story_package['seo_title_dek']['content']) && is_string($story_package['seo_title_dek']['content'])) {
+            if (preg_match('/SEO Title:\s*(.+)/i', $story_package['seo_title_dek']['content'], $matches)) {
+                return sanitize_text_field(trim($matches[1]));
+            }
+        }
+
+        return $fallback;
+    }
+
+    /**
+     * Extract a meta description from story package artifacts when available.
+     *
+     * @param array  $story_package Story package payload.
+     * @param string $fallback Default description.
+     * @return string
+     */
+    private function extract_story_package_meta_description($story_package, $fallback) {
+        if (!empty($story_package['meta_description']['content']) && is_string($story_package['meta_description']['content'])) {
+            return sanitize_text_field(trim($story_package['meta_description']['content']));
+        }
+
+        return $fallback;
     }
 
     /**

--- a/ai-post-scheduler/includes/class-aips-prompt-builder.php
+++ b/ai-post-scheduler/includes/class-aips-prompt-builder.php
@@ -336,20 +336,200 @@ INSTRUCTIONS;
             }
         }
 
+        $story_package_config = AIPS_Story_Package::normalize_template_config($template_data);
+        $story_package_prompts = array();
+
+        if (!empty($story_package_config['enabled'])) {
+            $shared_context = $this->build_story_package_shared_context($template_data, array(
+                'topic' => $sample_topic,
+                'title' => $sample_title,
+                'excerpt' => '[Generated excerpt would appear here]',
+                'content' => $sample_content,
+                'featured_image_prompt' => $image_prompt_processed,
+            ));
+
+            foreach ($story_package_config['outputs'] as $output_key) {
+                if ('full_article' === $output_key) {
+                    continue;
+                }
+
+                $story_package_prompts[$output_key] = $this->build_story_package_prompt($output_key, $template_data, $shared_context);
+            }
+        }
+
         return array(
             'prompts' => array(
                 'content' => $content_prompt,
                 'title' => $title_prompt,
                 'excerpt' => $excerpt_prompt,
                 'image' => $image_prompt_processed,
+                'story_package' => $story_package_prompts,
             ),
             'metadata' => array(
                 'voice' => $voice_name,
                 'article_structure' => $structure_name,
                 'sample_topic' => $sample_topic,
                 'include_sources' => !empty($template_data->include_sources),
+                'story_package_enabled' => !empty($story_package_config['enabled']),
+                'story_package_outputs' => $story_package_config['outputs'],
             ),
         );
+    }
+
+    /**
+     * Build a shared story package context block.
+     *
+     * @param object|AIPS_Generation_Context $template_or_context Template object or generation context.
+     * @param array                          $seed Seed values gathered during generation.
+     * @return array
+     */
+    public function build_story_package_shared_context($template_or_context, $seed = array()) {
+        $topic = '';
+        $content_prompt = '';
+        $template_name = '';
+        $title_prompt = '';
+        $article_structure_id = null;
+        $voice_name = '';
+
+        if ($template_or_context instanceof AIPS_Generation_Context) {
+            $topic = (string) $template_or_context->get_topic();
+            $content_prompt = (string) $template_or_context->get_content_prompt();
+            $template_name = (string) $template_or_context->get_name();
+            $title_prompt = (string) $template_or_context->get_title_prompt();
+            $article_structure_id = $template_or_context->get_article_structure_id();
+            $voice = $template_or_context->get_voice();
+            if ($voice && isset($voice->name)) {
+                $voice_name = $voice->name;
+            }
+        } else {
+            $topic = isset($seed['topic']) ? (string) $seed['topic'] : '';
+            $content_prompt = isset($template_or_context->prompt_template) ? (string) $template_or_context->prompt_template : '';
+            $template_name = isset($template_or_context->name) ? (string) $template_or_context->name : '';
+            $title_prompt = isset($template_or_context->title_prompt) ? (string) $template_or_context->title_prompt : '';
+            $article_structure_id = isset($template_or_context->article_structure_id) ? $template_or_context->article_structure_id : null;
+            if (!empty($template_or_context->voice_id)) {
+                $voice = $this->get_voice((int) $template_or_context->voice_id);
+                if ($voice && isset($voice->name)) {
+                    $voice_name = $voice->name;
+                }
+            }
+        }
+
+        $structure_summary = '';
+        if (!empty($article_structure_id)) {
+            $structure = $this->structure_manager->get_structure($article_structure_id);
+            if (is_array($structure) && !empty($structure['name'])) {
+                $structure_summary = $structure['name'];
+                if (!empty($structure['prompt_template'])) {
+                    $structure_summary .= "\n" . $structure['prompt_template'];
+                }
+            }
+        }
+
+        return array_merge(
+            array(
+                'template_name' => $template_name,
+                'topic' => $topic,
+                'content_prompt' => $content_prompt,
+                'title_prompt' => $title_prompt,
+                'voice_name' => $voice_name,
+                'site_context' => $this->build_site_context_block(),
+                'article_structure' => $structure_summary,
+                'title' => '',
+                'excerpt' => '',
+                'content' => '',
+                'featured_image_prompt' => '',
+            ),
+            is_array($seed) ? $seed : array()
+        );
+    }
+
+    /**
+     * Build a story package prompt for a specific artifact.
+     *
+     * @param string                         $output_key Story package output key.
+     * @param object|AIPS_Generation_Context $template_or_context Template object or generation context.
+     * @param array                          $shared_context Shared generation context.
+     * @return string
+     */
+    public function build_story_package_prompt($output_key, $template_or_context, $shared_context = array()) {
+        $definitions = AIPS_Story_Package::get_output_definitions();
+        if (!isset($definitions[$output_key])) {
+            return '';
+        }
+
+        $shared_context = is_array($shared_context) ? $shared_context : array();
+        $parts = array();
+
+        if (!empty($shared_context['site_context'])) {
+            $parts[] = trim((string) $shared_context['site_context']);
+        }
+
+        if (!empty($shared_context['template_name'])) {
+            $parts[] = 'Template: ' . $shared_context['template_name'];
+        }
+
+        if (!empty($shared_context['topic'])) {
+            $parts[] = 'Topic: ' . $shared_context['topic'];
+        }
+
+        if (!empty($shared_context['voice_name'])) {
+            $parts[] = 'Voice: ' . $shared_context['voice_name'];
+        }
+
+        if (!empty($shared_context['article_structure'])) {
+            $parts[] = "Article structure guidance:
+" . $shared_context['article_structure'];
+        }
+
+        if (!empty($shared_context['content_prompt'])) {
+            $parts[] = "Original content prompt:
+" . $shared_context['content_prompt'];
+        }
+
+        if (!empty($shared_context['title_prompt'])) {
+            $parts[] = "Title prompt guidance:
+" . $shared_context['title_prompt'];
+        }
+
+        if (!empty($shared_context['title'])) {
+            $parts[] = 'Current article title: ' . $shared_context['title'];
+        }
+
+        if (!empty($shared_context['excerpt'])) {
+            $parts[] = "Current excerpt/dek context:
+" . $shared_context['excerpt'];
+        }
+
+        if (!empty($shared_context['content'])) {
+            $parts[] = "Current article body:
+" . $shared_context['content'];
+        }
+
+        if (!empty($shared_context['featured_image_prompt'])) {
+            $parts[] = "Featured image prompt or visual direction:
+" . $shared_context['featured_image_prompt'];
+        }
+
+        $instructions = array(
+            'seo_title_dek' => "Generate an SEO package for this story. Provide: 1) an SEO title under 65 characters, and 2) a dek/subheading of 1-2 sentences. Use labels 'SEO Title:' and 'Dek:'.",
+            'social_posts' => "Generate 3 coordinated social posts for different channels. Label them 'Post 1', 'Post 2', and 'Post 3'. Keep each distinct, concise, and ready for editors to adapt.",
+            'newsletter_summary' => "Write a newsletter-ready summary for this story in 2 short paragraphs plus a single CTA line.",
+            'faq_box' => "Write an FAQ box with 3-5 question-and-answer pairs grounded in this story. Format as plain text with 'Q:' and 'A:' labels.",
+            'pull_quotes' => "Write 3 strong pull quotes sourced from the story's main ideas. Format as bullet points.",
+            'meta_description' => "Write one meta description under 155 characters. Return only the meta description text.",
+            'featured_image_brief' => "Write a featured image brief for design or AI image production. Include subject, scene, mood, composition, and any text-overlay guidance.",
+        );
+
+        if (!isset($instructions[$output_key])) {
+            return '';
+        }
+
+        $parts[] = $instructions[$output_key];
+
+        return implode("
+
+", array_filter(array_map('trim', $parts)));
     }
 
     /**

--- a/ai-post-scheduler/includes/class-aips-session-to-json.php
+++ b/ai-post-scheduler/includes/class-aips-session-to-json.php
@@ -53,6 +53,7 @@ class AIPS_Session_To_JSON {
 			'post_id' => $history_item->post_id,
 			'wp_post' => $this->get_wp_post_data($history_item->post_id),
 			'history' => $this->format_history_item($history_item),
+			'story_package' => $history_item->post_id ? AIPS_Story_Package::get_post_package($history_item->post_id) : array(),
 			'history_containers' => $this->get_history_containers($history_item),
 		);
 		
@@ -171,6 +172,7 @@ class AIPS_Session_To_JSON {
 			'error_message' => $history_item->error_message,
 			'created_at' => $history_item->created_at,
 			'completed_at' => $history_item->completed_at,
+			'story_package_enabled' => !empty($history_item->post_id) && AIPS_Story_Package::post_has_package($history_item->post_id),
 		);
 	}
 	

--- a/ai-post-scheduler/includes/class-aips-story-package.php
+++ b/ai-post-scheduler/includes/class-aips-story-package.php
@@ -1,0 +1,288 @@
+<?php
+/**
+ * Story Package helper.
+ *
+ * Centralizes template configuration, prompt metadata, and persistence helpers
+ * for coordinated editorial packages generated alongside a post.
+ *
+ * @package AI_Post_Scheduler
+ * @since 2.1.0
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+/**
+ * Class AIPS_Story_Package
+ */
+class AIPS_Story_Package {
+
+	/**
+	 * Post meta key used to store the latest generated package artifacts.
+	 */
+	const POST_META_KEY = 'aips_story_package_artifacts';
+
+	/**
+	 * Get all supported story package outputs.
+	 *
+	 * @return array
+	 */
+	public static function get_output_definitions() {
+		return array(
+			'full_article' => array(
+				'label' => __('Full Article', 'ai-post-scheduler'),
+				'description' => __('The main post title, excerpt, and article body that WordPress publishes.', 'ai-post-scheduler'),
+				'component' => 'story_package_full_article',
+				'format' => 'article',
+			),
+			'seo_title_dek' => array(
+				'label' => __('SEO Title + Dek', 'ai-post-scheduler'),
+				'description' => __('A search-focused title and supporting dek/subheading for editorial review.', 'ai-post-scheduler'),
+				'component' => 'story_package_seo_title_dek',
+				'format' => 'text',
+			),
+			'social_posts' => array(
+				'label' => __('Social Posts', 'ai-post-scheduler'),
+				'description' => __('Platform-ready social copy variations built from the same story angle.', 'ai-post-scheduler'),
+				'component' => 'story_package_social_posts',
+				'format' => 'text',
+			),
+			'newsletter_summary' => array(
+				'label' => __('Newsletter Summary', 'ai-post-scheduler'),
+				'description' => __('A concise email/newsletter version of the same story.', 'ai-post-scheduler'),
+				'component' => 'story_package_newsletter_summary',
+				'format' => 'text',
+			),
+			'faq_box' => array(
+				'label' => __('FAQ Box', 'ai-post-scheduler'),
+				'description' => __('Frequently asked questions and answers derived from the article context.', 'ai-post-scheduler'),
+				'component' => 'story_package_faq_box',
+				'format' => 'text',
+			),
+			'pull_quotes' => array(
+				'label' => __('Pull Quotes', 'ai-post-scheduler'),
+				'description' => __('Memorable pull quotes editors can drop into layouts or social cards.', 'ai-post-scheduler'),
+				'component' => 'story_package_pull_quotes',
+				'format' => 'text',
+			),
+			'meta_description' => array(
+				'label' => __('Meta Description', 'ai-post-scheduler'),
+				'description' => __('A search snippet-ready meta description.', 'ai-post-scheduler'),
+				'component' => 'story_package_meta_description',
+				'format' => 'text',
+			),
+			'featured_image_brief' => array(
+				'label' => __('Featured Image Brief', 'ai-post-scheduler'),
+				'description' => __('A creative brief describing the hero image treatment for the story.', 'ai-post-scheduler'),
+				'component' => 'story_package_featured_image_brief',
+				'format' => 'text',
+			),
+		);
+	}
+
+	/**
+	 * Normalize a configured story package output list.
+	 *
+	 * @param mixed $outputs Raw configured outputs.
+	 * @return array
+	 */
+	public static function normalize_outputs($outputs) {
+		$definitions = self::get_output_definitions();
+		$normalized = array();
+
+		if (is_string($outputs) && '' !== $outputs) {
+			$decoded = json_decode($outputs, true);
+			if (is_array($decoded)) {
+				$outputs = $decoded;
+			} else {
+				$outputs = array_map('trim', explode(',', $outputs));
+			}
+		}
+
+		if (!is_array($outputs)) {
+			$outputs = array();
+		}
+
+		foreach ($outputs as $output) {
+			$key = sanitize_key($output);
+			if (isset($definitions[$key])) {
+				$normalized[] = $key;
+			}
+		}
+
+		$normalized = array_values(array_unique($normalized));
+
+		if (!in_array('full_article', $normalized, true)) {
+			array_unshift($normalized, 'full_article');
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Normalize a template's story package configuration.
+	 *
+	 * @param array|object $template Template configuration.
+	 * @return array
+	 */
+	public static function normalize_template_config($template) {
+		$enabled = false;
+		$outputs = array('full_article');
+
+		if (is_array($template)) {
+			$enabled = !empty($template['story_package_enabled']);
+			if (isset($template['story_package_outputs'])) {
+				$outputs = self::normalize_outputs($template['story_package_outputs']);
+			}
+		} elseif (is_object($template)) {
+			$enabled = !empty($template->story_package_enabled);
+			if (isset($template->story_package_outputs)) {
+				$outputs = self::normalize_outputs($template->story_package_outputs);
+			}
+		}
+
+		return array(
+			'enabled' => (bool) $enabled,
+			'outputs' => $outputs,
+		);
+	}
+
+	/**
+	 * Build a default package payload from artifacts.
+	 *
+	 * @param array $outputs Selected outputs.
+	 * @param array $artifacts Artifact payloads keyed by output slug.
+	 * @return array
+	 */
+	public static function build_package_payload($outputs, $artifacts) {
+		$outputs = self::normalize_outputs($outputs);
+		$definitions = self::get_output_definitions();
+		$payload_artifacts = array();
+
+		foreach ($outputs as $output_key) {
+			$definition = isset($definitions[$output_key]) ? $definitions[$output_key] : array();
+			$artifact = isset($artifacts[$output_key]) && is_array($artifacts[$output_key]) ? $artifacts[$output_key] : array();
+
+			$payload_artifacts[$output_key] = array_merge(
+				array(
+					'key' => $output_key,
+					'label' => isset($definition['label']) ? $definition['label'] : $output_key,
+					'component' => isset($definition['component']) ? $definition['component'] : $output_key,
+					'format' => isset($definition['format']) ? $definition['format'] : 'text',
+					'content' => '',
+					'generated_at' => current_time('mysql'),
+				),
+				$artifact
+			);
+		}
+
+		return array(
+			'version' => 1,
+			'outputs' => $outputs,
+			'artifacts' => $payload_artifacts,
+			'generated_at' => current_time('mysql'),
+		);
+	}
+
+	/**
+	 * Persist a package payload for a post.
+	 *
+	 * @param int   $post_id Post ID.
+	 * @param array $package Package payload.
+	 * @return bool
+	 */
+	public static function save_post_package($post_id, $package) {
+		$post_id = absint($post_id);
+		if (!$post_id) {
+			return false;
+		}
+
+		return false !== update_post_meta($post_id, self::POST_META_KEY, wp_json_encode($package));
+	}
+
+	/**
+	 * Read a package payload for a post.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return array
+	 */
+	public static function get_post_package($post_id) {
+		$post_id = absint($post_id);
+		if (!$post_id) {
+			return array();
+		}
+
+		$raw = get_post_meta($post_id, self::POST_META_KEY, true);
+		if (empty($raw)) {
+			return array();
+		}
+
+		if (is_array($raw)) {
+			return $raw;
+		}
+
+		$decoded = json_decode((string) $raw, true);
+
+		return is_array($decoded) ? $decoded : array();
+	}
+
+	/**
+	 * Check if a post has stored package artifacts.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return bool
+	 */
+	public static function post_has_package($post_id) {
+		$package = self::get_post_package($post_id);
+		return !empty($package['artifacts']) && is_array($package['artifacts']);
+	}
+
+	/**
+	 * Update a single artifact inside an existing package payload.
+	 *
+	 * @param int    $post_id Post ID.
+	 * @param string $artifact_key Artifact key.
+	 * @param array  $artifact Artifact payload.
+	 * @return array Updated package payload.
+	 */
+	public static function update_post_artifact($post_id, $artifact_key, $artifact) {
+		$package = self::get_post_package($post_id);
+		$definitions = self::get_output_definitions();
+		$artifact_key = sanitize_key($artifact_key);
+
+		if (!isset($definitions[$artifact_key])) {
+			return $package;
+		}
+
+		if (empty($package)) {
+			$package = self::build_package_payload(array($artifact_key), array());
+		}
+
+		$outputs = isset($package['outputs']) ? self::normalize_outputs($package['outputs']) : array('full_article');
+		if (!in_array($artifact_key, $outputs, true)) {
+			$outputs[] = $artifact_key;
+		}
+
+		$package['outputs'] = self::normalize_outputs($outputs);
+		if (!isset($package['artifacts']) || !is_array($package['artifacts'])) {
+			$package['artifacts'] = array();
+		}
+
+		$package['artifacts'][$artifact_key] = array_merge(
+			array(
+				'key' => $artifact_key,
+				'label' => $definitions[$artifact_key]['label'],
+				'component' => $definitions[$artifact_key]['component'],
+				'format' => $definitions[$artifact_key]['format'],
+				'generated_at' => current_time('mysql'),
+			),
+			is_array($artifact) ? $artifact : array('content' => $artifact)
+		);
+
+		$package['generated_at'] = current_time('mysql');
+		self::save_post_package($post_id, $package);
+
+		return $package;
+	}
+}

--- a/ai-post-scheduler/includes/class-aips-template-repository.php
+++ b/ai-post-scheduler/includes/class-aips-template-repository.php
@@ -120,6 +120,7 @@ class AIPS_Template_Repository {
 
         $insert_data = array(
             'name' => sanitize_text_field($data['name']),
+            'description' => isset($data['description']) ? sanitize_textarea_field($data['description']) : '',
             'prompt_template' => wp_kses_post($data['prompt_template']),
             'title_prompt' => isset($data['title_prompt']) ? sanitize_text_field($data['title_prompt']) : '',
             'voice_id' => isset($data['voice_id']) ? absint($data['voice_id']) : null,
@@ -135,10 +136,12 @@ class AIPS_Template_Repository {
             'post_author' => isset($data['post_author']) ? absint($data['post_author']) : get_current_user_id(),
             'include_sources' => isset($data['include_sources']) ? (int) $data['include_sources'] : 0,
             'source_group_ids' => isset($data['source_group_ids']) ? sanitize_text_field($data['source_group_ids']) : wp_json_encode(array()),
+            'story_package_enabled' => !empty($data['story_package_enabled']) ? 1 : 0,
+            'story_package_outputs' => isset($data['story_package_outputs']) ? sanitize_text_field($data['story_package_outputs']) : wp_json_encode(array('full_article')),
             'is_active' => isset($data['is_active']) ? 1 : 0,
         );
         
-        $format = array('%s', '%s', '%s', '%d', '%d', '%s', '%d', '%s', '%s', '%s', '%s', '%d', '%s', '%d', '%d', '%s', '%d');
+        $format = array('%s', '%s', '%s', '%s', '%d', '%d', '%s', '%d', '%s', '%s', '%s', '%s', '%d', '%s', '%d', '%d', '%s', '%d', '%s', '%d');
         
         $result = $this->wpdb->insert($this->table_name, $insert_data, $format);
         
@@ -162,6 +165,11 @@ class AIPS_Template_Repository {
             $format[] = '%s';
         }
         
+        if (isset($data['description'])) {
+            $update_data['description'] = sanitize_textarea_field($data['description']);
+            $format[] = '%s';
+        }
+
         if (isset($data['prompt_template'])) {
             $update_data['prompt_template'] = wp_kses_post($data['prompt_template']);
             $format[] = '%s';
@@ -238,6 +246,16 @@ class AIPS_Template_Repository {
             $format[] = '%s';
         }
         
+        if (isset($data['story_package_enabled'])) {
+            $update_data['story_package_enabled'] = $data['story_package_enabled'] ? 1 : 0;
+            $format[] = '%d';
+        }
+
+        if (isset($data['story_package_outputs'])) {
+            $update_data['story_package_outputs'] = sanitize_text_field($data['story_package_outputs']);
+            $format[] = '%s';
+        }
+
         if (isset($data['is_active'])) {
             $update_data['is_active'] = $data['is_active'] ? 1 : 0;
             $format[] = '%d';

--- a/ai-post-scheduler/includes/class-aips-templates-controller.php
+++ b/ai-post-scheduler/includes/class-aips-templates-controller.php
@@ -48,6 +48,8 @@ class AIPS_Templates_Controller {
             'source_group_ids' => isset($_POST['source_group_ids']) && is_array($_POST['source_group_ids'])
                 ? wp_json_encode(array_map('absint', $_POST['source_group_ids']))
                 : wp_json_encode(array()),
+            'story_package_enabled' => isset($_POST['story_package_enabled']) ? 1 : 0,
+            'story_package_outputs' => $this->get_story_package_outputs_from_request(),
             'is_active' => isset($_POST['is_active']) ? 1 : 0,
         );
 
@@ -150,6 +152,8 @@ class AIPS_Templates_Controller {
             'post_author' => $template->post_author,
             'include_sources' => isset($template->include_sources) ? $template->include_sources : 0,
             'source_group_ids' => isset($template->source_group_ids) ? $template->source_group_ids : wp_json_encode(array()),
+            'story_package_enabled' => isset($template->story_package_enabled) ? (int) $template->story_package_enabled : 0,
+            'story_package_outputs' => isset($template->story_package_outputs) ? $template->story_package_outputs : wp_json_encode(array('full_article')),
             'is_active' => $template->is_active,
         );
 
@@ -193,6 +197,8 @@ class AIPS_Templates_Controller {
             'post_category' => isset($_POST['post_category']) ? absint($_POST['post_category']) : 0,
             'post_tags' => isset($_POST['post_tags']) ? sanitize_text_field($_POST['post_tags']) : '',
             'post_author' => isset($_POST['post_author']) ? absint($_POST['post_author']) : get_current_user_id(),
+            'story_package_enabled' => isset($_POST['story_package_enabled']) ? 1 : 0,
+            'story_package_outputs' => $this->get_story_package_outputs_from_request(),
         );
 
         if (empty($data['prompt_template'])) {
@@ -257,6 +263,8 @@ class AIPS_Templates_Controller {
             'source_group_ids' => isset($_POST['source_group_ids']) && is_array($_POST['source_group_ids'])
                 ? wp_json_encode(array_map('absint', $_POST['source_group_ids']))
                 : wp_json_encode(array()),
+            'story_package_enabled' => isset($_POST['story_package_enabled']) ? 1 : 0,
+            'story_package_outputs' => $this->get_story_package_outputs_from_request(),
         );
 
         if (empty($template_data->prompt_template)) {
@@ -273,6 +281,21 @@ class AIPS_Templates_Controller {
         $result = $prompt_builder->build_prompts($template_data, null, $voice);
 
         wp_send_json_success($result);
+    }
+
+    /**
+     * Read and normalize story package output selections from the current request.
+     *
+     * @return string JSON-encoded list of output slugs.
+     */
+    private function get_story_package_outputs_from_request() {
+        $raw_outputs = isset($_POST['story_package_outputs']) ? wp_unslash($_POST['story_package_outputs']) : array();
+
+        if (!is_array($raw_outputs)) {
+            $raw_outputs = array($raw_outputs);
+        }
+
+        return wp_json_encode(AIPS_Story_Package::normalize_outputs($raw_outputs));
     }
 
     /**

--- a/ai-post-scheduler/includes/class-aips-templates.php
+++ b/ai-post-scheduler/includes/class-aips-templates.php
@@ -69,6 +69,8 @@ class AIPS_Templates {
             'post_author' => isset($data['post_author']) ? absint($data['post_author']) : get_current_user_id(),
             'include_sources' => isset($data['include_sources']) ? (int) $data['include_sources'] : 0,
             'source_group_ids' => isset($data['source_group_ids']) ? sanitize_text_field($data['source_group_ids']) : wp_json_encode(array()),
+            'story_package_enabled' => !empty($data['story_package_enabled']) ? 1 : 0,
+            'story_package_outputs' => isset($data['story_package_outputs']) ? sanitize_text_field($data['story_package_outputs']) : wp_json_encode(array('full_article')),
             'is_active' => isset($data['is_active']) ? 1 : 0,
         );
         

--- a/ai-post-scheduler/templates/admin/generated-posts.php
+++ b/ai-post-scheduler/templates/admin/generated-posts.php
@@ -148,12 +148,21 @@ if (!defined('ABSPATH')) {
 											<span class="dashicons dashicons-admin-customizer"></span>
 											<?php esc_html_e('AI Edit', 'ai-post-scheduler'); ?>
 										</button>
-								<button class="aips-btn aips-btn-sm aips-btn-secondary aips-view-session" 
-								        data-history-id="<?php echo esc_attr($post_data['history_id']); ?>"
-								        title="<?php esc_attr_e('View Session', 'ai-post-scheduler'); ?>">
-									<span class="dashicons dashicons-visibility"></span>
-									<?php esc_html_e('View Session', 'ai-post-scheduler'); ?>
+										<button class="aips-btn aips-btn-sm aips-btn-secondary aips-view-session" 
+										        data-history-id="<?php echo esc_attr($post_data['history_id']); ?>"
+										        title="<?php esc_attr_e('View Session', 'ai-post-scheduler'); ?>">
+											<span class="dashicons dashicons-visibility"></span>
+											<?php esc_html_e('View Session', 'ai-post-scheduler'); ?>
 										</button>
+										<?php if (!empty($post_data['has_story_package'])): ?>
+										<button class="aips-btn aips-btn-sm aips-btn-secondary aips-view-session"
+										        data-history-id="<?php echo esc_attr($post_data['history_id']); ?>"
+										        data-session-tab="package"
+										        title="<?php esc_attr_e('Review Story Package', 'ai-post-scheduler'); ?>">
+											<span class="dashicons dashicons-screenoptions"></span>
+											<?php esc_html_e('Review Package', 'ai-post-scheduler'); ?>
+										</button>
+										<?php endif; ?>
 									</div>
 								</td>
 							</tr>
@@ -352,12 +361,21 @@ if (!defined('ABSPATH')) {
 											<span class="dashicons dashicons-admin-customizer"></span>
 											<?php esc_html_e('AI Edit', 'ai-post-scheduler'); ?>
 										</button>
-								<button class="aips-btn aips-btn-sm aips-btn-secondary aips-view-session"
-									data-history-id="<?php echo esc_attr($post_data['history_id']); ?>"
-									title="<?php esc_attr_e('View Session', 'ai-post-scheduler'); ?>">
-									<span class="dashicons dashicons-visibility"></span>
-									<?php esc_html_e('View Session', 'ai-post-scheduler'); ?>
+										<button class="aips-btn aips-btn-sm aips-btn-secondary aips-view-session"
+											data-history-id="<?php echo esc_attr($post_data['history_id']); ?>"
+											title="<?php esc_attr_e('View Session', 'ai-post-scheduler'); ?>">
+											<span class="dashicons dashicons-visibility"></span>
+											<?php esc_html_e('View Session', 'ai-post-scheduler'); ?>
 										</button>
+										<?php if (!empty($post_data['has_story_package'])): ?>
+										<button class="aips-btn aips-btn-sm aips-btn-secondary aips-view-session"
+											data-history-id="<?php echo esc_attr($post_data['history_id']); ?>"
+											data-session-tab="package"
+											title="<?php esc_attr_e('Review Story Package', 'ai-post-scheduler'); ?>">
+											<span class="dashicons dashicons-screenoptions"></span>
+											<?php esc_html_e('Review Package', 'ai-post-scheduler'); ?>
+										</button>
+										<?php endif; ?>
 									</div>
 								</td>
 							</tr>

--- a/ai-post-scheduler/templates/admin/templates.php
+++ b/ai-post-scheduler/templates/admin/templates.php
@@ -62,6 +62,11 @@ if (!defined('ABSPATH')) {
                         <tr data-template-id="<?php echo esc_attr($template->id); ?>">
                             <td class="column-name">
                                 <div class="cell-primary"><?php echo esc_html($template->name); ?></div>
+                                <?php if (!empty($template->story_package_enabled)): ?>
+                                <div style="margin-top: 4px;">
+                                    <span class="aips-badge aips-badge-neutral"><?php esc_html_e('Story Package', 'ai-post-scheduler'); ?></span>
+                                </div>
+                                <?php endif; ?>
                             </td>
                             <td>
                                 <span class="aips-badge aips-badge-neutral">
@@ -393,6 +398,36 @@ if (!defined('ABSPATH')) {
                                 <?php endif; ?>
                             </div>
                         </div>
+
+                        <?php $story_package_outputs = AIPS_Story_Package::get_output_definitions(); ?>
+                        <div class="aips-form-row" style="margin-top: 20px;">
+                            <label class="aips-checkbox-label">
+                                <input type="checkbox" id="story_package_enabled" name="story_package_enabled" value="1">
+                                <?php esc_html_e('Generate a coordinated story package', 'ai-post-scheduler'); ?>
+                            </label>
+                            <p class="description"><?php esc_html_e('Create additional editorial artifacts from the same approved topic or budget item so reviewers can inspect the full package together.', 'ai-post-scheduler'); ?></p>
+                        </div>
+
+                        <div id="aips-story-package-options" style="display:none; margin-top: 8px;">
+                            <div class="aips-form-row">
+                                <label><?php esc_html_e('Package Outputs', 'ai-post-scheduler'); ?></label>
+                                <div class="aips-checkbox-group">
+                                    <?php foreach ($story_package_outputs as $story_output_key => $story_output): ?>
+                                        <label class="aips-checkbox-label" style="display:block; margin-bottom:6px;">
+                                            <input type="checkbox"
+                                                name="story_package_outputs[]"
+                                                class="aips-story-package-output"
+                                                value="<?php echo esc_attr($story_output_key); ?>"
+                                                <?php checked('full_article', $story_output_key); ?>
+                                                <?php disabled('full_article', $story_output_key); ?>>
+                                            <strong><?php echo esc_html($story_output['label']); ?></strong>
+                                            <span class="description" style="display:block; margin-left: 24px;"><?php echo esc_html($story_output['description']); ?></span>
+                                        </label>
+                                    <?php endforeach; ?>
+                                </div>
+                                <p class="description"><?php esc_html_e('The full article remains the anchor asset. Add any supporting outputs your editors want to review or regenerate individually.', 'ai-post-scheduler'); ?></p>
+                            </div>
+                        </div>
                     </div>
                     
                     <!-- Step 4: Featured Image -->
@@ -480,6 +515,10 @@ if (!defined('ABSPATH')) {
                                 <div class="aips-summary-item">
                                     <strong><?php esc_html_e('Featured Image:', 'ai-post-scheduler'); ?></strong>
                                     <span id="summary_featured_image"><?php esc_html_e('No', 'ai-post-scheduler'); ?></span>
+                                </div>
+                                <div class="aips-summary-item">
+                                    <strong><?php esc_html_e('Story Package:', 'ai-post-scheduler'); ?></strong>
+                                    <span id="summary_story_package"><?php esc_html_e('Article only', 'ai-post-scheduler'); ?></span>
                                 </div>
                             </div>
                         </div>

--- a/ai-post-scheduler/templates/partials/view-session-modal.php
+++ b/ai-post-scheduler/templates/partials/view-session-modal.php
@@ -43,6 +43,7 @@ if (!defined('ABSPATH')) {
 				<ul class="aips-tab-nav">
 					<li><a href="#aips-tab-logs" class="active"><?php esc_html_e('Logs', 'ai-post-scheduler'); ?></a></li>
 					<li><a href="#aips-tab-ai"><?php esc_html_e('AI', 'ai-post-scheduler'); ?></a></li>
+					<li><a href="#aips-tab-package"><?php esc_html_e('Package', 'ai-post-scheduler'); ?></a></li>
 				</ul>
 				
 				<div id="aips-tab-logs" class="aips-tab-content active">
@@ -51,6 +52,10 @@ if (!defined('ABSPATH')) {
 				
 				<div id="aips-tab-ai" class="aips-tab-content" style="display: none;">
 					<div id="aips-ai-list"></div>
+				</div>
+
+				<div id="aips-tab-package" class="aips-tab-content" style="display: none;">
+					<div id="aips-package-list"></div>
 				</div>
 			</div>
 		</div>

--- a/ai-post-scheduler/tests/bootstrap.php
+++ b/ai-post-scheduler/tests/bootstrap.php
@@ -928,6 +928,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
         'class-aips-prompt-section-repository.php',
         'class-aips-sources-repository.php',
         'class-aips-template-processor.php',
+        'class-aips-story-package.php',
         'class-aips-prompt-builder.php',
         'class-aips-prompt-builder-post-content.php',
         'class-aips-prompt-builder-post-title.php',

--- a/ai-post-scheduler/tests/test-story-package.php
+++ b/ai-post-scheduler/tests/test-story-package.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Tests for story package helpers and prompt builder integration.
+ *
+ * @package AI_Post_Scheduler
+ */
+
+class Test_AIPS_Story_Package extends WP_UnitTestCase {
+
+	public function test_normalize_outputs_keeps_supported_keys_and_forces_full_article() {
+		$result = AIPS_Story_Package::normalize_outputs(array('social_posts', 'meta_description', 'unknown'));
+
+		$this->assertSame(
+			array('full_article', 'social_posts', 'meta_description'),
+			$result
+		);
+	}
+
+	public function test_build_package_payload_adds_labels_and_components() {
+		$payload = AIPS_Story_Package::build_package_payload(
+			array('full_article', 'newsletter_summary'),
+			array(
+				'newsletter_summary' => array(
+					'content' => 'A short email-ready summary.',
+				),
+			)
+		);
+
+		$this->assertArrayHasKey('artifacts', $payload);
+		$this->assertSame('newsletter_summary', $payload['artifacts']['newsletter_summary']['key']);
+		$this->assertSame('story_package_newsletter_summary', $payload['artifacts']['newsletter_summary']['component']);
+		$this->assertSame('A short email-ready summary.', $payload['artifacts']['newsletter_summary']['content']);
+	}
+
+	public function test_prompt_builder_includes_story_package_prompts_when_enabled() {
+		$builder = new AIPS_Prompt_Builder(new AIPS_Template_Processor(), new AIPS_Article_Structure_Manager());
+		$template = (object) array(
+			'prompt_template' => 'Write about {{topic}}',
+			'title_prompt' => 'Create a title about {{topic}}',
+			'image_prompt' => 'Illustrate {{topic}}',
+			'voice_id' => 0,
+			'article_structure_id' => 0,
+			'include_sources' => 0,
+			'story_package_enabled' => 1,
+			'story_package_outputs' => wp_json_encode(array('full_article', 'newsletter_summary', 'meta_description')),
+		);
+
+		$result = $builder->build_prompts($template, 'AI policy');
+
+		$this->assertArrayHasKey('story_package', $result['prompts']);
+		$this->assertArrayHasKey('newsletter_summary', $result['prompts']['story_package']);
+		$this->assertArrayHasKey('meta_description', $result['prompts']['story_package']);
+		$this->assertStringContainsString('newsletter-ready summary', $result['prompts']['story_package']['newsletter_summary']);
+		$this->assertSame(
+			array('full_article', 'newsletter_summary', 'meta_description'),
+			$result['metadata']['story_package_outputs']
+		);
+	}
+}

--- a/ai-post-scheduler/tests/test-templates-controller-save.php
+++ b/ai-post-scheduler/tests/test-templates-controller-save.php
@@ -124,4 +124,30 @@ class Test_AIPS_Templates_Controller_Save extends WP_UnitTestCase {
 		$this->assertNotNull($this->templates_stub->saved_data);
 		$this->assertSame(0, $this->templates_stub->saved_data['generate_featured_image']);
 	}
+
+	public function test_ajax_save_template_normalizes_story_package_outputs() {
+		$_POST['nonce'] = wp_create_nonce('aips_ajax_nonce');
+		$_POST['name'] = 'Template with story package';
+		$_POST['prompt_template'] = 'Write about {{topic}}';
+		$_POST['story_package_enabled'] = '1';
+		$_POST['story_package_outputs'] = array('social_posts', 'meta_description');
+		$_REQUEST = $_POST;
+
+		ob_start();
+		try {
+			$this->controller->ajax_save_template();
+		} catch (WPAjaxDieStopException $e) {
+			// Expected for wp_send_json_* in tests.
+		} catch (WPAjaxDieContinueException $e) {
+			// Some environments throw continue exceptions for AJAX responses.
+		}
+		ob_end_clean();
+
+		$this->assertNotNull($this->templates_stub->saved_data);
+		$this->assertSame(1, $this->templates_stub->saved_data['story_package_enabled']);
+		$this->assertSame(
+			wp_json_encode(array('full_article', 'social_posts', 'meta_description')),
+			$this->templates_stub->saved_data['story_package_outputs']
+		);
+	}
 }


### PR DESCRIPTION
### Motivation

- Provide a way for editors to request a coordinated “story package” (article + supporting artifacts) from a single approved topic or template so reviewers can inspect a complete editorial package. 
- Let editors choose which package outputs (SEO title/dek, social posts, newsletter summary, FAQ, pull quotes, meta description, featured image brief, etc.) to generate alongside the article. 
- Reuse existing prompt builders, generation context, and partial-regeneration flows so artifacts share context, are observable in history, and can be regenerated per-artifact.

### Description

- Added a new helper/model `AIPS_Story_Package` to define outputs, normalize selections, build payloads, persist artifacts to post meta, and update individual artifacts (`includes/class-aips-story-package.php`).
- Persisted template-level package settings and outputs in templates schema and repository, and exposed them in the templates controller (`includes/class-aips-db-manager.php`, `includes/class-aips-template-repository.php`, `includes/class-aips-templates-controller.php`, `includes/class-aips-templates.php`).
- Extended the prompt builder and generator to build per-artifact prompts from a shared package context, request artifact generation during post creation/preview, extract SEO/meta hints into post metadata when available, and save the finalized package to post/session data (`includes/class-aips-prompt-builder.php`, `includes/class-aips-generator.php`).
- Exposed package artifacts in the Generated Posts session view and session JSON, added a new Package tab and "Review Package" action in the Generated Posts UI, and added client-side controls to preview and regenerate individual artifacts (`templates/admin/generated-posts.php`, `templates/partials/view-session-modal.php`, `assets/js/admin-view-session.js`, `assets/js/admin.js`).
- Wired regeneration flows so package artifacts can be regenerated using the existing component regeneration pattern and history container logging; added support for regenerating package artifacts in the AI Edit controller and regeneration service (`includes/class-aips-ai-edit-controller.php`, `includes/class-aips-component-regeneration-service.php`).
- Included session export and viewer changes so story-package payloads and per-artifact revisions are available via the session JSON/API (`includes/class-aips-session-to-json.php`, `includes/class-aips-generated-posts-controller.php`).
- Added unit tests covering core story-package helpers and the templates controller save normalization (`tests/test-story-package.php`, updated `tests/test-templates-controller-save.php`) and registered the new helper in tests bootstrap.

### Testing

- Performed PHP syntax checks with `php -l` for modified PHP files, which reported no syntax errors for the primary changed files (`class-aips-story-package.php`, `class-aips-generator.php`, `class-aips-prompt-builder.php`, `templates/admin/generated-posts.php`, etc.).
- Performed JavaScript syntax checks with `node --check` for `assets/js/admin.js` and `assets/js/admin-view-session.js` after iterating on fixes; no syntax errors detected.
- Attempted to run targeted PHPUnit tests `tests/test-story-package.php` and `tests/test-templates-controller-save.php` but `vendor/bin/phpunit` was not available in this environment (PHPUnit run was therefore not executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf591f299883218543c519ea228897)