### PR TITLE
Add live coverage workflows for generated stories

### DIFF
--- a/ai-post-scheduler/assets/css/admin.css
+++ b/ai-post-scheduler/assets/css/admin.css
@@ -3380,3 +3380,82 @@ margin-right: 8px;
     display: block;
 }
 
+
+.aips-live-story-badges {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+	margin-top: 6px;
+}
+
+.aips-live-story-meta {
+	margin-top: 6px;
+	font-size: 12px;
+	color: #50575e;
+}
+
+.aips-live-story-panel {
+	margin-top: 10px;
+	border: 1px solid #dcdcde;
+	border-radius: 6px;
+	background: #fff;
+}
+
+.aips-live-story-panel summary {
+	padding: 10px 14px;
+	cursor: pointer;
+	font-weight: 600;
+}
+
+.aips-live-story-panel-body {
+	padding: 14px;
+	border-top: 1px solid #f0f0f1;
+	display: grid;
+	gap: 12px;
+}
+
+.aips-live-story-form-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+	gap: 12px;
+}
+
+.aips-live-story-form-grid label,
+.aips-live-story-panel-body > label {
+	display: grid;
+	gap: 6px;
+	font-weight: 600;
+}
+
+.aips-live-story-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
+.aips-live-story-history {
+	margin: 0;
+	padding-left: 18px;
+	display: grid;
+	gap: 10px;
+}
+
+.aips-live-story-history li {
+	margin: 0;
+}
+
+.aips-live-story-history-meta {
+	font-size: 12px;
+	color: #50575e;
+	margin-top: 4px;
+}
+
+.aips-live-story-status-live {
+	background: #fbeaea;
+	color: #8a2424;
+}
+
+.aips-live-story-status-developing {
+	background: #fff3cd;
+	color: #8a5800;
+}

--- a/ai-post-scheduler/assets/css/calendar.css
+++ b/ai-post-scheduler/assets/css/calendar.css
@@ -417,3 +417,13 @@
 .aips-calendar-more-events:hover {
 	background: #e5f0fa;
 }
+
+.aips-calendar-event.color-live {
+	background: #8e44ad;
+	color: #fff;
+}
+
+.aips-calendar-event.color-live-developing {
+	background: #ff8c00;
+	color: #fff;
+}

--- a/ai-post-scheduler/assets/js/admin-generated-posts.js
+++ b/ai-post-scheduler/assets/js/admin-generated-posts.js
@@ -1,80 +1,149 @@
 /**
  * Generated Posts Admin JavaScript
  *
- * Handles the Generated Posts page.
- * View Session functionality is now in admin-view-session.js (reusable module).
+ * Handles Generated Posts interactions including live-story controls.
  *
  * @package AI_Post_Scheduler
  * @since 2.0.0
  */
 (function($) {
+	'use strict';
 
-  // Initialize on document ready
-  $(document).ready(function() {
-      // View Session functionality is automatically initialized by admin-view-session.js
+	function getPanelData($panel) {
+		return {
+			post_id: $panel.data('post-id'),
+			history_id: $panel.data('history-id'),
+			is_live_story: $panel.find('.aips-live-story-flag').is(':checked') ? 1 : 0,
+			story_status: $panel.find('.aips-live-story-status').val(),
+			thread_identifier: $panel.find('.aips-live-story-thread').val(),
+			parent_story_id: $panel.find('.aips-live-story-parent').val(),
+			update_brief: $panel.find('.aips-live-story-brief').val(),
+			update_reason: $panel.find('.aips-live-story-reason').val(),
+			published_at: $panel.find('.aips-live-story-published-at').val(),
+			is_major_update: $panel.find('.aips-live-story-major').is(':checked') ? 1 : 0
+		};
+	}
 
-      // Post Preview Modal - Hover functionality
-      var previewModal = $('#aips-post-preview-modal');
-      var previewIframe = $('#aips-post-preview-iframe');
-      var hoverTimeout;
-      
-      // Show preview on hover
-      $(document).on('click', '.aips-preview-trigger', function(e) {
-          clearTimeout(hoverTimeout);
-          
-          var postId = $(this).data('post-id');
-          var siteUrl = (aipsGeneratedPostsConfig && aipsGeneratedPostsConfig.siteUrl) ? aipsGeneratedPostsConfig.siteUrl : '';
-          var previewUrl = siteUrl + '/?p=' + postId + '&preview=true';
-          
-          previewIframe.attr('src', previewUrl);
-          previewModal.fadeIn(200);
-      });
-      
-      // Hide preview when leaving icon
-    //   $(document).on('mouseleave', '.aips-preview-trigger', function() {
-    //       hoverTimeout = setTimeout(function() {
-    //           if (!previewModal.is(':hover')) {
-    //               closePreviewModal();
-    //           }
-    //       }, 200);
-    //   });
-      
-      // Keep modal open when hovering over it
-    //   previewModal.on('mouseenter', function() {
-    //       clearTimeout(hoverTimeout);
-    //   });
-      
-    //   // Close when leaving modal
-    //   previewModal.on('mouseleave', function() {
-    //       hoverTimeout = setTimeout(function() {
-    //           closePreviewModal();
-    //       }, 200);
-    //   });
-      
-      // Close preview modal
-      /**
-       * Fade out the post preview modal and clear the iframe `src`.
-       *
-       * Clearing the `src` stops any in-progress page load inside the iframe
-       * and frees the memory used by the preview URL.
-       */
-      function closePreviewModal() {
-          previewModal.fadeOut(200, function() {
-              previewIframe.attr('src', '');
-          });
-      }
-      
-      // Close button handler
-      $(document).on('click', '#aips-post-preview-modal .aips-modal-close', function(e) {
-          e.preventDefault();
-          closePreviewModal();
-      });
-      
-      // Close on Escape key
-      $(document).on('keydown', function(e) {
-          if (e.key === 'Escape' && previewModal.is(':visible')) {
-              closePreviewModal();
-          }
-      });
-  });
+	function renderHistory($panel, items) {
+		var $history = $panel.find('.aips-live-story-history');
+		$history.empty();
+
+		if (!items || !items.length) {
+			$history.append($('<li>').text(aipsGeneratedPostsConfig.noLiveHistory || 'No live-story updates recorded yet.'));
+			return;
+		}
+
+		items.forEach(function(item) {
+			var meta = [];
+			if (item.published_at) {
+				meta.push(item.published_at);
+			}
+			if (item.update_reason) {
+				meta.push(item.update_reason);
+			}
+			if (item.changed_sections && item.changed_sections.length) {
+				meta.push(item.changed_sections.join(', '));
+			}
+
+			var $li = $('<li>');
+			$li.append($('<div>').text(item.message || ''));
+			$li.append($('<div>').addClass('aips-live-story-history-meta').text(meta.join(' · ')));
+			$history.append($li);
+		});
+	}
+
+	function updateStoryDisplay($panel, response) {
+		if (!response || !response.metadata) {
+			return;
+		}
+
+		var meta = response.metadata;
+		$panel.find('.aips-live-story-status').val(meta.story_status || '');
+		$panel.find('.aips-live-story-thread').val(meta.thread_identifier || '');
+		$panel.find('.aips-live-story-parent').val(meta.parent_story_id || '');
+		$panel.find('.aips-live-story-flag').prop('checked', !!meta.is_live_story);
+		if (response.top_summary) {
+			$panel.find('.aips-live-story-current-excerpt').text(response.top_summary);
+		}
+		if (response.headline) {
+			var $row = $panel.closest('tr');
+			$row.find('.cell-primary').first().text(response.headline);
+		}
+		if (response.change_history) {
+			renderHistory($panel, response.change_history);
+		}
+	}
+
+	function submitLiveAction($button, action, extraData) {
+		var $panel = $button.closest('.aips-live-story-panel-body');
+		var data = $.extend({
+			action: action,
+			nonce: aipsGeneratedPostsConfig.nonce
+		}, getPanelData($panel), extraData || {});
+
+		$button.prop('disabled', true);
+		$.post(aipsGeneratedPostsConfig.ajaxUrl, data)
+			.done(function(response) {
+				if (response && response.success) {
+					updateStoryDisplay($panel, response.data);
+					if (action === 'aips_live_story_append_update') {
+						$panel.find('.aips-live-story-brief, .aips-live-story-reason, .aips-live-story-published-at').val('');
+						$panel.find('.aips-live-story-major').prop('checked', false);
+					}
+					window.AIPS.Utilities.showToast(response.data.message || aipsGeneratedPostsConfig.liveStorySaved, 'success');
+				} else {
+					window.AIPS.Utilities.showToast((response && response.data && response.data.message) || aipsGeneratedPostsConfig.liveStoryError, 'error');
+				}
+			})
+			.fail(function() {
+				window.AIPS.Utilities.showToast(aipsGeneratedPostsConfig.liveStoryError, 'error');
+			})
+			.always(function() {
+				$button.prop('disabled', false);
+			});
+	}
+
+	$(document).ready(function() {
+		var previewModal = $('#aips-post-preview-modal');
+		var previewIframe = $('#aips-post-preview-iframe');
+
+		$(document).on('click', '.aips-preview-trigger', function() {
+			var postId = $(this).data('post-id');
+			var siteUrl = (aipsGeneratedPostsConfig && aipsGeneratedPostsConfig.siteUrl) ? aipsGeneratedPostsConfig.siteUrl : '';
+			previewIframe.attr('src', siteUrl + '/?p=' + postId + '&preview=true');
+			previewModal.fadeIn(200);
+		});
+
+		$(document).on('click', '#aips-post-preview-modal .aips-modal-close', function(e) {
+			e.preventDefault();
+			previewModal.fadeOut(200, function() {
+				previewIframe.attr('src', '');
+			});
+		});
+
+		$(document).on('keydown', function(e) {
+			if (e.key === 'Escape' && previewModal.is(':visible')) {
+				previewModal.fadeOut(200, function() {
+					previewIframe.attr('src', '');
+				});
+			}
+		});
+
+		$(document).on('click', '.aips-live-story-append', function(e) {
+			e.preventDefault();
+			submitLiveAction($(this), 'aips_live_story_append_update');
+		});
+
+		$(document).on('click', '.aips-live-story-regenerate', function(e) {
+			e.preventDefault();
+			submitLiveAction($(this), 'aips_live_story_regenerate_sections', {
+				sections: [$(this).data('sections')]
+			});
+		});
+
+		$(document).on('click', '.aips-live-story-refresh-history', function(e) {
+			e.preventDefault();
+			submitLiveAction($(this), 'aips_live_story_get_history');
+		});
+	});
 })(jQuery);

