### PR TITLE
Add editorial dossier workflow: storage, UI, context & prompt integration

### DIFF
--- a/ai-post-scheduler/assets/js/admin-sources.js
+++ b/ai-post-scheduler/assets/js/admin-sources.js
@@ -24,6 +24,9 @@
 		/** @type {number} ID of the source currently being edited (0 = new). */
 		currentSourceId: 0,
 
+		/** @type {number} ID of the dossier currently being edited (0 = new). */
+		currentDossierId: 0,
+
 		/**
 		 * Bootstrap the Sources page.
 		 *
@@ -68,6 +71,14 @@
 			$(document).on('click', '#aips-groups-modal', this.onGroupsOverlayClick.bind(this));
 			$(document).on('click', '#aips-add-group-btn', this.addSourceGroup.bind(this));
 			$(document).on('click', '.aips-delete-source-group', this.deleteSourceGroup.bind(this));
+
+			// Dossier modal.
+			$(document).on('click', '#aips-add-dossier-btn', this.openAddDossierModal.bind(this));
+			$(document).on('click', '.aips-edit-dossier', this.openEditDossierModal.bind(this));
+			$(document).on('click', '.aips-delete-dossier', this.deleteDossier.bind(this));
+			$(document).on('click', '#aips-save-dossier-btn', this.saveDossier.bind(this));
+			$(document).on('click', '#aips-dossier-modal .aips-modal-close', this.closeDossierModal.bind(this));
+			$(document).on('click', '#aips-dossier-modal', this.onDossierOverlayClick.bind(this));
 		},
 
 		// -----------------------------------------------------------------
@@ -159,6 +170,90 @@
 			$('#aips-source-description').val('');
 			$('#aips-source-is-active').prop('checked', true);
 			$('.aips-source-group-checkbox').prop('checked', false);
+		},
+
+		/**
+		 * Open the Add Dossier modal with defaults.
+		 *
+		 * @param {Event} e Click event.
+		 * @return {void}
+		 */
+		openAddDossierModal: function (e) {
+			e.preventDefault();
+			this.currentDossierId = 0;
+			this.resetDossierForm();
+			$('#aips-dossier-modal-title').text(aipsSourcesL10n.addDossier);
+			$('#aips-dossier-modal').show();
+		},
+
+		/**
+		 * Open the Edit Dossier modal populated from the row.
+		 *
+		 * @param {Event} e Click event.
+		 * @return {void}
+		 */
+		openEditDossierModal: function (e) {
+			e.preventDefault();
+			var $row = $(e.currentTarget).closest('tr');
+
+			this.currentDossierId = parseInt($row.data('dossier-id'), 10) || 0;
+
+			$('#aips-dossier-id').val(this.currentDossierId);
+			$('#aips-dossier-source-id').val(parseInt($row.data('source-id'), 10) || 0);
+			$('#aips-dossier-relation-type').val($row.data('relation-type'));
+			$('#aips-dossier-relation-id').val(parseInt($row.data('relation-id'), 10) || '');
+			$('#aips-dossier-source-url').val($row.data('source-url') || '');
+			$('#aips-dossier-source-type').val($row.data('source-type') || '');
+			$('#aips-dossier-quote-summary').val($row.data('quote-summary') || '');
+			$('#aips-dossier-trust-rating').val(parseInt($row.data('trust-rating'), 10) || 3);
+			$('#aips-dossier-citation-required').prop('checked', parseInt($row.data('citation-required'), 10) === 1);
+			$('#aips-dossier-verification-status').val($row.data('verification-status') || 'pending');
+			$('#aips-dossier-editor-notes').val($row.data('editor-notes') || '');
+
+			$('#aips-dossier-modal-title').text(aipsSourcesL10n.editDossier);
+			$('#aips-dossier-modal').show();
+		},
+
+		/**
+		 * Close the dossier modal.
+		 *
+		 * @param {Event} e Click event.
+		 * @return {void}
+		 */
+		closeDossierModal: function (e) {
+			e.preventDefault();
+			$('#aips-dossier-modal').hide();
+		},
+
+		/**
+		 * Close the dossier modal when clicking the overlay.
+		 *
+		 * @param {Event} e Click event.
+		 * @return {void}
+		 */
+		onDossierOverlayClick: function (e) {
+			if ($(e.target).is('#aips-dossier-modal')) {
+				$('#aips-dossier-modal').hide();
+			}
+		},
+
+		/**
+		 * Reset dossier form fields.
+		 *
+		 * @return {void}
+		 */
+		resetDossierForm: function () {
+			$('#aips-dossier-id').val(0);
+			$('#aips-dossier-source-id').val(0);
+			$('#aips-dossier-relation-type').val('author_topic');
+			$('#aips-dossier-relation-id').val('');
+			$('#aips-dossier-source-url').val('');
+			$('#aips-dossier-source-type').val('');
+			$('#aips-dossier-quote-summary').val('');
+			$('#aips-dossier-trust-rating').val('3');
+			$('#aips-dossier-citation-required').prop('checked', false);
+			$('#aips-dossier-verification-status').val('pending');
+			$('#aips-dossier-editor-notes').val('');
 		},
 
 		// -----------------------------------------------------------------
@@ -395,6 +490,99 @@
 				self.refreshPage();
 			}).fail(function () {
 				AIPS.Utilities.showToast('Failed to delete group.', 'error');
+			});
+		},
+
+		/**
+		 * Save a dossier record.
+		 *
+		 * @param {Event} e Click event.
+		 * @return {void}
+		 */
+		saveDossier: function (e) {
+			e.preventDefault();
+
+			var relationId = parseInt($('#aips-dossier-relation-id').val(), 10) || 0;
+			var sourceUrl = $('#aips-dossier-source-url').val().trim();
+
+			if (!relationId) {
+				AIPS.Utilities.showToast(aipsSourcesL10n.relationIdRequired, 'error');
+				return;
+			}
+
+			if (!sourceUrl) {
+				AIPS.Utilities.showToast(aipsSourcesL10n.urlRequired, 'error');
+				return;
+			}
+
+			var data = {
+				action: 'aips_save_source_dossier',
+				nonce: aipsAjax.nonce,
+				dossier_id: this.currentDossierId,
+				source_id: parseInt($('#aips-dossier-source-id').val(), 10) || 0,
+				relation_type: $('#aips-dossier-relation-type').val(),
+				relation_id: relationId,
+				source_url: sourceUrl,
+				source_type: $('#aips-dossier-source-type').val().trim(),
+				quote_summary: $('#aips-dossier-quote-summary').val().trim(),
+				trust_rating: parseInt($('#aips-dossier-trust-rating').val(), 10) || 3,
+				verification_status: $('#aips-dossier-verification-status').val(),
+				editor_notes: $('#aips-dossier-editor-notes').val().trim()
+			};
+
+			if ($('#aips-dossier-citation-required').is(':checked')) {
+				data.citation_required = 1;
+			}
+
+			$('#aips-save-dossier-btn').prop('disabled', true).text(aipsSourcesL10n.saving);
+
+			var self = this;
+			$.post(aipsAjax.ajaxUrl, data, function (response) {
+				$('#aips-save-dossier-btn').prop('disabled', false).text(aipsSourcesL10n.saveDossier);
+
+				if (!response.success) {
+					AIPS.Utilities.showToast(response.data.message || aipsSourcesL10n.saveFailed, 'error');
+					return;
+				}
+
+				AIPS.Utilities.showToast(response.data.message, 'success');
+				$('#aips-dossier-modal').hide();
+				self.refreshPage();
+			}).fail(function () {
+				$('#aips-save-dossier-btn').prop('disabled', false).text(aipsSourcesL10n.saveDossier);
+				AIPS.Utilities.showToast(aipsSourcesL10n.saveFailed, 'error');
+			});
+		},
+
+		/**
+		 * Delete a dossier record.
+		 *
+		 * @param {Event} e Click event.
+		 * @return {void}
+		 */
+		deleteDossier: function (e) {
+			e.preventDefault();
+			var dossierId = parseInt($(e.currentTarget).data('id'), 10);
+
+			if (!confirm(aipsSourcesL10n.deleteDossierConfirm)) {
+				return;
+			}
+
+			var self = this;
+			$.post(aipsAjax.ajaxUrl, {
+				action: 'aips_delete_source_dossier',
+				nonce: aipsAjax.nonce,
+				dossier_id: dossierId
+			}, function (response) {
+				if (!response.success) {
+					AIPS.Utilities.showToast(response.data.message || aipsSourcesL10n.deleteDossierFailed, 'error');
+					return;
+				}
+
+				AIPS.Utilities.showToast(response.data.message, 'success');
+				self.refreshPage();
+			}).fail(function () {
+				AIPS.Utilities.showToast(aipsSourcesL10n.deleteDossierFailed, 'error');
 			});
 		},
 

--- a/ai-post-scheduler/assets/js/admin.js
+++ b/ai-post-scheduler/assets/js/admin.js
@@ -459,6 +459,9 @@
             // Reset source groups
             $('.aips-template-source-group-cb').prop('checked', false);
             $('#template-source-groups-selector').hide();
+            $('#dossier_only_facts').prop('checked', false);
+            $('#dossier_mark_uncertain_claims').prop('checked', false);
+            $('#dossier_include_knowledge_gaps').prop('checked', false);
             // Initialize wizard to step 1
             AIPS.wizardGoToStep(1, $('#aips-template-modal'));
             $('#aips-template-modal').show();
@@ -524,6 +527,9 @@
                         sgIds.forEach(function(tid) {
                             $('.aips-template-source-group-cb[value="' + tid + '"]').prop('checked', true);
                         });