--- a/ai-post-scheduler/assets/js/calendar.js
+++ b/ai-post-scheduler/assets/js/calendar.js
@@ -516,7 +516,9 @@
 			// Determine color based on template ID
 			// Only assign specific colors to the first 3 templates; others get default color
 			var colorClass = 'color-default';
-			if (event.template_id) {
+			if (event.event_kind === 'live_story') {
+				colorClass = event.story_status === 'developing' ? 'color-live-developing' : 'color-live';
+			} else if (event.template_id) {
 				var templateId = parseInt(event.template_id, 10);
 				if (!isNaN(templateId) && templateId >= 1 && templateId <= templateColors.length) {
 					colorClass = templateColors[templateId - 1];
@@ -576,6 +578,7 @@
 			$('.aips-event-topic').text(event.topic || 'N/A');
 			$('.aips-event-category').text(event.category || 'N/A');
 			$('.aips-event-author').text(event.author || 'N/A');
+			$('.aips-event-story-status').text(event.story_status || 'N/A');
 			
 			// Show modal
 			$('#aips-calendar-event-modal').fadeIn(200);

--- a/ai-post-scheduler/includes/class-aips-admin-assets.php
+++ b/ai-post-scheduler/includes/class-aips-admin-assets.php
@@ -442,8 +442,13 @@ class AIPS_Admin_Assets {
             $config = AIPS_Config::get_instance();
             $client_threshold = (int) $config->get_option('generated_posts_log_threshold_client', 20);
             wp_localize_script('aips-admin-generated-posts', 'aipsGeneratedPostsConfig', array(
+                'ajaxUrl' => admin_url('admin-ajax.php'),
+                'nonce' => wp_create_nonce('aips_ajax_nonce'),
                 'clientLogThreshold' => $client_threshold,
                 'siteUrl' => home_url(),
+                'liveStorySaved' => __('Live story updated successfully.', 'ai-post-scheduler'),
+                'liveStoryError' => __('Failed to update the live story.', 'ai-post-scheduler'),
+                'noLiveHistory' => __('No live-story updates recorded yet.', 'ai-post-scheduler'),
             ));
             
             // Localize Post Review script for Pending Review tab

--- a/ai-post-scheduler/includes/class-aips-author-topics-generator.php
+++ b/ai-post-scheduler/includes/class-aips-author-topics-generator.php
@@ -56,6 +56,11 @@ class AIPS_Author_Topics_Generator {
 	private $prompt_builder;
 
 	/**
+	 * @var AIPS_Live_Coverage_Service Live coverage service.
+	 */
+	private $live_coverage_service;
+
+	/**
 	 * Initialize the generator.
 	 *
 	 * @param object|null $ai_service AI service instance (optional for testing).
@@ -74,6 +79,7 @@ class AIPS_Author_Topics_Generator {
 		$this->embeddings_service = $embeddings_service ?: new AIPS_Embeddings_Service($this->ai_service, $this->logger);
 		$this->feedback_repository = $feedback_repository ?: new AIPS_Feedback_Repository();
 		$this->prompt_builder = $prompt_builder ?: new AIPS_Prompt_Builder_Topic();
+		$this->live_coverage_service = new AIPS_Live_Coverage_Service();
 	}
 	
 	/**
@@ -270,6 +276,12 @@ class AIPS_Author_Topics_Generator {
 				continue;
 			}
 			
+			$metadata = $this->live_coverage_service->decorate_intake_metadata(array(
+				'generated_via' => 'ai_json',
+				'generation_date' => current_time('mysql'),
+				'keywords' => $keywords,
+			), $title);
+
 			// Create topic data
 			$topics[] = array(
 				'author_id' => $author->id,
@@ -277,11 +289,7 @@ class AIPS_Author_Topics_Generator {
 				'topic_prompt' => '', // Will be built when generating post
 				'status' => 'pending',
 				'score' => $score,
-				'metadata' => wp_json_encode(array(
-					'generated_via' => 'ai_json',
-					'generation_date' => current_time('mysql'),
-					'keywords' => $keywords
-				))
+				'metadata' => wp_json_encode($metadata)
 			);
 			
 			// Stop if we have enough topics
@@ -328,6 +336,11 @@ class AIPS_Author_Topics_Generator {
 			// Remove any quotes
 			$line = trim($line, '"\'');
 			
+			$metadata = $this->live_coverage_service->decorate_intake_metadata(array(
+				'generated_via' => 'ai',
+				'generation_date' => current_time('mysql'),
+			), $line);
+
 			// Create topic data
 			$topics[] = array(
 				'author_id' => $author->id,
@@ -335,10 +348,7 @@ class AIPS_Author_Topics_Generator {
 				'topic_prompt' => '', // Will be built when generating post
 				'status' => 'pending',
 				'score' => 50,
-				'metadata' => wp_json_encode(array(
-					'generated_via' => 'ai',
-					'generation_date' => current_time('mysql')
-				))
+				'metadata' => wp_json_encode($metadata)
 			);
 			
 			// Stop if we have enough topics

--- a/ai-post-scheduler/includes/class-aips-calendar-controller.php
+++ b/ai-post-scheduler/includes/class-aips-calendar-controller.php
@@ -28,6 +28,11 @@ class AIPS_Calendar_Controller {
 	 * @var AIPS_Template_Repository Template repository instance
 	 */
 	private $template_repo;
+
+	/**
+	 * @var AIPS_Live_Coverage_Service Live coverage service
+	 */
+	private $live_coverage_service;
 	
 	/**
 	 * Initialize the controller.
@@ -36,6 +41,7 @@ class AIPS_Calendar_Controller {
 		$this->schedule_repo = new AIPS_Schedule_Repository();
 		$this->interval_calculator = new AIPS_Interval_Calculator();
 		$this->template_repo = new AIPS_Template_Repository();
+		$this->live_coverage_service = new AIPS_Live_Coverage_Service();
 		add_action('wp_ajax_aips_get_calendar_events', array($this, 'ajax_get_calendar_events'));
 	}
 	
@@ -85,6 +91,8 @@ class AIPS_Calendar_Controller {
 			}
 		}
 		
+		$events = array_merge($events, $this->live_coverage_service->get_live_story_calendar_events($year, $month));
+
 		return $events;
 	}
 	

--- a/ai-post-scheduler/includes/class-aips-dashboard-controller.php
+++ b/ai-post-scheduler/includes/class-aips-dashboard-controller.php
@@ -26,6 +26,7 @@ class AIPS_Dashboard_Controller {
         $template_repo = new AIPS_Template_Repository();
         $post_review_repo = new AIPS_Post_Review_Repository();
         $author_topics_repo = new AIPS_Author_Topics_Repository();
+        $live_coverage_service = new AIPS_Live_Coverage_Service();
 
         // Get stats
         $history_stats = $history_repo->get_stats();
@@ -40,6 +41,8 @@ class AIPS_Dashboard_Controller {
         $partial_generations = $history_repo->get_partial_generations(array('per_page' => -1))['total'] ?? 0;
         $pending_reviews = $post_review_repo->get_draft_count();
         $topics_in_queue = isset($topic_counts['approved']) ? $topic_counts['approved'] : 0;
+        $live_story_counts = $live_coverage_service->get_live_story_counts();
+        $recent_live_stories = $live_coverage_service->get_recent_live_stories(5);
 
         // Get recent history
         $recent_posts_data = $history_repo->get_history(array('per_page' => 5));

--- a/ai-post-scheduler/includes/class-aips-generated-posts-controller.php
+++ b/ai-post-scheduler/includes/class-aips-generated-posts-controller.php
@@ -34,6 +34,11 @@ class AIPS_Generated_Posts_Controller {
 	 * @var AIPS_Post_Review_Repository Repository for post review data
 	 */
 	private $post_review_repository;
+
+	/**
+	 * @var AIPS_Live_Coverage_Service Live coverage service
+	 */
+	private $live_coverage_service;
 	
 	/**
 	 * @var array Cache for template names to avoid N+1 queries
@@ -57,10 +62,14 @@ class AIPS_Generated_Posts_Controller {
 		$this->history_repository = new AIPS_History_Repository();
 		$this->schedule_repository = new AIPS_Schedule_Repository();
 		$this->post_review_repository = new AIPS_Post_Review_Repository();
+		$this->live_coverage_service = new AIPS_Live_Coverage_Service();
 		
 		// Register AJAX handlers
 		add_action('wp_ajax_aips_get_post_session', array($this, 'ajax_get_post_session'));
 		add_action('wp_ajax_aips_get_session_json', array($this, 'ajax_get_session_json'));
+		add_action('wp_ajax_aips_live_story_append_update', array($this, 'ajax_live_story_append_update'));
+		add_action('wp_ajax_aips_live_story_regenerate_sections', array($this, 'ajax_live_story_regenerate_sections'));
+		add_action('wp_ajax_aips_live_story_get_history', array($this, 'ajax_live_story_get_history'));
 		// AJAX endpoint to download the session JSON as a file
 		add_action('wp_ajax_aips_download_session_json', array($this, 'ajax_download_session_json'));
 	}
@@ -110,15 +119,21 @@ class AIPS_Generated_Posts_Controller {
 			// Format source information
 			$source = $this->format_source($item);
 			
+			$story_metadata = $this->live_coverage_service->get_story_metadata($item->post_id);
+			$change_history = $this->live_coverage_service->get_change_history($item->post_id, $item->id, 25);
+
 			$posts_data[] = array(
 				'history_id' => $item->id,
 				'post_id' => $item->post_id,
 				'title' => $post->post_title,
+				'excerpt' => $post->post_excerpt,
 				'date_generated' => $item->created_at,
 				'date_published' => $post->post_date,
 				'date_scheduled' => $schedule ? $schedule->next_run : null,
 				'edit_link' => esc_url_raw(get_edit_post_link($item->post_id)),
 				'source' => $source,
+				'story_metadata' => $story_metadata,
+				'change_history' => $change_history,
 			);
 		}
 		
@@ -462,6 +477,101 @@ class AIPS_Generated_Posts_Controller {
 		));
 	}
 	
+	public function ajax_live_story_append_update() {
+		check_ajax_referer('aips_ajax_nonce', 'nonce');
+
+		$post_id = isset($_POST['post_id']) ? absint($_POST['post_id']) : 0;
+		$history_id = isset($_POST['history_id']) ? absint($_POST['history_id']) : 0;
+		if (!$post_id || !$history_id) {
+			wp_send_json_error(array('message' => __('Invalid live story request.', 'ai-post-scheduler')));
+		}
+
+		if (!current_user_can('edit_post', $post_id)) {
+			wp_send_json_error(array('message' => __('You do not have permission to update this story.', 'ai-post-scheduler')));
+		}
+
+		$result = $this->live_coverage_service->append_update_block($post_id, $history_id, array(
+			'update_brief' => isset($_POST['update_brief']) ? wp_unslash($_POST['update_brief']) : '',
+			'update_reason' => isset($_POST['update_reason']) ? wp_unslash($_POST['update_reason']) : '',
+			'sections' => array('update_block'),
+			'changed_sections' => array('update_block'),
+			'is_major_update' => !empty($_POST['is_major_update']),
+			'published_at' => isset($_POST['published_at']) ? wp_unslash($_POST['published_at']) : '',
+			'editor_user_id' => get_current_user_id(),
+			'is_live_story' => !empty($_POST['is_live_story']),
+			'thread_identifier' => isset($_POST['thread_identifier']) ? wp_unslash($_POST['thread_identifier']) : '',
+			'parent_story_id' => isset($_POST['parent_story_id']) ? absint($_POST['parent_story_id']) : 0,
+			'story_status' => isset($_POST['story_status']) ? wp_unslash($_POST['story_status']) : '',
+		));
+
+		if (is_wp_error($result)) {
+			wp_send_json_error(array('message' => $result->get_error_message()));
+		}
+
+		wp_send_json_success(array(
+			'message' => __('Update block appended successfully.', 'ai-post-scheduler'),
+			'metadata' => $result['metadata'],
+			'change_history' => $this->live_coverage_service->get_change_history($post_id, $history_id, 25),
+		));
+	}
+
+	public function ajax_live_story_regenerate_sections() {
+		check_ajax_referer('aips_ajax_nonce', 'nonce');
+
+		$post_id = isset($_POST['post_id']) ? absint($_POST['post_id']) : 0;
+		$history_id = isset($_POST['history_id']) ? absint($_POST['history_id']) : 0;
+		if (!$post_id || !$history_id) {
+			wp_send_json_error(array('message' => __('Invalid live story request.', 'ai-post-scheduler')));
+		}
+
+		if (!current_user_can('edit_post', $post_id)) {
+			wp_send_json_error(array('message' => __('You do not have permission to update this story.', 'ai-post-scheduler')));
+		}
+
+		$sections = isset($_POST['sections']) ? array_map('sanitize_key', (array) $_POST['sections']) : array();
+		$result = $this->live_coverage_service->regenerate_selected_sections($post_id, $history_id, array(
+			'sections' => $sections,
+			'update_reason' => isset($_POST['update_reason']) ? wp_unslash($_POST['update_reason']) : '',
+			'is_major_update' => !empty($_POST['is_major_update']),
+			'editor_user_id' => get_current_user_id(),
+			'is_live_story' => !empty($_POST['is_live_story']),
+			'thread_identifier' => isset($_POST['thread_identifier']) ? wp_unslash($_POST['thread_identifier']) : '',
+			'parent_story_id' => isset($_POST['parent_story_id']) ? absint($_POST['parent_story_id']) : 0,
+			'story_status' => isset($_POST['story_status']) ? wp_unslash($_POST['story_status']) : '',
+		));
+
+		if (is_wp_error($result)) {
+			wp_send_json_error(array('message' => $result->get_error_message()));
+		}
+
+		wp_send_json_success(array(
+			'message' => __('Selected sections regenerated successfully.', 'ai-post-scheduler'),
+			'headline' => isset($result['headline']) ? $result['headline'] : '',
+			'top_summary' => isset($result['top_summary']) ? $result['top_summary'] : '',
+			'metadata' => $result['metadata'],
+			'change_history' => $this->live_coverage_service->get_change_history($post_id, $history_id, 25),
+		));
+	}
+
+	public function ajax_live_story_get_history() {
+		check_ajax_referer('aips_ajax_nonce', 'nonce');
+
+		$post_id = isset($_POST['post_id']) ? absint($_POST['post_id']) : 0;
+		$history_id = isset($_POST['history_id']) ? absint($_POST['history_id']) : 0;
+		if (!$post_id) {
+			wp_send_json_error(array('message' => __('Invalid live story request.', 'ai-post-scheduler')));
+		}
+
+		if (!current_user_can('edit_post', $post_id)) {
+			wp_send_json_error(array('message' => __('You do not have permission to view this story history.', 'ai-post-scheduler')));
+		}
+
+		wp_send_json_success(array(
+			'message' => __('Live story history refreshed.', 'ai-post-scheduler'),
+			'change_history' => $this->live_coverage_service->get_change_history($post_id, $history_id, 50),
+		));
+	}
+
 	/**
 	 * Format source information for display
 	 *

--- a/ai-post-scheduler/includes/class-aips-generator.php
+++ b/ai-post-scheduler/includes/class-aips-generator.php
@@ -674,6 +674,28 @@ class AIPS_Generator {
 
         $generation_incomplete = in_array(false, $component_statuses, true);
 
+        $live_story_args = array(
+            'is_live_story' => false,
+            'thread_identifier' => '',
+            'parent_story_id' => 0,
+            'story_status' => '',
+        );
+
+        if ($context instanceof AIPS_Topic_Context) {
+            $topic_object = $context->get_topic_object();
+            $topic_metadata = !empty($topic_object->metadata) ? json_decode($topic_object->metadata, true) : array();
+            if (is_array($topic_metadata)) {
+                $live_story_args['is_live_story'] = !empty($topic_metadata['live_reopen_candidate']) || !empty($topic_metadata['is_live_story']);
+                $live_story_args['thread_identifier'] = isset($topic_metadata['thread_identifier']) ? $topic_metadata['thread_identifier'] : $context->get_topic();
+                if (!empty($topic_metadata['matched_story']['post_id'])) {
+                    $live_story_args['parent_story_id'] = absint($topic_metadata['matched_story']['post_id']);
+                    $live_story_args['story_status'] = 'developing';
+                } elseif (!empty($live_story_args['is_live_story'])) {
+                    $live_story_args['story_status'] = 'live';
+                }
+            }
+        }
+
         // Use Post Manager Service to save the generated post in WP
         $post_creation_data = array(
             'title' => $title,
@@ -686,6 +708,10 @@ class AIPS_Generator {
             'seo_title' => $title,
             'generation_incomplete' => $generation_incomplete,
             'component_statuses' => $component_statuses,
+            'is_live_story' => $live_story_args['is_live_story'],
+            'thread_identifier' => $live_story_args['thread_identifier'],
+            'parent_story_id' => $live_story_args['parent_story_id'],
+            'story_status' => $live_story_args['story_status'],
         );
 
         // Allow integrations to hook before the post is created.

--- a/ai-post-scheduler/includes/class-aips-live-coverage-service.php
+++ b/ai-post-scheduler/includes/class-aips-live-coverage-service.php
@@ -1,0 +1,667 @@
+<?php
+/**
+ * Live Coverage Service
+ *
+ * Supports continuously revised stories that preserve a canonical article
+ * identity while recording ordered update history in the existing history log.
+ *
+ * @package AI_Post_Scheduler
+ * @since 2.0.0
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+class AIPS_Live_Coverage_Service {
+
+	const META_LIVE_FLAG = 'aips_live_story_flag';
+	const META_THREAD_ID = 'aips_live_story_thread_id';
+	const META_PARENT_ID = 'aips_live_story_parent_post_id';
+	const META_STATUS = 'aips_live_story_status';
+	const META_LAST_UPDATE_AT = 'aips_live_story_last_update_at';
+	const META_LAST_UPDATE_TYPE = 'aips_live_story_last_update_type';
+	const META_MAJOR_COUNT = 'aips_live_story_major_update_count';
+	const META_MINOR_COUNT = 'aips_live_story_minor_update_count';
+
+	/**
+	 * @var AIPS_History_Service
+	 */
+	private $history_service;
+
+	/**
+	 * @var AIPS_History_Repository
+	 */
+	private $history_repository;
+
+	/**
+	 * @var AIPS_Component_Regeneration_Service
+	 */
+	private $component_regeneration_service;
+
+	/**
+	 * @var AIPS_Post_Manager
+	 */
+	private $post_manager;
+
+	public function __construct(
+		$history_service = null,
+		$history_repository = null,
+		$component_regeneration_service = null,
+		$post_manager = null
+	) {
+		$this->history_service = $history_service ?: new AIPS_History_Service();
+		$this->history_repository = $history_repository ?: new AIPS_History_Repository();
+		$this->component_regeneration_service = $component_regeneration_service ?: new AIPS_Component_Regeneration_Service();
+		$this->post_manager = $post_manager ?: new AIPS_Post_Manager();
+	}
+
+	/**
+	 * Apply or update live-story metadata on generated content.
+	 *
+	 * @param int   $post_id Post ID.
+	 * @param array $args Metadata arguments.
+	 * @return array Normalized metadata.
+	 */
+	public function update_generated_content_metadata($post_id, $args = array()) {
+		$post_id = absint($post_id);
+		if (!$post_id) {
+			return array();
+		}
+
+		$post = get_post($post_id);
+		if (!$post) {
+			return array();
+		}
+
+		$current = $this->get_story_metadata($post_id);
+		$is_live_story = isset($args['is_live_story']) ? (bool) $args['is_live_story'] : $current['is_live_story'];
+		$thread_identifier = isset($args['thread_identifier']) ? $this->normalize_thread_identifier($args['thread_identifier']) : $current['thread_identifier'];
+		$parent_story_id = isset($args['parent_story_id']) ? absint($args['parent_story_id']) : $current['parent_story_id'];
+		$story_status = isset($args['story_status']) ? $this->normalize_story_status($args['story_status']) : $current['story_status'];
+
+		if ('' === $thread_identifier) {
+			$thread_source = isset($args['thread_source']) ? $args['thread_source'] : $post->post_title;
+			$thread_identifier = $this->normalize_thread_identifier($thread_source);
+		}
+
+		if (!$parent_story_id) {
+			$parent_story_id = $post_id;
+		}
+
+		update_post_meta($post_id, self::META_LIVE_FLAG, $is_live_story ? '1' : '0');
+		update_post_meta($post_id, self::META_THREAD_ID, $thread_identifier);
+		update_post_meta($post_id, self::META_PARENT_ID, $parent_story_id);
+		update_post_meta($post_id, self::META_STATUS, $story_status);
+
+		return $this->get_story_metadata($post_id);
+	}
+
+	/**
+	 * Get normalized live-story metadata for a post.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return array
+	 */
+	public function get_story_metadata($post_id) {
+		$post_id = absint($post_id);
+		if (!$post_id) {
+			return array(
+				'is_live_story' => false,
+				'thread_identifier' => '',
+				'parent_story_id' => 0,
+				'story_status' => '',
+				'last_update_at' => '',
+				'last_update_type' => '',
+				'major_update_count' => 0,
+				'minor_update_count' => 0,
+			);
+		}
+
+		return array(
+			'is_live_story' => '1' === (string) get_post_meta($post_id, self::META_LIVE_FLAG, true),
+			'thread_identifier' => (string) get_post_meta($post_id, self::META_THREAD_ID, true),
+			'parent_story_id' => absint(get_post_meta($post_id, self::META_PARENT_ID, true)),
+			'story_status' => $this->normalize_story_status(get_post_meta($post_id, self::META_STATUS, true)),
+			'last_update_at' => (string) get_post_meta($post_id, self::META_LAST_UPDATE_AT, true),
+			'last_update_type' => (string) get_post_meta($post_id, self::META_LAST_UPDATE_TYPE, true),
+			'major_update_count' => absint(get_post_meta($post_id, self::META_MAJOR_COUNT, true)),
+			'minor_update_count' => absint(get_post_meta($post_id, self::META_MINOR_COUNT, true)),
+		);
+	}
+
+	/**
+	 * Append a timestamped update block to an existing canonical story.
+	 *
+	 * @param int   $post_id Post ID.
+	 * @param int   $history_id History ID.
+	 * @param array $args Update details.
+	 * @return array|WP_Error
+	 */
+	public function append_update_block($post_id, $history_id, $args = array()) {
+		$post_id = absint($post_id);
+		$history_id = absint($history_id);
+		$post = get_post($post_id);
+		if (!$post) {
+			return new WP_Error('missing_post', __('Post not found.', 'ai-post-scheduler'));
+		}
+
+		$update_brief = isset($args['update_brief']) ? sanitize_textarea_field(wp_unslash($args['update_brief'])) : '';
+		if ('' === $update_brief) {
+			return new WP_Error('missing_update_brief', __('An update brief is required.', 'ai-post-scheduler'));
+		}
+
+		$published_at = isset($args['published_at']) && '' !== $args['published_at'] ? sanitize_text_field($args['published_at']) : current_time('mysql');
+		$published_at_ts = strtotime($published_at);
+		if (false === $published_at_ts) {
+			$published_at = current_time('mysql');
+			$published_at_ts = strtotime($published_at);
+		}
+
+		$is_major_update = !empty($args['is_major_update']);
+		$changed_sections = isset($args['changed_sections']) ? $this->normalize_changed_sections($args['changed_sections']) : array('update_block');
+		$editor_user_id = isset($args['editor_user_id']) ? absint($args['editor_user_id']) : get_current_user_id();
+		$update_reason = isset($args['update_reason']) ? sanitize_text_field(wp_unslash($args['update_reason'])) : $update_brief;
+		$metadata = $this->update_generated_content_metadata($post_id, $args);
+
+		$timestamp_label = date_i18n(get_option('date_format') . ' ' . get_option('time_format'), $published_at_ts);
+		$update_block = "\n\n<!-- aips-live-update:start -->\n";
+		$update_block .= '<section class="aips-live-update-block" data-update-type="' . esc_attr($is_major_update ? 'major' : 'minor') . '">';
+		$update_block .= '<h3>' . esc_html(sprintf(__('Update — %s', 'ai-post-scheduler'), $timestamp_label)) . '</h3>';
+		$update_block .= '<p>' . esc_html($update_brief) . '</p>';
+		$update_block .= '</section>';
+		$update_block .= "\n<!-- aips-live-update:end -->";
+
+		$result = wp_update_post(array(
+			'ID' => $post_id,
+			'post_content' => (string) $post->post_content . $update_block,
+		), true);
+
+		if (is_wp_error($result)) {
+			return $result;
+		}
+
+		$this->bump_update_counters($post_id, $is_major_update, $published_at);
+		$this->record_live_event(
+			$post_id,
+			$history_id,
+			__('Live story update appended', 'ai-post-scheduler'),
+			'live_story_update_appended',
+			$update_reason,
+			$changed_sections,
+			$editor_user_id,
+			$published_at,
+			$metadata,
+			array(
+				'update_brief' => $update_brief,
+				'update_type' => $is_major_update ? 'major' : 'minor',
+			)
+		);
+
+		return array(
+			'post_id' => $post_id,
+			'content' => get_post_field('post_content', $post_id),
+			'metadata' => $this->get_story_metadata($post_id),
+		);
+	}
+
+	/**
+	 * Regenerate selected live-story sections while keeping the same post ID.
+	 *
+	 * @param int   $post_id Post ID.
+	 * @param int   $history_id History ID.
+	 * @param array $args Request arguments.
+	 * @return array|WP_Error
+	 */
+	public function regenerate_selected_sections($post_id, $history_id, $args = array()) {
+		$post_id = absint($post_id);
+		$history_id = absint($history_id);
+		$post = get_post($post_id);
+		if (!$post) {
+			return new WP_Error('missing_post', __('Post not found.', 'ai-post-scheduler'));
+		}
+
+		$sections = isset($args['sections']) ? $this->normalize_changed_sections($args['sections']) : array();
+		if (empty($sections)) {
+			return new WP_Error('missing_sections', __('Select at least one section to regenerate.', 'ai-post-scheduler'));
+		}
+
+		$context = $this->component_regeneration_service->get_generation_context($history_id);
+		if (is_wp_error($context)) {
+			return $context;
+		}
+
+		$context['post_id'] = $post_id;
+		$context['history_id'] = $history_id;
+		$context['current_title'] = $post->post_title;
+		$context['current_excerpt'] = $post->post_excerpt;
+		$context['current_content'] = $post->post_content;
+
+		$post_update = array('ID' => $post_id);
+		$changed_sections = array();
+		$response = array();
+
+		if (in_array('headline', $sections, true)) {
+			$new_title = $this->component_regeneration_service->regenerate_title($context);
+			if (is_wp_error($new_title)) {
+				return $new_title;
+			}
+			$post_update['post_title'] = sanitize_text_field($new_title);
+			$response['headline'] = $post_update['post_title'];
+			$changed_sections[] = 'headline';
+		}
+
+		if (in_array('top_summary', $sections, true)) {
+			$new_excerpt = $this->component_regeneration_service->regenerate_excerpt($context);
+			if (is_wp_error($new_excerpt)) {
+				return $new_excerpt;
+			}
+			$post_update['post_excerpt'] = sanitize_textarea_field($new_excerpt);
+			$response['top_summary'] = $post_update['post_excerpt'];
+			$changed_sections[] = 'top_summary';
+		}
+
+		if (count($post_update) > 1) {
+			$result = wp_update_post($post_update, true);
+			if (is_wp_error($result)) {
+				return $result;
+			}
+		}
+
+		$this->post_manager->reconcile_generation_status_meta_from_post($post_id);
+		$published_at = current_time('mysql');
+		$metadata = $this->update_generated_content_metadata($post_id, $args);
+		$is_major_update = !empty($args['is_major_update']) || count($changed_sections) > 1;
+		$this->bump_update_counters($post_id, $is_major_update, $published_at);
+
+		$update_reason = isset($args['update_reason']) ? sanitize_text_field(wp_unslash($args['update_reason'])) : __('Live story section refresh', 'ai-post-scheduler');
+		$editor_user_id = isset($args['editor_user_id']) ? absint($args['editor_user_id']) : get_current_user_id();
+		$this->record_live_event(
+			$post_id,
+			$history_id,
+			__('Live story sections regenerated', 'ai-post-scheduler'),
+			'live_story_sections_regenerated',
+			$update_reason,
+			$changed_sections,
+			$editor_user_id,
+			$published_at,
+			$metadata,
+			array(
+				'update_type' => $is_major_update ? 'major' : 'minor',
+			)
+		);
+
+		$response['post_id'] = $post_id;
+		$response['metadata'] = $this->get_story_metadata($post_id);
+		return $response;
+	}
+
+	/**
+	 * Reopen a previously published story when a new development matches the same thread.
+	 *
+	 * @param string $thread_identifier Thread identifier.
+	 * @param array  $args Reopen context.
+	 * @return array|null
+	 */
+	public function reopen_matching_story($thread_identifier, $args = array()) {
+		$match = $this->find_matching_story_by_thread($thread_identifier);
+		if (!$match) {
+			return null;
+		}
+
+		$post_id = (int) $match->ID;
+		$published_at = current_time('mysql');
+		$metadata = $this->update_generated_content_metadata($post_id, array_merge($args, array(
+			'is_live_story' => true,
+			'story_status' => 'developing',
+			'thread_identifier' => $thread_identifier,
+			'parent_story_id' => absint(get_post_meta($post_id, self::META_PARENT_ID, true)) ?: $post_id,
+		)));
+		$this->record_live_event(
+			$post_id,
+			isset($args['history_id']) ? absint($args['history_id']) : 0,
+			__('Live story reopened for a matching thread', 'ai-post-scheduler'),
+			'live_story_reopened',
+			isset($args['update_reason']) ? sanitize_text_field($args['update_reason']) : __('New development matched existing thread', 'ai-post-scheduler'),
+			array('thread_match'),
+			isset($args['editor_user_id']) ? absint($args['editor_user_id']) : get_current_user_id(),
+			$published_at,
+			$metadata,
+			array(
+				'matched_post_id' => $post_id,
+				'matched_post_title' => get_the_title($post_id),
+			)
+		);
+
+		return array(
+			'post_id' => $post_id,
+			'post_title' => get_the_title($post_id),
+			'edit_link' => get_edit_post_link($post_id, 'raw'),
+			'thread_identifier' => $metadata['thread_identifier'],
+			'story_status' => $metadata['story_status'],
+		);
+	}
+
+	/**
+	 * Add live-thread metadata to intake/topic payloads.
+	 *
+	 * @param array  $metadata Topic metadata.
+	 * @param string $thread_source Source string for the thread identifier.
+	 * @return array
+	 */
+	public function decorate_intake_metadata($metadata, $thread_source) {
+		if (!is_array($metadata)) {
+			$metadata = array();
+		}
+
+		$thread_identifier = $this->normalize_thread_identifier(isset($metadata['thread_identifier']) ? $metadata['thread_identifier'] : $thread_source);
+		$metadata['thread_identifier'] = $thread_identifier;
+		$metadata['live_reopen_candidate'] = false;
+
+		if ('' === $thread_identifier) {
+			return $metadata;
+		}
+
+		$match = $this->find_matching_story_by_thread($thread_identifier);
+		if ($match) {
+			$metadata['live_reopen_candidate'] = true;
+			$metadata['matched_story'] = array(
+				'post_id' => (int) $match->ID,
+				'post_title' => get_the_title($match->ID),
+				'edit_link' => get_edit_post_link($match->ID, 'raw'),
+				'story_status' => (string) get_post_meta($match->ID, self::META_STATUS, true),
+			);
+		}
+
+		return $metadata;
+	}
+
+	/**
+	 * Get ordered live-story history for a post.
+	 *
+	 * @param int $post_id Post ID.
+	 * @param int $history_id Optional history container ID.
+	 * @param int $limit Maximum entries.
+	 * @return array
+	 */
+	public function get_change_history($post_id, $history_id = 0, $limit = 50) {
+		$post_id = absint($post_id);
+		$history_id = absint($history_id);
+		$limit = absint($limit);
+		if (!$post_id) {
+			return array();
+		}
+
+		if (!$history_id) {
+			$history = $this->history_repository->get_by_post_id($post_id);
+			$history_id = $history ? absint($history->id) : 0;
+		}
+
+		if (!$history_id) {
+			return array();
+		}
+
+		$logs = $this->history_repository->get_logs_by_history_id($history_id, array(AIPS_History_Type::ACTIVITY));
+		$entries = array();
+		foreach ($logs as $log_entry) {
+			$details = json_decode($log_entry->details, true);
+			if (!is_array($details) || empty($details['context']['event_type'])) {
+				continue;
+			}
+
+			$event_type = (string) $details['context']['event_type'];
+			if (0 !== strpos($event_type, 'live_story_')) {
+				continue;
+			}
+
+			$entries[] = array(
+				'timestamp' => $log_entry->timestamp,
+				'message' => isset($details['message']) ? $details['message'] : '',
+				'update_reason' => isset($details['context']['update_reason']) ? $details['context']['update_reason'] : '',
+				'changed_sections' => isset($details['context']['changed_sections']) && is_array($details['context']['changed_sections']) ? $details['context']['changed_sections'] : array(),
+				'editor_user_id' => isset($details['context']['editor_user_id']) ? absint($details['context']['editor_user_id']) : 0,
+				'published_at' => isset($details['context']['published_at']) ? $details['context']['published_at'] : $log_entry->timestamp,
+				'event_type' => $event_type,
+				'update_type' => isset($details['context']['update_type']) ? $details['context']['update_type'] : '',
+			);
+		}
+
+		usort($entries, function($left, $right) {
+			return strcmp((string) $left['published_at'], (string) $right['published_at']);
+		});
+
+		if ($limit > 0 && count($entries) > $limit) {
+			$entries = array_slice($entries, -1 * $limit);
+		}
+
+		return $entries;
+	}
+
+	/**
+	 * Count live/developing stories for dashboard indicators.
+	 *
+	 * @return array
+	 */
+	public function get_live_story_counts() {
+		$live_posts = get_posts(array(
+			'post_type' => 'post',
+			'post_status' => array('publish', 'draft', 'future', 'pending'),
+			'posts_per_page' => -1,
+			'fields' => 'ids',
+			'meta_query' => array(
+				array(
+					'key' => self::META_LIVE_FLAG,
+					'value' => '1',
+				),
+			),
+		));
+
+		$counts = array(
+			'total' => 0,
+			'live' => 0,
+			'developing' => 0,
+		);
+
+		foreach ($live_posts as $post_id) {
+			$counts['total']++;
+			$status = $this->normalize_story_status(get_post_meta($post_id, self::META_STATUS, true));
+			if ('live' === $status) {
+				$counts['live']++;
+			} elseif ('developing' === $status) {
+				$counts['developing']++;
+			}
+		}
+
+		return $counts;
+	}
+
+	/**
+	 * Get recent live/developing stories.
+	 *
+	 * @param int $limit Maximum posts.
+	 * @return array
+	 */
+	public function get_recent_live_stories($limit = 5) {
+		$posts = get_posts(array(
+			'post_type' => 'post',
+			'post_status' => array('publish', 'draft', 'future', 'pending'),
+			'posts_per_page' => absint($limit),
+			'meta_key' => self::META_LIVE_FLAG,
+			'meta_value' => '1',
+			'orderby' => 'modified',
+			'order' => 'DESC',
+		));
+
+		$items = array();
+		foreach ($posts as $post) {
+			$metadata = $this->get_story_metadata($post->ID);
+			$items[] = array(
+				'post_id' => $post->ID,
+				'post_title' => $post->post_title,
+				'post_modified' => $post->post_modified,
+				'edit_link' => get_edit_post_link($post->ID, 'raw'),
+				'metadata' => $metadata,
+			);
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Get live-story calendar events for a month.
+	 *
+	 * @param int $year Year.
+	 * @param int $month Month.
+	 * @return array
+	 */
+	public function get_live_story_calendar_events($year, $month) {
+		$start = sprintf('%04d-%02d-01 00:00:00', $year, $month);
+		$end = sprintf('%04d-%02d-%02d 23:59:59', $year, $month, date('t', strtotime($start)));
+
+		$posts = get_posts(array(
+			'post_type' => 'post',
+			'post_status' => array('publish', 'draft', 'future', 'pending'),
+			'posts_per_page' => -1,
+			'meta_key' => self::META_LIVE_FLAG,
+			'meta_value' => '1',
+			'date_query' => array(
+				'relation' => 'OR',
+				array(
+					'column' => 'post_modified',
+					'after' => $start,
+					'before' => $end,
+					'inclusive' => true,
+				),
+				array(
+					'column' => 'post_date',
+					'after' => $start,
+					'before' => $end,
+					'inclusive' => true,
+				),
+			),
+		));
+
+		$events = array();
+		foreach ($posts as $post) {
+			$metadata = $this->get_story_metadata($post->ID);
+			$event_time = !empty($metadata['last_update_at']) ? $metadata['last_update_at'] : $post->post_modified;
+			$events[] = array(
+				'id' => 'live-' . $post->ID,
+				'title' => $post->post_title,
+				'start' => $event_time,
+				'template_id' => null,
+				'template_name' => __('Live Story', 'ai-post-scheduler'),
+				'frequency' => __('Rolling updates', 'ai-post-scheduler'),
+				'topic' => $metadata['thread_identifier'],
+				'category' => ucfirst($metadata['story_status'] ? $metadata['story_status'] : __('Live', 'ai-post-scheduler')),
+				'author' => get_the_author_meta('display_name', $post->post_author),
+				'event_kind' => 'live_story',
+				'story_status' => $metadata['story_status'],
+				'edit_link' => get_edit_post_link($post->ID, 'raw'),
+			);
+		}
+
+		return $events;
+	}
+
+	/**
+	 * Find a matching canonical story by thread identifier.
+	 *
+	 * @param string $thread_identifier Thread identifier.
+	 * @return WP_Post|null
+	 */
+	public function find_matching_story_by_thread($thread_identifier) {
+		$thread_identifier = $this->normalize_thread_identifier($thread_identifier);
+		if ('' === $thread_identifier) {
+			return null;
+		}
+
+		$posts = get_posts(array(
+			'post_type' => 'post',
+			'post_status' => array('publish', 'draft', 'future', 'pending'),
+			'posts_per_page' => 1,
+			'meta_query' => array(
+				array(
+					'key' => self::META_THREAD_ID,
+					'value' => $thread_identifier,
+				),
+			),
+			'orderby' => 'modified',
+			'order' => 'DESC',
+		));
+
+		if (!empty($posts)) {
+			return $posts[0];
+		}
+
+		return null;
+	}
+
+	private function normalize_story_status($status) {
+		$status = sanitize_key((string) $status);
+		if (!in_array($status, array('live', 'developing'), true)) {
+			return '';
+		}
+		return $status;
+	}
+
+	private function normalize_thread_identifier($value) {
+		$value = sanitize_title(wp_strip_all_tags((string) $value));
+		return (string) $value;
+	}
+
+	private function normalize_changed_sections($sections) {
+		$map = array(
+			'headline' => 'headline',
+			'title' => 'headline',
+			'top_summary' => 'top_summary',
+			'excerpt' => 'top_summary',
+			'update_block' => 'update_block',
+			'thread_match' => 'thread_match',
+		);
+
+		$sections = (array) $sections;
+		$normalized = array();
+		foreach ($sections as $section) {
+			$section = sanitize_key((string) $section);
+			if (isset($map[$section])) {
+				$normalized[] = $map[$section];
+			}
+		}
+
+		$normalized = array_values(array_unique($normalized));
+		return $normalized;
+	}
+
+	private function bump_update_counters($post_id, $is_major_update, $published_at) {
+		$meta_key = $is_major_update ? self::META_MAJOR_COUNT : self::META_MINOR_COUNT;
+		$current = absint(get_post_meta($post_id, $meta_key, true));
+		update_post_meta($post_id, $meta_key, $current + 1);
+		update_post_meta($post_id, self::META_LAST_UPDATE_AT, $published_at);
+		update_post_meta($post_id, self::META_LAST_UPDATE_TYPE, $is_major_update ? 'major' : 'minor');
+	}
+
+	private function record_live_event($post_id, $history_id, $message, $event_type, $update_reason, $changed_sections, $editor_user_id, $published_at, $metadata, $extra_context = array()) {
+		$history_container = AIPS_History_Container::resolve_existing($this->history_repository, $post_id, $history_id);
+		if (is_wp_error($history_container)) {
+			$history_container = $this->history_service->create('live_story_update', array(
+				'post_id' => $post_id,
+			));
+		}
+
+		$context = array_merge(array(
+			'event_type' => $event_type,
+			'event_status' => 'success',
+			'update_reason' => $update_reason,
+			'changed_sections' => $changed_sections,
+			'editor_user_id' => $editor_user_id,
+			'published_at' => $published_at,
+			'thread_identifier' => isset($metadata['thread_identifier']) ? $metadata['thread_identifier'] : '',
+			'parent_story_id' => isset($metadata['parent_story_id']) ? absint($metadata['parent_story_id']) : 0,
+			'story_status' => isset($metadata['story_status']) ? $metadata['story_status'] : '',
+			'update_type' => !empty($extra_context['update_type']) ? $extra_context['update_type'] : '',
+		), $extra_context);
+
+		$history_container->record('activity', $message, null, null, $context);
+	}
+}

--- a/ai-post-scheduler/includes/class-aips-post-manager.php
+++ b/ai-post-scheduler/includes/class-aips-post-manager.php
@@ -97,6 +97,22 @@ class AIPS_Post_Manager {
             );
         }
 
+        if (
+            isset($data['is_live_story'])
+            || isset($data['thread_identifier'])
+            || isset($data['parent_story_id'])
+            || isset($data['story_status'])
+        ) {
+            $live_coverage_service = new AIPS_Live_Coverage_Service();
+            $live_coverage_service->update_generated_content_metadata($post_id, array(
+                'is_live_story' => isset($data['is_live_story']) ? (bool) $data['is_live_story'] : false,
+                'thread_identifier' => isset($data['thread_identifier']) ? $data['thread_identifier'] : '',
+                'parent_story_id' => isset($data['parent_story_id']) ? absint($data['parent_story_id']) : 0,
+                'story_status' => isset($data['story_status']) ? $data['story_status'] : '',
+                'thread_source' => isset($data['topic']) ? $data['topic'] : $title,
+            ));
+        }
+
         // Handle Tags
         if (!empty($post_tags)) {
             $tags = array_map('trim', explode(',', $post_tags));

--- a/ai-post-scheduler/includes/class-aips-research-controller.php
+++ b/ai-post-scheduler/includes/class-aips-research-controller.php
@@ -39,6 +39,11 @@ class AIPS_Research_Controller {
      * @var AIPS_Content_Auditor Content Auditor instance
      */
     private $content_auditor;
+
+    /**
+     * @var AIPS_Live_Coverage_Service Live coverage service
+     */
+    private $live_coverage_service;
     
     /**
      * Initialize the controller.
@@ -48,6 +53,7 @@ class AIPS_Research_Controller {
         $this->repository = new AIPS_Trending_Topics_Repository();
         $this->logger = new AIPS_Logger();
         $this->content_auditor = new AIPS_Content_Auditor();
+        $this->live_coverage_service = new AIPS_Live_Coverage_Service();
         
         $this->init_hooks();
     }
@@ -143,10 +149,19 @@ class AIPS_Research_Controller {
         
         $topics = $this->repository->get_all($args);
         
-        // Parse keywords from JSON
+        // Parse keywords from JSON and flag matching live-story threads.
         foreach ($topics as &$topic) {
             if (!empty($topic['keywords'])) {
                 $topic['keywords'] = json_decode($topic['keywords'], true);
+            }
+
+            $live_metadata = $this->live_coverage_service->decorate_intake_metadata(array(), isset($topic['topic']) ? $topic['topic'] : '');
+            if (!empty($live_metadata['thread_identifier'])) {
+                $topic['thread_identifier'] = $live_metadata['thread_identifier'];
+            }
+            if (!empty($live_metadata['live_reopen_candidate'])) {
+                $topic['live_reopen_candidate'] = true;
+                $topic['matched_story'] = $live_metadata['matched_story'];
             }
         }
         

--- a/ai-post-scheduler/templates/admin/calendar.php
+++ b/ai-post-scheduler/templates/admin/calendar.php
@@ -83,6 +83,14 @@ if (!defined('ABSPATH')) {
 							<span class="aips-calendar-legend-color" style="background-color: #dba617;"></span>
 							<span><?php esc_html_e('Other Templates', 'ai-post-scheduler'); ?></span>
 						</div>
+						<div class="aips-calendar-legend-item">
+							<span class="aips-calendar-legend-color" style="background-color: #8e44ad;"></span>
+							<span><?php esc_html_e('Live Stories', 'ai-post-scheduler'); ?></span>
+						</div>
+						<div class="aips-calendar-legend-item">
+							<span class="aips-calendar-legend-color" style="background-color: #ff8c00;"></span>
+							<span><?php esc_html_e('Developing Stories', 'ai-post-scheduler'); ?></span>
+						</div>
 					</div>
 				</div>
 		
@@ -141,6 +149,7 @@ if (!defined('ABSPATH')) {
 					<p><strong><?php esc_html_e('Topic:', 'ai-post-scheduler'); ?></strong> <span class="aips-event-topic"></span></p>
 					<p><strong><?php esc_html_e('Category:', 'ai-post-scheduler'); ?></strong> <span class="aips-event-category"></span></p>
 					<p><strong><?php esc_html_e('Author:', 'ai-post-scheduler'); ?></strong> <span class="aips-event-author"></span></p>
+					<p><strong><?php esc_html_e('Story Status:', 'ai-post-scheduler'); ?></strong> <span class="aips-event-story-status"></span></p>
 				</div>
 			</div>
 			<div class="aips-calendar-modal-footer">

--- a/ai-post-scheduler/templates/admin/dashboard.php
+++ b/ai-post-scheduler/templates/admin/dashboard.php
@@ -68,6 +68,16 @@ if (!defined('ABSPATH')) {
                     <span class="aips-summary-label"><?php esc_html_e('Topics in Queue', 'ai-post-scheduler'); ?></span>
                 </div>
             </a>
+
+            <?php if (!empty($live_story_counts['total'])): ?>
+            <a href="<?php echo esc_url(AIPS_Admin_Menu_Helper::get_page_url('generated_posts')); ?>" class="aips-summary-card highlight" style="text-decoration: none; color: inherit;">
+                <div class="dashicons dashicons-megaphone aips-summary-icon" aria-hidden="true"></div>
+                <div class="aips-summary-content">
+                    <span class="aips-summary-number"><?php echo esc_html($live_story_counts['total']); ?></span>
+                    <span class="aips-summary-label"><?php esc_html_e('Live / Developing Stories', 'ai-post-scheduler'); ?></span>
+                </div>
+            </a>
+            <?php endif; ?>
             
             <?php if ($partial_generations > 0): ?>
             <a href="<?php echo esc_url(AIPS_Admin_Menu_Helper::get_page_url('generated_posts', array('s' => 'partial'))); ?>" class="aips-summary-card warning" style="text-decoration: none; color: inherit;">
@@ -197,6 +207,42 @@ if (!defined('ABSPATH')) {
                     </div>
                     <?php endif; ?>
                 </div>
+            </div>
+        </div>
+
+        <div class="aips-content-panel">
+            <div class="aips-panel-header">
+                <h2 class="aips-panel-title"><?php esc_html_e('Live Coverage Watch', 'ai-post-scheduler'); ?></h2>
+            </div>
+            <div class="aips-panel-body <?php echo empty($recent_live_stories) ? '' : 'no-padding'; ?>">
+                <?php if (!empty($recent_live_stories)): ?>
+                <table class="aips-table">
+                    <thead>
+                        <tr>
+                            <th><?php esc_html_e('Story', 'ai-post-scheduler'); ?></th>
+                            <th><?php esc_html_e('Status', 'ai-post-scheduler'); ?></th>
+                            <th><?php esc_html_e('Thread', 'ai-post-scheduler'); ?></th>
+                            <th><?php esc_html_e('Last Update', 'ai-post-scheduler'); ?></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($recent_live_stories as $story): ?>
+                        <tr>
+                            <td><a href="<?php echo esc_url($story['edit_link']); ?>" class="cell-primary"><?php echo esc_html($story['post_title']); ?></a></td>
+                            <td><span class="aips-badge aips-badge-<?php echo esc_attr('live' === $story['metadata']['story_status'] ? 'error' : 'warning'); ?>"><?php echo esc_html(ucfirst($story['metadata']['story_status'] ? $story['metadata']['story_status'] : 'live')); ?></span></td>
+                            <td class="cell-meta"><?php echo esc_html($story['metadata']['thread_identifier']); ?></td>
+                            <td class="cell-meta"><?php echo esc_html(date_i18n(get_option('date_format') . ' ' . get_option('time_format'), strtotime($story['metadata']['last_update_at'] ? $story['metadata']['last_update_at'] : $story['post_modified']))); ?></td>
+                        </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+                <?php else: ?>
+                <div class="aips-empty-state">
+                    <div class="dashicons dashicons-megaphone aips-empty-state-icon" aria-hidden="true"></div>
+                    <h3 class="aips-empty-state-title"><?php esc_html_e('No Live Stories Yet', 'ai-post-scheduler'); ?></h3>
+                    <p class="aips-empty-state-description"><?php esc_html_e('Mark a generated post as live or developing to track rolling updates here.', 'ai-post-scheduler'); ?></p>
+                </div>
+                <?php endif; ?>
             </div>
         </div>
         

--- a/ai-post-scheduler/templates/admin/generated-posts.php
+++ b/ai-post-scheduler/templates/admin/generated-posts.php
@@ -103,11 +103,30 @@ if (!defined('ABSPATH')) {
 						</thead>
 						<tbody>
 							<?php foreach ($posts_data as $post_data): ?>
+							<?php $story_meta = $post_data['story_metadata']; ?>
 							<tr>
 								<td>
 									<a href="<?php echo esc_url($post_data['edit_link']); ?>" class="cell-primary">
 										<?php echo esc_html($post_data['title']); ?>
 									</a>
+									<?php if (!empty($story_meta['is_live_story']) || !empty($story_meta['story_status'])): ?>
+									<div class="aips-live-story-badges">
+										<?php if (!empty($story_meta['is_live_story'])): ?>
+										<span class="aips-badge aips-badge-info"><?php esc_html_e('Live Story', 'ai-post-scheduler'); ?></span>
+										<?php endif; ?>
+										<?php if (!empty($story_meta['story_status'])): ?>
+										<span class="aips-badge aips-live-story-status-<?php echo esc_attr($story_meta['story_status']); ?>"><?php echo esc_html(ucfirst($story_meta['story_status'])); ?></span>
+										<?php endif; ?>
+									</div>
+									<div class="aips-live-story-meta">
+										<?php if (!empty($story_meta['thread_identifier'])): ?>
+										<span><?php echo esc_html(sprintf(__('Thread: %s', 'ai-post-scheduler'), $story_meta['thread_identifier'])); ?></span><br>
+										<?php endif; ?>
+										<?php if (!empty($story_meta['last_update_at'])): ?>
+										<span><?php echo esc_html(sprintf(__('Last update: %s', 'ai-post-scheduler'), date_i18n(get_option('date_format') . ' ' . get_option('time_format'), strtotime($story_meta['last_update_at'])))); ?></span>
+										<?php endif; ?>
+									</div>
+									<?php endif; ?>
 								</td>
 								<td>
 									<span class="aips-badge aips-badge-neutral">
@@ -116,7 +135,7 @@ if (!defined('ABSPATH')) {
 								</td>
 								<td>
 									<div class="cell-meta">
-										<?php 
+										<?php
 										if ($post_data['date_scheduled']) {
 											echo esc_html(date_i18n(get_option('date_format') . ' ' . get_option('time_format'), strtotime($post_data['date_scheduled'])));
 										} else {
@@ -141,20 +160,88 @@ if (!defined('ABSPATH')) {
 											<span class="dashicons dashicons-edit"></span>
 											<?php esc_html_e('Edit', 'ai-post-scheduler'); ?>
 										</a>
-										<button class="aips-btn aips-btn-sm aips-btn-secondary aips-ai-edit-btn" 
+										<button class="aips-btn aips-btn-sm aips-btn-secondary aips-ai-edit-btn"
 										        data-post-id="<?php echo esc_attr($post_data['post_id']); ?>"
 										        data-history-id="<?php echo esc_attr($post_data['history_id']); ?>"
 										        title="<?php esc_attr_e('AI Edit', 'ai-post-scheduler'); ?>">
 											<span class="dashicons dashicons-admin-customizer"></span>
 											<?php esc_html_e('AI Edit', 'ai-post-scheduler'); ?>
 										</button>
-								<button class="aips-btn aips-btn-sm aips-btn-secondary aips-view-session" 
-								        data-history-id="<?php echo esc_attr($post_data['history_id']); ?>"
-								        title="<?php esc_attr_e('View Session', 'ai-post-scheduler'); ?>">
-									<span class="dashicons dashicons-visibility"></span>
-									<?php esc_html_e('View Session', 'ai-post-scheduler'); ?>
+										<button class="aips-btn aips-btn-sm aips-btn-secondary aips-view-session"
+										        data-history-id="<?php echo esc_attr($post_data['history_id']); ?>"
+										        title="<?php esc_attr_e('View Session', 'ai-post-scheduler'); ?>">
+											<span class="dashicons dashicons-visibility"></span>
+											<?php esc_html_e('View Session', 'ai-post-scheduler'); ?>
 										</button>
 									</div>
+									<details class="aips-live-story-panel">
+										<summary><?php esc_html_e('Live Coverage', 'ai-post-scheduler'); ?></summary>
+										<div class="aips-live-story-panel-body" data-post-id="<?php echo esc_attr($post_data['post_id']); ?>" data-history-id="<?php echo esc_attr($post_data['history_id']); ?>">
+											<div class="aips-live-story-form-grid">
+												<label><?php esc_html_e('Story state', 'ai-post-scheduler'); ?>
+													<select class="aips-form-select aips-live-story-status">
+														<option value=""><?php esc_html_e('Not marked', 'ai-post-scheduler'); ?></option>
+														<option value="live" <?php selected($story_meta['story_status'], 'live'); ?>><?php esc_html_e('Live', 'ai-post-scheduler'); ?></option>
+														<option value="developing" <?php selected($story_meta['story_status'], 'developing'); ?>><?php esc_html_e('Developing', 'ai-post-scheduler'); ?></option>
+													</select>
+												</label>
+												<label><?php esc_html_e('Thread identifier', 'ai-post-scheduler'); ?>
+													<input type="text" class="aips-form-input aips-live-story-thread" value="<?php echo esc_attr($story_meta['thread_identifier']); ?>" placeholder="<?php esc_attr_e('e.g. election-night-2026', 'ai-post-scheduler'); ?>">
+												</label>
+												<label><?php esc_html_e('Parent story ID', 'ai-post-scheduler'); ?>
+													<input type="number" class="aips-form-input aips-live-story-parent" value="<?php echo esc_attr($story_meta['parent_story_id']); ?>" min="0">
+												</label>
+											</div>
+											<label>
+												<input type="checkbox" class="aips-live-story-flag" value="1" <?php checked(!empty($story_meta['is_live_story'])); ?>>
+												<?php esc_html_e('Treat this article as a continuously updated story', 'ai-post-scheduler'); ?>
+											</label>
+											<label><?php esc_html_e('Update brief', 'ai-post-scheduler'); ?>
+												<textarea class="aips-form-input aips-live-story-brief" rows="3" placeholder="<?php esc_attr_e('Explain what changed and why this update matters.', 'ai-post-scheduler'); ?>"></textarea>
+											</label>
+											<div class="aips-live-story-form-grid">
+												<label><?php esc_html_e('Update reason', 'ai-post-scheduler'); ?>
+													<input type="text" class="aips-form-input aips-live-story-reason" placeholder="<?php esc_attr_e('Breaking update, official statement, correction…', 'ai-post-scheduler'); ?>">
+												</label>
+												<label><?php esc_html_e('Publish/update time', 'ai-post-scheduler'); ?>
+													<input type="datetime-local" class="aips-form-input aips-live-story-published-at">
+												</label>
+												<label>
+													<input type="checkbox" class="aips-live-story-major" value="1">
+													<?php esc_html_e('Major update', 'ai-post-scheduler'); ?>
+												</label>
+											</div>
+											<div class="aips-live-story-actions">
+												<button type="button" class="aips-btn aips-btn-sm aips-btn-primary aips-live-story-append"><?php esc_html_e('Append Update Block', 'ai-post-scheduler'); ?></button>
+												<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-live-story-regenerate" data-sections="headline"><?php esc_html_e('Regenerate Headline', 'ai-post-scheduler'); ?></button>
+												<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-live-story-regenerate" data-sections="top_summary"><?php esc_html_e('Regenerate Top Summary', 'ai-post-scheduler'); ?></button>
+												<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-live-story-refresh-history"><?php esc_html_e('Refresh History', 'ai-post-scheduler'); ?></button>
+											</div>
+											<div class="aips-live-story-current-summary">
+												<strong><?php esc_html_e('Current top summary:', 'ai-post-scheduler'); ?></strong>
+												<p class="aips-live-story-current-excerpt"><?php echo esc_html($post_data['excerpt'] ? $post_data['excerpt'] : __('No summary available.', 'ai-post-scheduler')); ?></p>
+											</div>
+											<div>
+												<strong><?php esc_html_e('Change history', 'ai-post-scheduler'); ?></strong>
+												<ol class="aips-live-story-history">
+													<?php if (!empty($post_data['change_history'])): ?>
+														<?php foreach ($post_data['change_history'] as $change_item): ?>
+														<li>
+															<div><?php echo esc_html($change_item['message']); ?></div>
+															<div class="aips-live-story-history-meta">
+																<?php echo esc_html(date_i18n(get_option('date_format') . ' ' . get_option('time_format'), strtotime($change_item['published_at']))); ?>
+																<?php if (!empty($change_item['update_reason'])): ?> · <?php echo esc_html($change_item['update_reason']); ?><?php endif; ?>
+																<?php if (!empty($change_item['changed_sections'])): ?> · <?php echo esc_html(implode(', ', $change_item['changed_sections'])); ?><?php endif; ?>
+															</div>
+														</li>
+														<?php endforeach; ?>
+													<?php else: ?>
+														<li><?php esc_html_e('No live-story updates recorded yet.', 'ai-post-scheduler'); ?></li>
+													<?php endif; ?>
+												</ol>
+											</div>
+										</div>
+									</details>
 								</td>
 							</tr>
 							<?php endforeach; ?>


### PR DESCRIPTION
### Motivation

- Support stories that are revised and republished continuously while preserving a canonical article identity and ordered update history. 
- Provide editors the ability to append timestamped update briefs, selectively regenerate headline/top summary sections, and mark stories as "live" or "developing". 
- Surface live/developing story activity in admin calendar and dashboard and let research intake identify reopen candidates for matching threads.

### Description

- Introduce `AIPS_Live_Coverage_Service` with APIs to update live-story metadata, append timestamped update blocks, selectively regenerate sections, reopen matching canonical stories, decorate intake/topic metadata, and produce ordered change history logged to `aips_history_log`. 
- Wire live-story metadata into generation and post creation flows by passing `is_live_story`, `thread_identifier`, `parent_story_id`, and `story_status` from the generator (`AIPS_Generator`) to `AIPS_Post_Manager::create_post` and by decorating research/author-topic intake (topic generator and research controller) so new developments can be flagged as reopen candidates. 
- Extend the Generated Posts admin UI and client-side JS to add live-coverage controls (update brief, thread, parent ID, major/minor toggle), new AJAX endpoints (`aips_live_story_append_update`, `aips_live_story_regenerate_sections`, `aips_live_story_get_history`), and ordered change-history rendering; add UI panels and styles in `templates/admin/generated-posts.php`, `assets/js/admin-generated-posts.js`, and `assets/css/admin.css`. 
- Add dashboard and calendar indicators and events for live/developing stories, update calendar rendering and legend, and add client/server plumbing to show story status in event details (`AIPS_Dashboard_Controller`, `AIPS_Calendar_Controller`, `templates/admin/dashboard.php`, `templates/admin/calendar.php`, and `assets/js/calendar.js`).

### Testing

- Ran PHP syntax checks on the modified files with `php -l`, including `includes/class-aips-live-coverage-service.php`, `includes/class-aips-post-manager.php`, `includes/class-aips-generator.php`, `includes/class-aips-author-topics-generator.php`, `includes/class-aips-research-controller.php`, `includes/class-aips-generated-posts-controller.php`, `includes/class-aips-dashboard-controller.php`, `includes/class-aips-calendar-controller.php`, and updated admin templates; all reported no syntax errors. 
- Verified new JS and CSS assets were added and localized strings were provided via `AIPS_Admin_Assets` and that the generated-posts and calendar pages include the new UI elements (smoke-tested by static checks). 
- PHPUnit/CI tests were not executed in this environment because Composer/vendor dependencies are not installed here (vendor autoload and `vendor/bin/phpunit` were not available).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf5929ac7c83218f840790766a6c80)