+                        $('#dossier_only_facts').prop('checked', t.dossier_only_facts == 1);
+                        $('#dossier_mark_uncertain_claims').prop('checked', t.dossier_mark_uncertain_claims == 1);
+                        $('#dossier_include_knowledge_gaps').prop('checked', t.dossier_include_knowledge_gaps == 1);
 
                         // Scan for AI Variables after loading template data
                         AIPS.initAIVariablesScanner();
@@ -713,6 +719,9 @@
                         $('.aips-template-source-group-cb:checked').each(function() { ids.push($(this).val()); });
                         return ids;
                     }()),
+                    dossier_only_facts: $('#dossier_only_facts').is(':checked') ? 1 : 0,
+                    dossier_mark_uncertain_claims: $('#dossier_mark_uncertain_claims').is(':checked') ? 1 : 0,
+                    dossier_include_knowledge_gaps: $('#dossier_include_knowledge_gaps').is(':checked') ? 1 : 0,
                     is_active: $('#is_active').is(':checked') ? 1 : 0
                 },
                 success: function(response) {
@@ -786,6 +795,9 @@
                         $('.aips-template-source-group-cb:checked').each(function() { ids.push($(this).val()); });
                         return ids;
                     }()),
+                    dossier_only_facts: $('#dossier_only_facts').is(':checked') ? 1 : 0,
+                    dossier_mark_uncertain_claims: $('#dossier_mark_uncertain_claims').is(':checked') ? 1 : 0,
+                    dossier_include_knowledge_gaps: $('#dossier_include_knowledge_gaps').is(':checked') ? 1 : 0,
                     is_active: 0 // Save as inactive draft
                 },
                 success: function(response) {
@@ -3905,7 +3917,10 @@
                     var ids = [];
                     $('.aips-template-source-group-cb:checked').each(function() { ids.push($(this).val()); });
                     return ids;
-                }())
+                }()),
+                dossier_only_facts: $('#dossier_only_facts').is(':checked') ? 1 : 0,
+                dossier_mark_uncertain_claims: $('#dossier_mark_uncertain_claims').is(':checked') ? 1 : 0,
+                dossier_include_knowledge_gaps: $('#dossier_include_knowledge_gaps').is(':checked') ? 1 : 0
             };
             
             $.ajax({

--- a/ai-post-scheduler/includes/class-aips-admin-assets.php
+++ b/ai-post-scheduler/includes/class-aips-admin-assets.php
@@ -633,6 +633,12 @@ class AIPS_Admin_Assets {
                 'deleteFailed'      => __('Failed to delete source.', 'ai-post-scheduler'),
                 'toggleFailed'      => __('Failed to update source status.', 'ai-post-scheduler'),
                 'urlRequired'       => __('A URL is required.', 'ai-post-scheduler'),
+                'addDossier'        => __('Add Dossier Record', 'ai-post-scheduler'),
+                'editDossier'       => __('Edit Dossier Record', 'ai-post-scheduler'),
+                'saveDossier'       => __('Save Dossier Record', 'ai-post-scheduler'),
+                'relationIdRequired' => __('A related editorial record ID is required.', 'ai-post-scheduler'),
+                'deleteDossierConfirm' => __('Are you sure you want to delete this dossier record?', 'ai-post-scheduler'),
+                'deleteDossierFailed' => __('Failed to delete dossier record.', 'ai-post-scheduler'),
                 'groupNameRequired' => __('Please enter a group name.', 'ai-post-scheduler'),
                 'deleteGroupConfirm' => __('Delete this Source Group? Sources in this group will not be deleted.', 'ai-post-scheduler'),
             ));

--- a/ai-post-scheduler/includes/class-aips-db-manager.php
+++ b/ai-post-scheduler/includes/class-aips-db-manager.php
@@ -21,6 +21,7 @@ class AIPS_DB_Manager {
         'aips_notifications',
         'aips_sources',
         'aips_source_group_terms',
+        'aips_source_dossiers',
     );
 
     public function __construct() {
@@ -68,6 +69,7 @@ class AIPS_DB_Manager {
         $table_notifications        = $tables['aips_notifications'];
         $table_sources              = $tables['aips_sources'];
         $table_source_group_terms   = $tables['aips_source_group_terms'];
+        $table_source_dossiers      = $tables['aips_source_dossiers'];
 
         $sql = array();
 
@@ -130,6 +132,9 @@ class AIPS_DB_Manager {
             post_author bigint(20) DEFAULT NULL,
             include_sources tinyint(1) DEFAULT 0,
             source_group_ids text DEFAULT NULL,
+            dossier_only_facts tinyint(1) DEFAULT 0,
+            dossier_mark_uncertain_claims tinyint(1) DEFAULT 0,
+            dossier_include_knowledge_gaps tinyint(1) DEFAULT 0,
             is_active tinyint(1) DEFAULT 1,
             created_at datetime DEFAULT CURRENT_TIMESTAMP,
             updated_at datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
@@ -345,6 +350,29 @@ class AIPS_DB_Manager {
             UNIQUE KEY source_term (source_id, term_id),
             KEY source_id (source_id),
             KEY term_id (term_id)
+        ) $charset_collate;";
+
+        $sql[] = "CREATE TABLE $table_source_dossiers (
+            id bigint(20) NOT NULL AUTO_INCREMENT,
+            source_id bigint(20) DEFAULT NULL,
+            relation_type varchar(50) NOT NULL DEFAULT 'author_topic',
+            relation_id bigint(20) NOT NULL,
+            source_url varchar(2083) NOT NULL,
+            source_type varchar(100) DEFAULT NULL,
+            quote_summary text DEFAULT NULL,
+            trust_rating tinyint(1) NOT NULL DEFAULT 3,
+            citation_required tinyint(1) NOT NULL DEFAULT 0,
+            verification_status varchar(50) NOT NULL DEFAULT 'pending',
+            editor_notes text DEFAULT NULL,
+            created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            PRIMARY KEY  (id),
+            KEY source_id (source_id),
+            KEY relation_type (relation_type),
+            KEY relation_id (relation_id),
+            KEY relation_lookup (relation_type, relation_id),
+            KEY verification_status (verification_status),
+            KEY citation_required (citation_required)
         ) $charset_collate;";
 
         return $sql;

--- a/ai-post-scheduler/includes/class-aips-generation-context-factory.php
+++ b/ai-post-scheduler/includes/class-aips-generation-context-factory.php
@@ -47,6 +47,11 @@ class AIPS_Generation_Context_Factory {
 	private $voices_repository;
 
 	/**
+	 * @var AIPS_Sources_Repository
+	 */
+	private $sources_repository;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -55,6 +60,7 @@ class AIPS_Generation_Context_Factory {
 		$this->author_topics_repository = new AIPS_Author_Topics_Repository();
 		$this->authors_repository = new AIPS_Authors_Repository();
 		$this->voices_repository = new AIPS_Voices_Repository();
+		$this->sources_repository = new AIPS_Sources_Repository();
 	}
 
 	/**
@@ -98,15 +104,17 @@ class AIPS_Generation_Context_Factory {
 
 			// Get topic string if available from topic_id
 			$topic_string = null;
+			$dossier_records = array();
 			if ($history->topic_id) {
 				$topic_data = $this->author_topics_repository->get_by_id($history->topic_id);
 				if ($topic_data) {
 					$topic_string = $topic_data->topic_title;
+					$dossier_records = $this->sources_repository->get_dossiers_for_relation('author_topic', (int) $history->topic_id);
 				}
 			}
 
 			// Create Template Context
-			$context['generation_context'] = new AIPS_Template_Context($template, $voice, $topic_string);
+			$context['generation_context'] = new AIPS_Template_Context($template, $voice, $topic_string, null, $dossier_records);
 			$context['context_type'] = 'template';
 			$context['context_name'] = $template->name;
 
@@ -123,7 +131,8 @@ class AIPS_Generation_Context_Factory {
 			}
 
 			// Create Topic Context
-			$context['generation_context'] = new AIPS_Topic_Context($author, $topic);
+			$dossier_records = $this->sources_repository->get_dossiers_for_relation('author_topic', (int) $topic->id);
+			$context['generation_context'] = new AIPS_Topic_Context($author, $topic, '', null, $dossier_records);
 			$context['context_type'] = 'topic';
 			$context['context_name'] = $author->name . ': ' . $topic->topic_title;
 

--- a/ai-post-scheduler/includes/class-aips-post-review-repository.php
+++ b/ai-post-scheduler/includes/class-aips-post-review-repository.php
@@ -29,6 +29,11 @@ class AIPS_Post_Review_Repository {
 	 * @var wpdb WordPress database abstraction object
 	 */
 	private $wpdb;
+
+	/**
+	 * @var AIPS_Sources_Repository
+	 */
+	private $sources_repository;
 	
 	/**
 	 * Initialize the repository.
@@ -37,6 +42,7 @@ class AIPS_Post_Review_Repository {
 		global $wpdb;
 		$this->wpdb = $wpdb;
 		$this->table_name = $wpdb->prefix . 'aips_history';
+		$this->sources_repository = new AIPS_Sources_Repository();
 	}
 	
 	/**
@@ -148,6 +154,29 @@ class AIPS_Post_Review_Repository {
 			);
 		}
 		
+		$topic_ids = array();
+		foreach ($results as $result) {
+			if (!empty($result->topic_id)) {
+				$topic_ids[] = (int) $result->topic_id;
+			}
+		}
+
+		$checklist_map = $this->sources_repository->get_dossier_checklist_by_author_topic_ids($topic_ids);
+
+		foreach ($results as $result) {
+			$result->dossier_checklist = array(
+				'dossier_count' => 0,
+				'citation_required_count' => 0,
+				'unverified_count' => 0,
+				'needs_attention' => false,
+				'summary' => __('No dossier items linked to this draft.', 'ai-post-scheduler'),
+			);
+
+			if (!empty($result->topic_id) && isset($checklist_map[(int) $result->topic_id])) {
+				$result->dossier_checklist = $checklist_map[(int) $result->topic_id];
+			}
+		}
+
 		return array(
 			'items' => $results,
 			'total' => (int) $total,

--- a/ai-post-scheduler/includes/class-aips-prompt-builder.php
+++ b/ai-post-scheduler/includes/class-aips-prompt-builder.php
@@ -291,6 +291,62 @@ INSTRUCTIONS;
     }
 
     /**
+     * Build an editorial dossier block for inclusion in AI prompts.
+     *
+     * @param array $dossier_records Dossier records associated with the generation context.
+     * @param array $preferences     Dossier prompt preferences.
+     * @return string Formatted dossier block or empty string.
+     */
+    public function build_dossier_block(array $dossier_records, array $preferences = array()) {
+        if (empty($dossier_records)) {
+            return '';
+        }
+
+        $preferences = wp_parse_args(
+            $preferences,
+            array(
+                'only_use_dossier_facts'        => false,
+                'mark_uncertain_claims'         => false,
+                'produce_knowledge_gap_section' => false,
+            )
+        );
+
+        $block = "Editorial dossier (formal research and sourcing record):\n";
+
+        if (!empty($preferences['only_use_dossier_facts'])) {
+            $block .= "- Use only the factual claims grounded in the dossier entries below.\n";
+            $block .= "- Do not introduce new factual assertions that are not supported by this dossier.\n";
+        }
+
+        if (!empty($preferences['mark_uncertain_claims'])) {
+            $block .= "- Clearly label any claim that depends on pending, disputed, or low-confidence dossier material as uncertain.\n";
+        }
+
+        if (!empty($preferences['produce_knowledge_gap_section'])) {
+            $block .= "- Include a short \"What we know / What we don't know\" section based on the dossier.\n";
+        }
+
+        foreach ($dossier_records as $record) {
+            $summary = !empty($record->quote_summary) ? trim($record->quote_summary) : __('No summary provided.', 'ai-post-scheduler');
+            $notes   = !empty($record->editor_notes) ? trim($record->editor_notes) : '';
+
+            $block .= "\n";
+            $block .= '- Source URL: ' . $record->source_url . "\n";
+            $block .= '- Source type: ' . (!empty($record->source_type) ? $record->source_type : __('General', 'ai-post-scheduler')) . "\n";
+            $block .= '- Verification status: ' . $record->verification_status . "\n";
+            $block .= '- Trust/confidence rating: ' . intval($record->trust_rating) . "/5\n";
+            $block .= '- Citation required: ' . (!empty($record->citation_required) ? 'yes' : 'no') . "\n";
+            $block .= '- Summary / quote: ' . $summary . "\n";
+
+            if (!empty($notes)) {
+                $block .= '- Editor notes: ' . $notes . "\n";
+            }
+        }
+
+        return $block . "\n";
+    }
+
+    /**
      * Build all prompts for a template configuration.
      *
      * Generates content, title, excerpt, and image prompts for a given template
@@ -348,6 +404,11 @@ INSTRUCTIONS;
                 'article_structure' => $structure_name,
                 'sample_topic' => $sample_topic,
                 'include_sources' => !empty($template_data->include_sources),
+                'dossier_prompt_preferences' => array(
+                    'only_use_dossier_facts' => !empty($template_data->dossier_only_facts),
+                    'mark_uncertain_claims' => !empty($template_data->dossier_mark_uncertain_claims),
+                    'produce_knowledge_gap_section' => !empty($template_data->dossier_include_knowledge_gaps),
+                ),
             ),
         );
     }
@@ -440,6 +501,8 @@ INSTRUCTIONS;
     public function inject_sources_into_content_prompt($prompt, $subject, $topic = null) {
         $include_sources = false;
         $group_ids       = array();
+        $dossier_records = array();
+        $dossier_preferences = array();
 
         // Context-based flow implements the generation context interface.
         if ($subject instanceof AIPS_Generation_Context) {
@@ -447,6 +510,9 @@ INSTRUCTIONS;
                 $include_sources = true;
                 $group_ids       = $subject->get_source_group_ids();
             }
+
+            $dossier_records     = $subject->get_dossier_records();
+            $dossier_preferences = $subject->get_dossier_prompt_preferences();
         } else {
             // Legacy template object flow.
             if (!empty($subject) && !empty($subject->include_sources)) {
@@ -458,16 +524,26 @@ INSTRUCTIONS;
             }
         }
 
-        if (!$include_sources) {
+        $prefix = '';
+
+        if ($include_sources) {
+            $sources_block = $this->build_sources_block($group_ids);
+            if (!empty($sources_block)) {
+                $prefix .= $sources_block;
+            }
+        }
+
+        if (!empty($dossier_records)) {
+            $dossier_block = $this->build_dossier_block($dossier_records, $dossier_preferences);
+            if (!empty($dossier_block)) {
+                $prefix .= $dossier_block;
+            }
+        }
+
+        if (empty($prefix)) {
             return $prompt;
         }
 
-        $sources_block = $this->build_sources_block($group_ids);
-
-        if (empty($sources_block)) {
-            return $prompt;
-        }
-
-        return $sources_block . $prompt;
+        return $prefix . $prompt;
     }
 }

--- a/ai-post-scheduler/includes/class-aips-settings.php
+++ b/ai-post-scheduler/includes/class-aips-settings.php
@@ -1222,8 +1222,9 @@ class AIPS_Settings {
      * @return void
      */
     public function render_sources_page() {
-        $repo    = new AIPS_Sources_Repository();
-        $sources = $repo->get_all(false);
+        $repo     = new AIPS_Sources_Repository();
+        $sources  = $repo->get_all(false);
+        $dossiers = $repo->get_dossiers(array('limit' => 250));
 
         // Build source group name map: term_id => name (avoid per-row get_term calls in the template).
         $source_groups = get_terms(array(
@@ -1241,6 +1242,8 @@ class AIPS_Settings {
         // Build source → term IDs map: source_id => int[] (one query, not N queries).
         $all_source_ids = array_map(function ($s) { return (int) $s->id; }, $sources);
         $source_term_ids_map = $repo->get_term_ids_for_sources($all_source_ids);
+        $dossier_relation_types = $repo->get_dossier_relation_types();
+        $dossier_statuses       = $repo->get_dossier_verification_statuses();
 
         include AIPS_PLUGIN_DIR . 'templates/admin/sources.php';
     }

--- a/ai-post-scheduler/includes/class-aips-sources-controller.php
+++ b/ai-post-scheduler/includes/class-aips-sources-controller.php
@@ -42,6 +42,9 @@ class AIPS_Sources_Controller {
 		add_action('wp_ajax_aips_get_source_groups', array($this, 'ajax_get_source_groups'));
 		add_action('wp_ajax_aips_save_source_group', array($this, 'ajax_save_source_group'));
 		add_action('wp_ajax_aips_delete_source_group', array($this, 'ajax_delete_source_group'));
+		add_action('wp_ajax_aips_get_source_dossiers', array($this, 'ajax_get_source_dossiers'));
+		add_action('wp_ajax_aips_save_source_dossier', array($this, 'ajax_save_source_dossier'));
+		add_action('wp_ajax_aips_delete_source_dossier', array($this, 'ajax_delete_source_dossier'));
 	}
 
 	/**
@@ -331,5 +334,118 @@ class AIPS_Sources_Controller {
 		}
 
 		wp_send_json_success(array('message' => __('Source group deleted.', 'ai-post-scheduler')));
+	}
+
+	/**
+	 * Return dossier records for the editorial workflow UI.
+	 *
+	 * @return void Sends JSON response.
+	 */
+	public function ajax_get_source_dossiers() {
+		check_ajax_referer('aips_ajax_nonce', 'nonce');
+
+		if (!current_user_can('manage_options')) {
+			wp_send_json_error(array('message' => __('Permission denied.', 'ai-post-scheduler')));
+		}
+
+		$dossiers = $this->repo->get_dossiers(array('limit' => 250));
+
+		wp_send_json_success(array('dossiers' => $dossiers));
+	}
+
+	/**
+	 * Create or update an editorial dossier record.
+	 *
+	 * @return void Sends JSON response.
+	 */
+	public function ajax_save_source_dossier() {
+		check_ajax_referer('aips_ajax_nonce', 'nonce');
+
+		if (!current_user_can('manage_options')) {
+			wp_send_json_error(array('message' => __('Permission denied.', 'ai-post-scheduler')));
+		}
+
+		$dossier_id          = isset($_POST['dossier_id']) ? absint($_POST['dossier_id']) : 0;
+		$source_id           = isset($_POST['source_id']) ? absint($_POST['source_id']) : 0;
+		$relation_type       = isset($_POST['relation_type']) ? sanitize_key(wp_unslash($_POST['relation_type'])) : 'author_topic';
+		$relation_id         = isset($_POST['relation_id']) ? absint($_POST['relation_id']) : 0;
+		$source_url          = isset($_POST['source_url']) ? esc_url_raw(wp_unslash($_POST['source_url'])) : '';
+		$source_type         = isset($_POST['source_type']) ? sanitize_text_field(wp_unslash($_POST['source_type'])) : '';
+		$quote_summary       = isset($_POST['quote_summary']) ? sanitize_textarea_field(wp_unslash($_POST['quote_summary'])) : '';
+		$trust_rating        = isset($_POST['trust_rating']) ? absint($_POST['trust_rating']) : 3;
+		$citation_required   = isset($_POST['citation_required']) ? 1 : 0;
+		$verification_status = isset($_POST['verification_status']) ? sanitize_key(wp_unslash($_POST['verification_status'])) : 'pending';
+		$editor_notes        = isset($_POST['editor_notes']) ? sanitize_textarea_field(wp_unslash($_POST['editor_notes'])) : '';
+
+		if (empty($relation_id)) {
+			wp_send_json_error(array('message' => __('A related editorial record ID is required.', 'ai-post-scheduler')));
+		}
+
+		if (empty($source_url) || !filter_var($source_url, FILTER_VALIDATE_URL)) {
+			wp_send_json_error(array('message' => __('Please enter a valid source URL.', 'ai-post-scheduler')));
+		}
+
+		$data = array(
+			'source_id'           => $source_id,
+			'relation_type'       => $relation_type,
+			'relation_id'         => $relation_id,
+			'source_url'          => $source_url,
+			'source_type'         => $source_type,
+			'quote_summary'       => $quote_summary,
+			'trust_rating'        => $trust_rating,
+			'citation_required'   => $citation_required,
+			'verification_status' => $verification_status,
+			'editor_notes'        => $editor_notes,
+		);
+
+		if ($dossier_id > 0) {
+			$result = $this->repo->update_dossier($dossier_id, $data);
+			if (!$result) {
+				wp_send_json_error(array('message' => __('Failed to update dossier record.', 'ai-post-scheduler')));
+			}
+
+			wp_send_json_success(
+				array(
+					'message' => __('Dossier record updated.', 'ai-post-scheduler'),
+					'dossier' => $this->repo->get_dossier_by_id($dossier_id),
+				)
+			);
+		}
+
+		$new_id = $this->repo->create_dossier($data);
+		if (!$new_id) {
+			wp_send_json_error(array('message' => __('Failed to create dossier record.', 'ai-post-scheduler')));
+		}
+
+		wp_send_json_success(
+			array(
+				'message' => __('Dossier record created.', 'ai-post-scheduler'),
+				'dossier' => $this->repo->get_dossier_by_id($new_id),
+			)
+		);
+	}
+
+	/**
+	 * Delete an editorial dossier record.
+	 *
+	 * @return void Sends JSON response.
+	 */
+	public function ajax_delete_source_dossier() {
+		check_ajax_referer('aips_ajax_nonce', 'nonce');
+
+		if (!current_user_can('manage_options')) {
+			wp_send_json_error(array('message' => __('Permission denied.', 'ai-post-scheduler')));
+		}
+
+		$dossier_id = isset($_POST['dossier_id']) ? absint($_POST['dossier_id']) : 0;
+		if (!$dossier_id) {
+			wp_send_json_error(array('message' => __('Invalid dossier ID.', 'ai-post-scheduler')));
+		}
+
+		if (!$this->repo->delete_dossier($dossier_id)) {
+			wp_send_json_error(array('message' => __('Failed to delete dossier record.', 'ai-post-scheduler')));
+		}
+
+		wp_send_json_success(array('message' => __('Dossier record deleted.', 'ai-post-scheduler')));
 	}
 }

--- a/ai-post-scheduler/includes/class-aips-sources-repository.php
+++ b/ai-post-scheduler/includes/class-aips-sources-repository.php
@@ -31,6 +31,11 @@ class AIPS_Sources_Repository {
 	private $groups_table;
 
 	/**
+	 * @var string The source dossier records table name (with prefix).
+	 */
+	private $dossiers_table;
+
+	/**
 	 * @var wpdb WordPress database abstraction object.
 	 */
 	private $wpdb;
@@ -40,9 +45,10 @@ class AIPS_Sources_Repository {
 	 */
 	public function __construct() {
 		global $wpdb;
-		$this->wpdb         = $wpdb;
-		$this->table_name   = $wpdb->prefix . 'aips_sources';
-		$this->groups_table = $wpdb->prefix . 'aips_source_group_terms';
+		$this->wpdb          = $wpdb;
+		$this->table_name    = $wpdb->prefix . 'aips_sources';
+		$this->groups_table  = $wpdb->prefix . 'aips_source_group_terms';
+		$this->dossiers_table = $wpdb->prefix . 'aips_source_dossiers';
 	}
 
 	/**
@@ -351,5 +357,321 @@ class AIPS_Sources_Repository {
 			array('source_id' => $source_id),
 			array('%d')
 		);
+	}
+
+	/**
+	 * Get available dossier relation types.
+	 *
+	 * @return array<string,string> Map of relation type => label.
+	 */
+	public function get_dossier_relation_types() {
+		return array(
+			'author_topic'      => __('Author Topic', 'ai-post-scheduler'),
+			'research_item'     => __('Research Item', 'ai-post-scheduler'),
+			'story_budget_item' => __('Story Budget Item', 'ai-post-scheduler'),
+		);
+	}
+
+	/**
+	 * Get dossier verification status labels.
+	 *
+	 * @return array<string,string> Map of status => label.
+	 */
+	public function get_dossier_verification_statuses() {
+		return array(
+			'pending'      => __('Pending Verification', 'ai-post-scheduler'),
+			'verified'     => __('Verified', 'ai-post-scheduler'),
+			'needs_review' => __('Needs Review', 'ai-post-scheduler'),
+			'disputed'     => __('Disputed', 'ai-post-scheduler'),
+		);
+	}
+
+	/**
+	 * Get dossier records with optional filtering.
+	 *
+	 * @param array $args Optional query args.
+	 * @return array Array of dossier objects.
+	 */
+	public function get_dossiers($args = array()) {
+		$defaults = array(
+			'relation_type' => '',
+			'relation_id'   => 0,
+			'source_id'     => 0,
+			'limit'         => 100,
+		);
+
+		$args = wp_parse_args($args, $defaults);
+
+		$where = array('1=1');
+		$values = array();
+
+		if (!empty($args['relation_type'])) {
+			$where[]  = 'd.relation_type = %s';
+			$values[] = sanitize_key($args['relation_type']);
+		}
+
+		if (!empty($args['relation_id'])) {
+			$where[]  = 'd.relation_id = %d';
+			$values[] = absint($args['relation_id']);
+		}
+
+		if (!empty($args['source_id'])) {
+			$where[]  = 'd.source_id = %d';
+			$values[] = absint($args['source_id']);
+		}
+
+		$limit = max(1, min(500, absint($args['limit'])));
+
+		$query = "
+			SELECT d.*, s.label AS source_label
+			FROM {$this->dossiers_table} d
+			LEFT JOIN {$this->table_name} s ON s.id = d.source_id
+			WHERE " . implode(' AND ', $where) . '
+			ORDER BY d.updated_at DESC, d.id DESC
+			LIMIT %d
+		';
+
+		$values[] = $limit;
+
+		$results = $this->wpdb->get_results($this->wpdb->prepare($query, $values));
+
+		return array_map(array($this, 'hydrate_dossier_record'), $results);
+	}
+
+	/**
+	 * Get a single dossier record by ID.
+	 *
+	 * @param int $id Dossier ID.
+	 * @return object|null Dossier object or null if not found.
+	 */
+	public function get_dossier_by_id($id) {
+		$query = $this->wpdb->prepare(
+			"SELECT d.*, s.label AS source_label
+			FROM {$this->dossiers_table} d
+			LEFT JOIN {$this->table_name} s ON s.id = d.source_id
+			WHERE d.id = %d",
+			$id
+		);
+
+		$row = $this->wpdb->get_row($query);
+
+		return $row ? $this->hydrate_dossier_record($row) : null;
+	}
+
+	/**
+	 * Create a new dossier record.
+	 *
+	 * @param array $data Dossier data.
+	 * @return int|false Insert ID or false on failure.
+	 */
+	public function create_dossier($data) {
+		$insert_data = $this->sanitize_dossier_data($data);
+		$result      = $this->wpdb->insert(
+			$this->dossiers_table,
+			$insert_data,
+			array('%d', '%s', '%d', '%s', '%s', '%s', '%d', '%d', '%s', '%s')
+		);
+
+		return $result ? $this->wpdb->insert_id : false;
+	}
+
+	/**
+	 * Update a dossier record.
+	 *
+	 * @param int   $id   Dossier ID.
+	 * @param array $data Partial dossier data.
+	 * @return bool True on success.
+	 */
+	public function update_dossier($id, $data) {
+		$update_data = $this->sanitize_dossier_data($data, true);
+		if (empty($update_data)) {
+			return false;
+		}
+
+		$format = array();
+		foreach ($update_data as $key => $value) {
+			if (in_array($key, array('source_id', 'relation_id', 'trust_rating', 'citation_required'), true)) {
+				$format[] = '%d';
+			} else {
+				$format[] = '%s';
+			}
+		}
+
+		return $this->wpdb->update(
+			$this->dossiers_table,
+			$update_data,
+			array('id' => $id),
+			$format,
+			array('%d')
+		) !== false;
+	}
+
+	/**
+	 * Delete a dossier record.
+	 *
+	 * @param int $id Dossier ID.
+	 * @return bool True on success.
+	 */
+	public function delete_dossier($id) {
+		return $this->wpdb->delete(
+			$this->dossiers_table,
+			array('id' => $id),
+			array('%d')
+		) !== false;
+	}
+
+	/**
+	 * Get dossier records for a single editorial relation.
+	 *
+	 * @param string $relation_type Relation type.
+	 * @param int    $relation_id   Relation ID.
+	 * @return array Array of dossier records.
+	 */
+	public function get_dossiers_for_relation($relation_type, $relation_id) {
+		return $this->get_dossiers(
+			array(
+				'relation_type' => $relation_type,
+				'relation_id'   => $relation_id,
+				'limit'         => 250,
+			)
+		);
+	}
+
+	/**
+	 * Build pre-publish checklist data for author-topic-linked draft posts.
+	 *
+	 * @param int[] $topic_ids Topic IDs.
+	 * @return array<int,array<string,mixed>> Topic ID => checklist data.
+	 */
+	public function get_dossier_checklist_by_author_topic_ids(array $topic_ids) {
+		$topic_ids = array_values(array_filter(array_map('absint', $topic_ids)));
+		if (empty($topic_ids)) {
+			return array();
+		}
+
+		$placeholders = implode(',', array_fill(0, count($topic_ids), '%d'));
+
+		// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		$query = $this->wpdb->prepare(
+			"SELECT relation_id,
+				COUNT(*) AS dossier_count,
+				SUM(CASE WHEN citation_required = 1 THEN 1 ELSE 0 END) AS citation_required_count,
+				SUM(CASE WHEN verification_status != 'verified' THEN 1 ELSE 0 END) AS unverified_count
+			FROM {$this->dossiers_table}
+			WHERE relation_type = 'author_topic'
+				AND relation_id IN ($placeholders)
+			GROUP BY relation_id",
+			...$topic_ids
+		);
+		// phpcs:enable WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+
+		$rows = $this->wpdb->get_results($query);
+		$map  = array();
+
+		foreach ($rows as $row) {
+			$topic_id = (int) $row->relation_id;
+			$citation_required = (int) $row->citation_required_count;
+			$unverified        = (int) $row->unverified_count;
+
+			$messages = array();
+			if ($citation_required > 0) {
+				$messages[] = sprintf(
+					_n('%d dossier item still needs citation coverage', '%d dossier items still need citation coverage', $citation_required, 'ai-post-scheduler'),
+					$citation_required
+				);
+			}
+			if ($unverified > 0) {
+				$messages[] = sprintf(
+					_n('%d dossier item is not verified', '%d dossier items are not verified', $unverified, 'ai-post-scheduler'),
+					$unverified
+				);
+			}
+
+			$map[$topic_id] = array(
+				'dossier_count'            => (int) $row->dossier_count,
+				'citation_required_count'  => $citation_required,
+				'unverified_count'         => $unverified,
+				'needs_attention'          => ($citation_required > 0 || $unverified > 0),
+				'summary'                  => empty($messages)
+					? __('Research dossier checks are complete.', 'ai-post-scheduler')
+					: implode('. ', $messages) . '.',
+			);
+		}
+
+		return $map;
+	}
+
+	/**
+	 * Sanitize dossier input before persistence.
+	 *
+	 * @param array $data Raw dossier data.
+	 * @param bool  $partial True when sanitizing a partial update payload.
+	 * @return array Sanitized dossier data.
+	 */
+	private function sanitize_dossier_data($data, $partial = false) {
+		$allowed_relation_types       = array_keys($this->get_dossier_relation_types());
+		$allowed_verification_status  = array_keys($this->get_dossier_verification_statuses());
+		$sanitized                    = array();
+
+		if (!$partial || array_key_exists('source_id', $data)) {
+			$sanitized['source_id'] = !empty($data['source_id']) ? absint($data['source_id']) : 0;
+		}
+
+		if (!$partial || array_key_exists('relation_type', $data)) {
+			$relation_type = isset($data['relation_type']) ? sanitize_key($data['relation_type']) : 'author_topic';
+			$sanitized['relation_type'] = in_array($relation_type, $allowed_relation_types, true) ? $relation_type : 'author_topic';
+		}
+
+		if (!$partial || array_key_exists('relation_id', $data)) {
+			$sanitized['relation_id'] = isset($data['relation_id']) ? absint($data['relation_id']) : 0;
+		}
+
+		if (!$partial || array_key_exists('source_url', $data)) {
+			$sanitized['source_url'] = isset($data['source_url']) ? esc_url_raw($data['source_url']) : '';
+		}
+
+		if (!$partial || array_key_exists('source_type', $data)) {
+			$sanitized['source_type'] = isset($data['source_type']) ? sanitize_text_field($data['source_type']) : '';
+		}
+
+		if (!$partial || array_key_exists('quote_summary', $data)) {
+			$sanitized['quote_summary'] = isset($data['quote_summary']) ? sanitize_textarea_field($data['quote_summary']) : '';
+		}
+
+		if (!$partial || array_key_exists('trust_rating', $data)) {
+			$trust_rating = isset($data['trust_rating']) ? absint($data['trust_rating']) : 3;
+			$sanitized['trust_rating'] = min(5, max(1, $trust_rating));
+		}
+
+		if (!$partial || array_key_exists('citation_required', $data)) {
+			$sanitized['citation_required'] = !empty($data['citation_required']) ? 1 : 0;
+		}
+
+		if (!$partial || array_key_exists('verification_status', $data)) {
+			$verification_status = isset($data['verification_status']) ? sanitize_key($data['verification_status']) : 'pending';
+			$sanitized['verification_status'] = in_array($verification_status, $allowed_verification_status, true) ? $verification_status : 'pending';
+		}
+
+		if (!$partial || array_key_exists('editor_notes', $data)) {
+			$sanitized['editor_notes'] = isset($data['editor_notes']) ? sanitize_textarea_field($data['editor_notes']) : '';
+		}
+
+		return $sanitized;
+	}
+
+	/**
+	 * Normalize dossier row values before returning them to callers.
+	 *
+	 * @param object $row Raw DB row.
+	 * @return object Normalized dossier row.
+	 */
+	private function hydrate_dossier_record($row) {
+		$row->id                = isset($row->id) ? (int) $row->id : 0;
+		$row->source_id         = isset($row->source_id) ? (int) $row->source_id : 0;
+		$row->relation_id       = isset($row->relation_id) ? (int) $row->relation_id : 0;
+		$row->trust_rating      = isset($row->trust_rating) ? (int) $row->trust_rating : 3;
+		$row->citation_required = !empty($row->citation_required) ? 1 : 0;
+
+		return $row;
 	}
 }

--- a/ai-post-scheduler/includes/class-aips-template-context.php
+++ b/ai-post-scheduler/includes/class-aips-template-context.php
@@ -35,6 +35,16 @@ class AIPS_Template_Context implements AIPS_Generation_Context {
 	private $creation_method;
 
 	/**
+	 * @var array Dossier records attached to this generation context.
+	 */
+	private $dossier_records;
+
+	/**
+	 * @var array Dossier-aware prompt preferences for this template.
+	 */
+	private $dossier_prompt_preferences;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param object      $template Template object.
@@ -42,11 +52,20 @@ class AIPS_Template_Context implements AIPS_Generation_Context {
 	 * @param string|null $topic    Optional topic string.
 	 * @param string|null $creation_method Optional creation method.
 	 */
-	public function __construct($template, $voice = null, $topic = null, $creation_method = null) {
-		$this->template = $template;
-		$this->voice = $voice;
-		$this->topic = $topic;
-		$this->creation_method = $creation_method;
+	public function __construct($template, $voice = null, $topic = null, $creation_method = null, $dossier_records = array(), $dossier_prompt_preferences = array()) {
+		$this->template                  = $template;
+		$this->voice                     = $voice;
+		$this->topic                     = $topic;
+		$this->creation_method           = $creation_method;
+		$this->dossier_records           = is_array($dossier_records) ? $dossier_records : array();
+		$this->dossier_prompt_preferences = wp_parse_args(
+			$dossier_prompt_preferences,
+			array(
+				'only_use_dossier_facts'      => !empty($template->dossier_only_facts),
+				'mark_uncertain_claims'       => !empty($template->dossier_mark_uncertain_claims),
+				'produce_knowledge_gap_section' => !empty($template->dossier_include_knowledge_gaps),
+			)
+		);
 	}
 
 	/**
@@ -257,6 +276,24 @@ class AIPS_Template_Context implements AIPS_Generation_Context {
 	}
 
 	/**
+	 * Get dossier records attached to this context.
+	 *
+	 * @return array
+	 */
+	public function get_dossier_records() {
+		return $this->dossier_records;
+	}
+
+	/**
+	 * Get dossier-aware prompt preferences.
+	 *
+	 * @return array<string,bool>
+	 */
+	public function get_dossier_prompt_preferences() {
+		return $this->dossier_prompt_preferences;
+	}
+
+	/**
 	 * Get all context data as an array.
 	 *
 	 * @return array Context data.
@@ -285,6 +322,12 @@ class AIPS_Template_Context implements AIPS_Generation_Context {
 		if ($this->get_article_structure_id()) {
 			$data['article_structure_id'] = $this->get_article_structure_id();
 		}
+
+		if (!empty($this->dossier_records)) {
+			$data['dossier_records'] = $this->dossier_records;
+		}
+
+		$data['dossier_prompt_preferences'] = $this->get_dossier_prompt_preferences();
 
 		return $data;
 	}

--- a/ai-post-scheduler/includes/class-aips-template-repository.php
+++ b/ai-post-scheduler/includes/class-aips-template-repository.php
@@ -135,10 +135,13 @@ class AIPS_Template_Repository {
             'post_author' => isset($data['post_author']) ? absint($data['post_author']) : get_current_user_id(),
             'include_sources' => isset($data['include_sources']) ? (int) $data['include_sources'] : 0,
             'source_group_ids' => isset($data['source_group_ids']) ? sanitize_text_field($data['source_group_ids']) : wp_json_encode(array()),
+            'dossier_only_facts' => isset($data['dossier_only_facts']) ? (int) $data['dossier_only_facts'] : 0,
+            'dossier_mark_uncertain_claims' => isset($data['dossier_mark_uncertain_claims']) ? (int) $data['dossier_mark_uncertain_claims'] : 0,
+            'dossier_include_knowledge_gaps' => isset($data['dossier_include_knowledge_gaps']) ? (int) $data['dossier_include_knowledge_gaps'] : 0,
             'is_active' => isset($data['is_active']) ? 1 : 0,
         );
         
-        $format = array('%s', '%s', '%s', '%d', '%d', '%s', '%d', '%s', '%s', '%s', '%s', '%d', '%s', '%d', '%d', '%s', '%d');
+        $format = array('%s', '%s', '%s', '%d', '%d', '%s', '%d', '%s', '%s', '%s', '%s', '%d', '%s', '%d', '%d', '%s', '%d', '%d', '%d', '%d');
         
         $result = $this->wpdb->insert($this->table_name, $insert_data, $format);
         
@@ -236,6 +239,21 @@ class AIPS_Template_Repository {
         if (isset($data['source_group_ids'])) {
             $update_data['source_group_ids'] = sanitize_text_field($data['source_group_ids']);
             $format[] = '%s';
+        }
+
+        if (isset($data['dossier_only_facts'])) {
+            $update_data['dossier_only_facts'] = (int) $data['dossier_only_facts'];
+            $format[] = '%d';
+        }
+
+        if (isset($data['dossier_mark_uncertain_claims'])) {
+            $update_data['dossier_mark_uncertain_claims'] = (int) $data['dossier_mark_uncertain_claims'];
+            $format[] = '%d';
+        }
+
+        if (isset($data['dossier_include_knowledge_gaps'])) {
+            $update_data['dossier_include_knowledge_gaps'] = (int) $data['dossier_include_knowledge_gaps'];
+            $format[] = '%d';
         }
         
         if (isset($data['is_active'])) {

--- a/ai-post-scheduler/includes/class-aips-templates-controller.php
+++ b/ai-post-scheduler/includes/class-aips-templates-controller.php
@@ -48,6 +48,9 @@ class AIPS_Templates_Controller {
             'source_group_ids' => isset($_POST['source_group_ids']) && is_array($_POST['source_group_ids'])
                 ? wp_json_encode(array_map('absint', $_POST['source_group_ids']))
                 : wp_json_encode(array()),
+            'dossier_only_facts' => isset($_POST['dossier_only_facts']) ? 1 : 0,
+            'dossier_mark_uncertain_claims' => isset($_POST['dossier_mark_uncertain_claims']) ? 1 : 0,
+            'dossier_include_knowledge_gaps' => isset($_POST['dossier_include_knowledge_gaps']) ? 1 : 0,
             'is_active' => isset($_POST['is_active']) ? 1 : 0,
         );
 
@@ -150,6 +153,9 @@ class AIPS_Templates_Controller {
             'post_author' => $template->post_author,
             'include_sources' => isset($template->include_sources) ? $template->include_sources : 0,
             'source_group_ids' => isset($template->source_group_ids) ? $template->source_group_ids : wp_json_encode(array()),
+            'dossier_only_facts' => isset($template->dossier_only_facts) ? $template->dossier_only_facts : 0,
+            'dossier_mark_uncertain_claims' => isset($template->dossier_mark_uncertain_claims) ? $template->dossier_mark_uncertain_claims : 0,
+            'dossier_include_knowledge_gaps' => isset($template->dossier_include_knowledge_gaps) ? $template->dossier_include_knowledge_gaps : 0,
             'is_active' => $template->is_active,
         );
 
@@ -193,6 +199,13 @@ class AIPS_Templates_Controller {
             'post_category' => isset($_POST['post_category']) ? absint($_POST['post_category']) : 0,
             'post_tags' => isset($_POST['post_tags']) ? sanitize_text_field($_POST['post_tags']) : '',
             'post_author' => isset($_POST['post_author']) ? absint($_POST['post_author']) : get_current_user_id(),
+            'include_sources' => isset($_POST['include_sources']) ? 1 : 0,
+            'source_group_ids' => isset($_POST['source_group_ids']) && is_array($_POST['source_group_ids'])
+                ? wp_json_encode(array_map('absint', $_POST['source_group_ids']))
+                : wp_json_encode(array()),
+            'dossier_only_facts' => isset($_POST['dossier_only_facts']) ? 1 : 0,
+            'dossier_mark_uncertain_claims' => isset($_POST['dossier_mark_uncertain_claims']) ? 1 : 0,
+            'dossier_include_knowledge_gaps' => isset($_POST['dossier_include_knowledge_gaps']) ? 1 : 0,
         );
 
         if (empty($data['prompt_template'])) {
@@ -257,6 +270,9 @@ class AIPS_Templates_Controller {
             'source_group_ids' => isset($_POST['source_group_ids']) && is_array($_POST['source_group_ids'])
                 ? wp_json_encode(array_map('absint', $_POST['source_group_ids']))
                 : wp_json_encode(array()),
+            'dossier_only_facts' => isset($_POST['dossier_only_facts']) ? 1 : 0,
+            'dossier_mark_uncertain_claims' => isset($_POST['dossier_mark_uncertain_claims']) ? 1 : 0,
+            'dossier_include_knowledge_gaps' => isset($_POST['dossier_include_knowledge_gaps']) ? 1 : 0,
         );
 
         if (empty($template_data->prompt_template)) {

--- a/ai-post-scheduler/includes/class-aips-templates.php
+++ b/ai-post-scheduler/includes/class-aips-templates.php
@@ -69,6 +69,9 @@ class AIPS_Templates {
             'post_author' => isset($data['post_author']) ? absint($data['post_author']) : get_current_user_id(),
             'include_sources' => isset($data['include_sources']) ? (int) $data['include_sources'] : 0,
             'source_group_ids' => isset($data['source_group_ids']) ? sanitize_text_field($data['source_group_ids']) : wp_json_encode(array()),
+            'dossier_only_facts' => isset($data['dossier_only_facts']) ? (int) $data['dossier_only_facts'] : 0,
+            'dossier_mark_uncertain_claims' => isset($data['dossier_mark_uncertain_claims']) ? (int) $data['dossier_mark_uncertain_claims'] : 0,
+            'dossier_include_knowledge_gaps' => isset($data['dossier_include_knowledge_gaps']) ? (int) $data['dossier_include_knowledge_gaps'] : 0,
             'is_active' => isset($data['is_active']) ? 1 : 0,
         );
         

--- a/ai-post-scheduler/includes/class-aips-topic-context.php
+++ b/ai-post-scheduler/includes/class-aips-topic-context.php
@@ -35,6 +35,11 @@ class AIPS_Topic_Context implements AIPS_Generation_Context {
 	private $creation_method;
 
 	/**
+	 * @var array Dossier records attached to the author topic.
+	 */
+	private $dossier_records;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param object $author            Author object.
@@ -42,11 +47,12 @@ class AIPS_Topic_Context implements AIPS_Generation_Context {
 	 * @param string $expanded_context  Optional expanded context from similar topics.
 	 * @param string|null $creation_method Optional creation method.
 	 */
-	public function __construct($author, $topic, $expanded_context = '', $creation_method = null) {
-		$this->author = $author;
-		$this->topic = $topic;
+	public function __construct($author, $topic, $expanded_context = '', $creation_method = null, $dossier_records = null) {
+		$this->author           = $author;
+		$this->topic            = $topic;
 		$this->expanded_context = $expanded_context;
-		$this->creation_method = $creation_method;
+		$this->creation_method  = $creation_method;
+		$this->dossier_records  = is_array($dossier_records) ? $dossier_records : $this->load_topic_dossiers();
 	}
 
 	/**
@@ -280,6 +286,28 @@ class AIPS_Topic_Context implements AIPS_Generation_Context {
 	}
 
 	/**
+	 * Get dossier records attached to this topic.
+	 *
+	 * @return array
+	 */
+	public function get_dossier_records() {
+		return $this->dossier_records;
+	}
+
+	/**
+	 * Get dossier-aware prompt preferences for topic generation.
+	 *
+	 * @return array<string,bool>
+	 */
+	public function get_dossier_prompt_preferences() {
+		return array(
+			'only_use_dossier_facts'        => false,
+			'mark_uncertain_claims'         => !empty($this->dossier_records),
+			'produce_knowledge_gap_section' => !empty($this->dossier_records),
+		);
+	}
+
+	/**
 	 * Get all context data as an array.
 	 *
 	 * @return array Context data.
@@ -302,6 +330,28 @@ class AIPS_Topic_Context implements AIPS_Generation_Context {
 			'article_structure_id' => $this->get_article_structure_id(),
 			'voice_tone' => isset($this->author->voice_tone) ? $this->author->voice_tone : '',
 			'writing_style' => isset($this->author->writing_style) ? $this->author->writing_style : '',
+			'dossier_records' => $this->get_dossier_records(),
+			'dossier_prompt_preferences' => $this->get_dossier_prompt_preferences(),
 		);
+	}
+
+	/**
+	 * Load dossier records attached to the current author topic.
+	 *
+	 * @return array
+	 */
+	private function load_topic_dossiers() {
+		if (empty($this->topic->id)) {
+			return array();
+		}
+
+		global $wpdb;
+		if (!is_object($wpdb) || !method_exists($wpdb, 'get_results')) {
+			return array();
+		}
+
+		$repo = new AIPS_Sources_Repository();
+
+		return $repo->get_dossiers_for_relation('author_topic', (int) $this->topic->id);
 	}
 }

--- a/ai-post-scheduler/includes/interface-aips-generation-context.php
+++ b/ai-post-scheduler/includes/interface-aips-generation-context.php
@@ -166,6 +166,20 @@ interface AIPS_Generation_Context {
 	public function get_source_group_ids();
 
 	/**
+	 * Get dossier records attached to the editorial item that is being generated.
+	 *
+	 * @return array Array of dossier record objects.
+	 */
+	public function get_dossier_records();
+
+	/**
+	 * Get dossier-aware prompt preferences for this context.
+	 *
+	 * @return array<string,bool> Prompt preferences keyed by feature flag.
+	 */
+	public function get_dossier_prompt_preferences();
+
+	/**
 	 * Get all context data as an array for serialization/storage.
 	 *
 	 * @return array Context data array.

--- a/ai-post-scheduler/templates/admin/post-review.php
+++ b/ai-post-scheduler/templates/admin/post-review.php
@@ -151,6 +151,14 @@ $templates = $template_repository->get_all();
 											esc_html(date_i18n(get_option('date_format'), strtotime($item->post_modified)))
 										); ?>
 									</div>
+									<?php if (!empty($item->dossier_checklist) && is_array($item->dossier_checklist)): ?>
+										<div class="aips-table-meta" style="margin-top:6px;">
+											<strong><?php esc_html_e('Pre-publish checklist:', 'ai-post-scheduler'); ?></strong>
+											<span class="aips-badge <?php echo !empty($item->dossier_checklist['needs_attention']) ? 'aips-badge-warning' : 'aips-badge-success'; ?>">
+												<?php echo esc_html($item->dossier_checklist['summary']); ?>
+											</span>
+										</div>
+									<?php endif; ?>
 								</td>
 								<td class="column-template">
 									<?php if ($item->template_name): ?>

--- a/ai-post-scheduler/templates/admin/sources.php
+++ b/ai-post-scheduler/templates/admin/sources.php
@@ -36,6 +36,24 @@ if (!isset($source_group_name_map) || !is_array($source_group_name_map)) {
 if (!isset($source_term_ids_map) || !is_array($source_term_ids_map)) {
 	$source_term_ids_map = array();
 }
+if (!isset($dossiers) || !is_array($dossiers)) {
+	$dossiers = array();
+}
+if (!isset($dossier_relation_types) || !is_array($dossier_relation_types)) {
+	$dossier_relation_types = array(
+		'author_topic'      => __('Author Topic', 'ai-post-scheduler'),
+		'research_item'     => __('Research Item', 'ai-post-scheduler'),
+		'story_budget_item' => __('Story Budget Item', 'ai-post-scheduler'),
+	);
+}
+if (!isset($dossier_statuses) || !is_array($dossier_statuses)) {
+	$dossier_statuses = array(
+		'pending'      => __('Pending Verification', 'ai-post-scheduler'),
+		'verified'     => __('Verified', 'ai-post-scheduler'),
+		'needs_review' => __('Needs Review', 'ai-post-scheduler'),
+		'disputed'     => __('Disputed', 'ai-post-scheduler'),
+	);
+}
 ?>
 <div class="wrap aips-wrap">
 	<div class="aips-page-container">
@@ -195,6 +213,101 @@ if (!isset($source_term_ids_map) || !is_array($source_term_ids_map)) {
 			<?php endif; ?>
 		</div>
 
+		<div class="aips-content-panel" style="margin-top:24px;">
+			<div class="aips-panel-header" style="display:flex; align-items:center; justify-content:space-between; gap:16px;">
+				<div>
+					<h2 style="margin:0;"><?php esc_html_e('Editorial Dossiers', 'ai-post-scheduler'); ?></h2>
+					<p class="description" style="margin:4px 0 0;"><?php esc_html_e('Capture formal research notes, supporting quotes, and verification status before generation. Dossiers can be attached to research items, author topics, or story-budget items.', 'ai-post-scheduler'); ?></p>
+				</div>
+				<button type="button" class="aips-btn aips-btn-primary" id="aips-add-dossier-btn">
+					<span class="dashicons dashicons-media-document"></span>
+					<?php esc_html_e('Add Dossier Record', 'ai-post-scheduler'); ?>
+				</button>
+			</div>
+
+			<?php if (!empty($dossiers)): ?>
+				<div class="aips-panel-body no-padding">
+					<table class="aips-table aips-sources-table" id="aips-dossiers-table">
+						<thead>
+							<tr>
+								<th><?php esc_html_e('Editorial Item', 'ai-post-scheduler'); ?></th>
+								<th><?php esc_html_e('Source', 'ai-post-scheduler'); ?></th>
+								<th><?php esc_html_e('Type', 'ai-post-scheduler'); ?></th>
+								<th><?php esc_html_e('Verification', 'ai-post-scheduler'); ?></th>
+								<th><?php esc_html_e('Citation', 'ai-post-scheduler'); ?></th>
+								<th><?php esc_html_e('Trust', 'ai-post-scheduler'); ?></th>
+								<th><?php esc_html_e('Summary', 'ai-post-scheduler'); ?></th>
+								<th><?php esc_html_e('Actions', 'ai-post-scheduler'); ?></th>
+							</tr>
+						</thead>
+						<tbody>
+							<?php foreach ($dossiers as $dossier): ?>
+								<tr
+									data-dossier-id="<?php echo esc_attr($dossier->id); ?>"
+									data-source-id="<?php echo esc_attr($dossier->source_id); ?>"
+									data-relation-type="<?php echo esc_attr($dossier->relation_type); ?>"
+									data-relation-id="<?php echo esc_attr($dossier->relation_id); ?>"
+									data-source-url="<?php echo esc_attr($dossier->source_url); ?>"
+									data-source-type="<?php echo esc_attr($dossier->source_type); ?>"
+									data-quote-summary="<?php echo esc_attr($dossier->quote_summary); ?>"
+									data-trust-rating="<?php echo esc_attr($dossier->trust_rating); ?>"
+									data-citation-required="<?php echo esc_attr($dossier->citation_required); ?>"
+									data-verification-status="<?php echo esc_attr($dossier->verification_status); ?>"
+									data-editor-notes="<?php echo esc_attr($dossier->editor_notes); ?>">
+									<td>
+										<strong><?php echo esc_html(isset($dossier_relation_types[$dossier->relation_type]) ? $dossier_relation_types[$dossier->relation_type] : $dossier->relation_type); ?></strong>
+										<div class="cell-meta"><?php printf(esc_html__('ID #%d', 'ai-post-scheduler'), (int) $dossier->relation_id); ?></div>
+									</td>
+									<td>
+										<a href="<?php echo esc_url($dossier->source_url); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html($dossier->source_url); ?></a>
+										<?php if (!empty($dossier->source_label)): ?>
+											<div class="cell-meta"><?php echo esc_html($dossier->source_label); ?></div>
+										<?php endif; ?>
+									</td>
+									<td><?php echo esc_html(!empty($dossier->source_type) ? $dossier->source_type : '—'); ?></td>
+									<td>
+										<span class="aips-badge <?php echo $dossier->verification_status === 'verified' ? 'aips-badge-success' : 'aips-badge-neutral'; ?>">
+											<?php echo esc_html(isset($dossier_statuses[$dossier->verification_status]) ? $dossier_statuses[$dossier->verification_status] : $dossier->verification_status); ?>
+										</span>
+									</td>
+									<td>
+										<?php if (!empty($dossier->citation_required)): ?>
+											<span class="aips-badge aips-badge-warning"><?php esc_html_e('Required', 'ai-post-scheduler'); ?></span>
+										<?php else: ?>
+											<span class="cell-meta"><?php esc_html_e('Optional', 'ai-post-scheduler'); ?></span>
+										<?php endif; ?>
+									</td>
+									<td><?php echo esc_html(sprintf(__('%d/5', 'ai-post-scheduler'), (int) $dossier->trust_rating)); ?></td>
+									<td>
+										<?php echo esc_html(!empty($dossier->quote_summary) ? wp_trim_words($dossier->quote_summary, 16, '…') : '—'); ?>
+										<?php if (!empty($dossier->editor_notes)): ?>
+											<div class="cell-meta"><?php echo esc_html(wp_trim_words($dossier->editor_notes, 12, '…')); ?></div>
+										<?php endif; ?>
+									</td>
+									<td>
+										<div class="aips-action-buttons">
+											<button type="button" class="aips-btn aips-btn-sm aips-edit-dossier" data-id="<?php echo esc_attr($dossier->id); ?>">
+												<span class="dashicons dashicons-edit"></span>
+											</button>
+											<button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-dossier" data-id="<?php echo esc_attr($dossier->id); ?>">
+												<span class="dashicons dashicons-trash"></span>
+											</button>
+										</div>
+									</td>
+								</tr>
+							<?php endforeach; ?>
+						</tbody>
+					</table>
+				</div>
+			<?php else: ?>
+				<div class="aips-empty-state">
+					<span class="dashicons dashicons-media-document" aria-hidden="true"></span>
+					<h3><?php esc_html_e('No Dossier Records Yet', 'ai-post-scheduler'); ?></h3>
+					<p><?php esc_html_e('Add research-backed dossier records so editors can track what is verified, what must be cited, and what still needs review before generation.', 'ai-post-scheduler'); ?></p>
+				</div>
+			<?php endif; ?>
+		</div>
+
 	</div><!-- .aips-page-container -->
 </div><!-- .wrap -->
 
@@ -268,6 +381,101 @@ if (!isset($source_term_ids_map) || !is_array($source_term_ids_map)) {
 			<button type="button" class="button button-primary" id="aips-save-source-btn">
 				<?php esc_html_e('Save Source', 'ai-post-scheduler'); ?>
 			</button>
+		</div>
+	</div>
+</div>
+
+<!-- Add / Edit Dossier Modal -->
+<div id="aips-dossier-modal" class="aips-modal" style="display:none;" role="dialog" aria-modal="true" aria-labelledby="aips-dossier-modal-title">
+	<div class="aips-modal-content">
+		<div class="aips-modal-header">
+			<h2 id="aips-dossier-modal-title"><?php esc_html_e('Add Dossier Record', 'ai-post-scheduler'); ?></h2>
+			<button class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
+		</div>
+		<div class="aips-modal-body">
+			<form id="aips-dossier-form" novalidate>
+				<input type="hidden" name="dossier_id" id="aips-dossier-id" value="0">
+
+				<div class="aips-form-row">
+					<label for="aips-dossier-relation-type"><?php esc_html_e('Editorial Item Type', 'ai-post-scheduler'); ?></label>
+					<select id="aips-dossier-relation-type" name="relation_type" class="regular-text">
+						<?php foreach ($dossier_relation_types as $relation_key => $relation_label): ?>
+							<option value="<?php echo esc_attr($relation_key); ?>"><?php echo esc_html($relation_label); ?></option>
+						<?php endforeach; ?>
+					</select>
+				</div>
+
+				<div class="aips-form-row">
+					<label for="aips-dossier-relation-id">
+						<?php esc_html_e('Editorial Item ID', 'ai-post-scheduler'); ?>
+						<span class="required" aria-hidden="true">*</span>
+					</label>
+					<input type="number" id="aips-dossier-relation-id" name="relation_id" min="1" class="small-text" required>
+					<p class="description"><?php esc_html_e('Enter the related research item, author topic, or story-budget item ID.', 'ai-post-scheduler'); ?></p>
+				</div>
+
+				<div class="aips-form-row">
+					<label for="aips-dossier-source-id"><?php esc_html_e('Trusted Source (Optional)', 'ai-post-scheduler'); ?></label>
+					<select id="aips-dossier-source-id" name="source_id" class="regular-text">
+						<option value="0"><?php esc_html_e('None', 'ai-post-scheduler'); ?></option>
+						<?php foreach ($sources as $source): ?>
+							<option value="<?php echo esc_attr($source->id); ?>"><?php echo esc_html(!empty($source->label) ? $source->label : $source->url); ?></option>
+						<?php endforeach; ?>
+					</select>
+				</div>
+
+				<div class="aips-form-row">
+					<label for="aips-dossier-source-url">
+						<?php esc_html_e('Source URL', 'ai-post-scheduler'); ?>
+						<span class="required" aria-hidden="true">*</span>
+					</label>
+					<input type="url" id="aips-dossier-source-url" name="source_url" required class="regular-text" placeholder="<?php esc_attr_e('https://example.com/article', 'ai-post-scheduler'); ?>">
+				</div>
+
+				<div class="aips-form-row">
+					<label for="aips-dossier-source-type"><?php esc_html_e('Source Type', 'ai-post-scheduler'); ?></label>
+					<input type="text" id="aips-dossier-source-type" name="source_type" class="regular-text" placeholder="<?php esc_attr_e('Primary research, press release, analyst note…', 'ai-post-scheduler'); ?>">
+				</div>
+
+				<div class="aips-form-row">
+					<label for="aips-dossier-quote-summary"><?php esc_html_e('Quote / Snippet Summary', 'ai-post-scheduler'); ?></label>
+					<textarea id="aips-dossier-quote-summary" name="quote_summary" rows="4" class="large-text" placeholder="<?php esc_attr_e('Capture the key claim, quote, or evidence that will inform generation.', 'ai-post-scheduler'); ?>"></textarea>
+				</div>
+
+				<div class="aips-form-row">
+					<label for="aips-dossier-trust-rating"><?php esc_html_e('Trust / Confidence Rating', 'ai-post-scheduler'); ?></label>
+					<select id="aips-dossier-trust-rating" name="trust_rating" class="small-text">
+						<?php for ($rating = 1; $rating <= 5; $rating++): ?>
+							<option value="<?php echo esc_attr($rating); ?>"><?php echo esc_html(sprintf(__('%d / 5', 'ai-post-scheduler'), $rating)); ?></option>
+						<?php endfor; ?>
+					</select>
+				</div>
+
+				<div class="aips-form-row">
+					<label for="aips-dossier-verification-status"><?php esc_html_e('Verification Status', 'ai-post-scheduler'); ?></label>
+					<select id="aips-dossier-verification-status" name="verification_status" class="regular-text">
+						<?php foreach ($dossier_statuses as $status_key => $status_label): ?>
+							<option value="<?php echo esc_attr($status_key); ?>"><?php echo esc_html($status_label); ?></option>
+						<?php endforeach; ?>
+					</select>
+				</div>
+
+				<div class="aips-form-row">
+					<label class="aips-checkbox-label">
+						<input type="checkbox" id="aips-dossier-citation-required" name="citation_required" value="1">
+						<?php esc_html_e('Citation required in final draft', 'ai-post-scheduler'); ?>
+					</label>
+				</div>
+
+				<div class="aips-form-row">
+					<label for="aips-dossier-editor-notes"><?php esc_html_e('Editor Notes', 'ai-post-scheduler'); ?></label>
+					<textarea id="aips-dossier-editor-notes" name="editor_notes" rows="3" class="large-text" placeholder="<?php esc_attr_e('Anything the editor needs to remember before approval or publication.', 'ai-post-scheduler'); ?>"></textarea>
+				</div>
+			</form>
+		</div>
+		<div class="aips-modal-footer">
+			<button type="button" class="button aips-modal-close"><?php esc_html_e('Cancel', 'ai-post-scheduler'); ?></button>
+			<button type="button" class="button button-primary" id="aips-save-dossier-btn"><?php esc_html_e('Save Dossier Record', 'ai-post-scheduler'); ?></button>
 		</div>
 	</div>
 </div>

--- a/ai-post-scheduler/templates/admin/templates.php
+++ b/ai-post-scheduler/templates/admin/templates.php
@@ -393,6 +393,25 @@ if (!defined('ABSPATH')) {
                                 <?php endif; ?>
                             </div>
                         </div>
+
+                        <div class="aips-form-row">
+                            <label><?php esc_html_e('Dossier-Aware Editorial Rules', 'ai-post-scheduler'); ?></label>
+                            <div class="aips-checkbox-group">
+                                <label class="aips-checkbox-label" style="display:block; margin-bottom:4px;">
+                                    <input type="checkbox" id="dossier_only_facts" name="dossier_only_facts" value="1">
+                                    <?php esc_html_e('Only use dossier facts', 'ai-post-scheduler'); ?>
+                                </label>
+                                <label class="aips-checkbox-label" style="display:block; margin-bottom:4px;">
+                                    <input type="checkbox" id="dossier_mark_uncertain_claims" name="dossier_mark_uncertain_claims" value="1">
+                                    <?php esc_html_e('Mark uncertain claims', 'ai-post-scheduler'); ?>
+                                </label>
+                                <label class="aips-checkbox-label" style="display:block; margin-bottom:4px;">
+                                    <input type="checkbox" id="dossier_include_knowledge_gaps" name="dossier_include_knowledge_gaps" value="1">
+                                    <?php esc_html_e('Include “What we know / What we don’t know” section', 'ai-post-scheduler'); ?>
+                                </label>
+                            </div>
+                            <p class="description"><?php esc_html_e('These instructions are applied whenever dossier records are attached to the generation context, making research and sourcing a formal step before content generation.', 'ai-post-scheduler'); ?></p>
+                        </div>
                     </div>
                     
                     <!-- Step 4: Featured Image -->


### PR DESCRIPTION
### Motivation
- Make research and sourcing a first-class editorial step by introducing a dossier layer that can be attached to research items, author topics, or story-budget items.  
- Surface dossier metadata into the generation pipeline so prompts can be constrained by verified facts and editors can see citation/verification gaps before publishing.

### Description
- Add database table `aips_source_dossiers` and wire it into `AIPS_DB_Manager::get_schema()` to persist dossier records (source URL, type, quote/snippet, trust rating, citation_required, verification_status, editor notes).  
- Implement repository support in `AIPS_Sources_Repository` for CRUD, queries, relation lookups, checklist aggregation, input sanitization, and hydration helpers.  
- Add AJAX controller endpoints in `AIPS_Sources_Controller` for listing/creating/updating/deleting dossiers and expose them to the Trusted Sources admin page.  
- Extend admin UI: `templates/admin/sources.php`, `assets/js/admin-sources.js`, and localized strings to manage dossier records and a modal form; add template UI checkboxes and JS wiring (`templates.php`, `assets/js/admin.js`) to persist dossier-aware prompt flags.  
- Propagate dossiers into generation contexts by extending `AIPS_Generation_Context` with `get_dossier_records()` and `get_dossier_prompt_preferences()`, and update `AIPS_Template_Context`, `AIPS_Topic_Context`, and `AIPS_Generation_Context_Factory` to attach fetched dossiers.  
- Update `AIPS_Prompt_Builder` to build a structured dossier block (`build_dossier_block`) and inject it (alongside trusted sources) into content prompts when dossiers are present and template/topic preferences request dossier-aware behavior.  
- Persist template-level dossier flags in `AIPS_Template_Repository`/`AIPS_Templates_Controller` and include them in preview/build flows.  
- Add pre-publish checklist integration: `AIPS_Post_Review_Repository` collects dossier checklist data per topic and `templates/admin/post-review.php` displays a badge summarizing citation/verification issues.

### Testing
- Ran PHP syntax checks: `php -l` over modified PHP files (DB manager, repositories, controllers, contexts, prompt builder, templates, settings, post-review repo, templates) — all returned no syntax errors.  
- Ran JS validation: `node --check ai-post-scheduler/assets/js/admin.js` and `node --check ai-post-scheduler/assets/js/admin-sources.js` — checks passed.  
- Attempted to run PHPUnit but `vendor/bin/phpunit` is not present in this environment, so no unit test suite was executed.  
- Changes were committed on the feature branch (commit prefix shown in run); all local linting/sanity checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf59411ea083219095ef711720f713)