### PR TITLE
Add Editions (editorial packages) with planner, schedule, generation and UI integration

### DIFF
--- a/ai-post-scheduler/ai-post-scheduler.php
+++ b/ai-post-scheduler/ai-post-scheduler.php
@@ -187,6 +187,7 @@ final class AI_Post_Scheduler {
             new AIPS_Templates();
             new AIPS_Templates_Controller();
             new AIPS_History();
+            new AIPS_Editions_Controller();
             
             // Initialize Post Review handler globally to avoid duplicate AJAX registration
             global $aips_post_review_handler;
@@ -225,6 +226,7 @@ final class AI_Post_Scheduler {
         new AIPS_Post_Review_Notifications();
 		new AIPS_Partial_Generation_Notifications();
 		new AIPS_Partial_Generation_State_Reconciler();
+        new AIPS_Edition_Prompt_Helper();
 
         // Admin toolbar (visible on both admin and frontend for users with manage_options)
         new AIPS_Admin_Bar();

--- a/ai-post-scheduler/assets/js/admin-planner.js
+++ b/ai-post-scheduler/assets/js/admin-planner.js
@@ -414,7 +414,8 @@
                     topics: topics,
                     template_id: templateId,
                     start_date: startDate,
-                    frequency: $('#bulk-frequency').val()
+                    frequency: $('#bulk-frequency').val(),
+                    edition_id: $('#bulk-edition').val()
                 },
                 success: function(response) {
                     if (response.success) {

--- a/ai-post-scheduler/includes/class-aips-db-manager.php
+++ b/ai-post-scheduler/includes/class-aips-db-manager.php
@@ -21,6 +21,8 @@ class AIPS_DB_Manager {
         'aips_notifications',
         'aips_sources',
         'aips_source_group_terms',
+        'aips_editions',
+        'aips_edition_slots',
     );
 
     public function __construct() {
@@ -68,6 +70,8 @@ class AIPS_DB_Manager {
         $table_notifications        = $tables['aips_notifications'];
         $table_sources              = $tables['aips_sources'];
         $table_source_group_terms   = $tables['aips_source_group_terms'];
+        $table_editions             = $tables['aips_editions'];
+        $table_edition_slots        = $tables['aips_edition_slots'];
 
         $sql = array();
 
@@ -337,18 +341,59 @@ class AIPS_DB_Manager {
             KEY created_at (created_at)
         ) $charset_collate;";
 
-        $sql[] = "CREATE TABLE $table_source_group_terms (
-            id bigint(20) NOT NULL AUTO_INCREMENT,
-            source_id bigint(20) NOT NULL,
-            term_id bigint(20) NOT NULL,
-            PRIMARY KEY  (id),
-            UNIQUE KEY source_term (source_id, term_id),
-            KEY source_id (source_id),
-            KEY term_id (term_id)
-        ) $charset_collate;";
+	        $sql[] = "CREATE TABLE $table_source_group_terms (
+	            id bigint(20) NOT NULL AUTO_INCREMENT,
+	            source_id bigint(20) NOT NULL,
+	            term_id bigint(20) NOT NULL,
+	            PRIMARY KEY  (id),
+	            UNIQUE KEY source_term (source_id, term_id),
+	            KEY source_id (source_id),
+	            KEY term_id (term_id)
+	        ) $charset_collate;";
 
-        return $sql;
-    }
+	        $sql[] = "CREATE TABLE $table_editions (
+	            id bigint(20) NOT NULL AUTO_INCREMENT,
+	            name varchar(255) NOT NULL,
+	            theme varchar(255) DEFAULT NULL,
+	            cadence varchar(50) NOT NULL DEFAULT 'weekly',
+	            target_publish_date datetime NOT NULL,
+	            required_slots int NOT NULL DEFAULT 1,
+	            owner varchar(255) NOT NULL,
+	            channel_type varchar(100) NOT NULL,
+	            is_active tinyint(1) DEFAULT 1,
+	            created_at datetime DEFAULT CURRENT_TIMESTAMP,
+	            updated_at datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+	            PRIMARY KEY  (id),
+	            KEY target_publish_date (target_publish_date),
+	            KEY owner (owner),
+	            KEY channel_type (channel_type),
+	            KEY is_active (is_active)
+	        ) $charset_collate;";
+
+	        $sql[] = "CREATE TABLE $table_edition_slots (
+	            id bigint(20) NOT NULL AUTO_INCREMENT,
+	            edition_id bigint(20) NOT NULL,
+	            slot_key varchar(100) NOT NULL,
+	            slot_label varchar(255) NOT NULL,
+	            assigned_topic text DEFAULT NULL,
+	            template_id bigint(20) DEFAULT NULL,
+	            schedule_id bigint(20) DEFAULT NULL,
+	            post_id bigint(20) DEFAULT NULL,
+	            sourcing_status varchar(20) NOT NULL DEFAULT 'ready',
+	            notes text DEFAULT NULL,
+	            sort_order int NOT NULL DEFAULT 0,
+	            created_at datetime DEFAULT CURRENT_TIMESTAMP,
+	            updated_at datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+	            PRIMARY KEY  (id),
+	            KEY edition_id (edition_id),
+	            KEY schedule_id (schedule_id),
+	            KEY post_id (post_id),
+	            KEY template_id (template_id),
+	            KEY sourcing_status (sourcing_status)
+	        ) $charset_collate;";
+
+	        return $sql;
+	    }
 
     public static function install_tables() {
         require_once(ABSPATH . 'wp-admin/includes/upgrade.php');

--- a/ai-post-scheduler/includes/class-aips-edition-prompt-helper.php
+++ b/ai-post-scheduler/includes/class-aips-edition-prompt-helper.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Edition Prompt Helper
+ *
+ * Injects edition-aware template variables for coordinated editorial packages.
+ *
+ * @package AI_Post_Scheduler
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+class AIPS_Edition_Prompt_Helper {
+
+	/**
+	 * @var array
+	 */
+	private static $current_context = array();
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_filter('aips_template_variables', array($this, 'register_template_variables'), 10, 2);
+	}
+
+	/**
+	 * Set the current edition context for a generation run.
+	 *
+	 * @param array $context Edition context.
+	 * @return void
+	 */
+	public static function set_current_context($context) {
+		self::$current_context = is_array($context) ? $context : array();
+	}
+
+	/**
+	 * Clear the current edition context.
+	 *
+	 * @return void
+	 */
+	public static function clear_current_context() {
+		self::$current_context = array();
+	}
+
+	/**
+	 * Add edition variables to the template processor.
+	 *
+	 * @param array       $variables Existing variables.
+	 * @param string|null $topic     Current topic.
+	 * @return array
+	 */
+	public function register_template_variables($variables, $topic = null) {
+		$context = self::$current_context;
+		$related_items = '';
+
+		if (!empty($context['edition_related_items']) && is_array($context['edition_related_items'])) {
+			$related_items = implode('; ', array_map('sanitize_text_field', $context['edition_related_items']));
+		}
+
+		$variables['{{edition_name}}'] = isset($context['edition_name']) ? sanitize_text_field($context['edition_name']) : '';
+		$variables['{{edition_theme}}'] = isset($context['edition_theme']) ? sanitize_text_field($context['edition_theme']) : '';
+		$variables['{{edition_cadence}}'] = isset($context['edition_cadence']) ? sanitize_text_field($context['edition_cadence']) : '';
+		$variables['{{edition_target_publish_date}}'] = isset($context['edition_target_publish_date']) ? sanitize_text_field($context['edition_target_publish_date']) : '';
+		$variables['{{edition_required_slots}}'] = isset($context['edition_required_slots']) ? (string) absint($context['edition_required_slots']) : '';
+		$variables['{{edition_owner}}'] = isset($context['edition_owner']) ? sanitize_text_field($context['edition_owner']) : '';
+		$variables['{{edition_channel_type}}'] = isset($context['edition_channel_type']) ? sanitize_text_field($context['edition_channel_type']) : '';
+		$variables['{{edition_slot_name}}'] = isset($context['edition_slot_name']) ? sanitize_text_field($context['edition_slot_name']) : '';
+		$variables['{{edition_related_items}}'] = $related_items;
+
+		return $variables;
+	}
+}

--- a/ai-post-scheduler/includes/class-aips-editions-controller.php
+++ b/ai-post-scheduler/includes/class-aips-editions-controller.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Editions Controller
+ *
+ * AJAX management for editorial package editions.
+ *
+ * @package AI_Post_Scheduler
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+class AIPS_Editions_Controller {
+
+	/**
+	 * @var AIPS_Editions_Repository
+	 */
+	private $repository;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param AIPS_Editions_Repository|null $repository Repository.
+	 */
+	public function __construct($repository = null) {
+		$this->repository = $repository ?: new AIPS_Editions_Repository();
+
+		add_action('wp_ajax_aips_get_editions', array($this, 'ajax_get_editions'));
+		add_action('wp_ajax_aips_get_edition', array($this, 'ajax_get_edition'));
+		add_action('wp_ajax_aips_save_edition', array($this, 'ajax_save_edition'));
+		add_action('wp_ajax_aips_delete_edition', array($this, 'ajax_delete_edition'));
+	}
+
+	/**
+	 * Get all editions.
+	 *
+	 * @return void
+	 */
+	public function ajax_get_editions() {
+		$this->guard_request();
+		wp_send_json_success(array('editions' => $this->repository->get_all()));
+	}
+
+	/**
+	 * Get a single edition.
+	 *
+	 * @return void
+	 */
+	public function ajax_get_edition() {
+		$this->guard_request();
+
+		$edition_id = isset($_POST['edition_id']) ? absint($_POST['edition_id']) : 0;
+		$edition = $this->repository->get_by_id($edition_id);
+		if (!$edition) {
+			wp_send_json_error(array('message' => __('Edition not found.', 'ai-post-scheduler')));
+		}
+
+		wp_send_json_success(array('edition' => $edition));
+	}
+
+	/**
+	 * Save an edition.
+	 *
+	 * @return void
+	 */
+	public function ajax_save_edition() {
+		$this->guard_request();
+
+		$slot_keys = isset($_POST['slot_key']) ? (array) $_POST['slot_key'] : array();
+		$slot_labels = isset($_POST['slot_label']) ? (array) $_POST['slot_label'] : array();
+		$slot_notes = isset($_POST['slot_notes']) ? (array) $_POST['slot_notes'] : array();
+		$slot_sourcing = isset($_POST['slot_sourcing_status']) ? (array) $_POST['slot_sourcing_status'] : array();
+		$slot_topics = isset($_POST['slot_assigned_topic']) ? (array) $_POST['slot_assigned_topic'] : array();
+		$slot_templates = isset($_POST['slot_template_id']) ? (array) $_POST['slot_template_id'] : array();
+		$slot_schedules = isset($_POST['slot_schedule_id']) ? (array) $_POST['slot_schedule_id'] : array();
+		$slot_posts = isset($_POST['slot_post_id']) ? (array) $_POST['slot_post_id'] : array();
+
+		$slots = array();
+		foreach ($slot_keys as $index => $slot_key) {
+			$slots[] = array(
+				'slot_key' => $slot_key,
+				'slot_label' => isset($slot_labels[$index]) ? $slot_labels[$index] : '',
+				'notes' => isset($slot_notes[$index]) ? $slot_notes[$index] : '',
+				'sourcing_status' => isset($slot_sourcing[$index]) ? $slot_sourcing[$index] : 'ready',
+				'assigned_topic' => isset($slot_topics[$index]) ? $slot_topics[$index] : '',
+				'template_id' => isset($slot_templates[$index]) ? $slot_templates[$index] : 0,
+				'schedule_id' => isset($slot_schedules[$index]) ? $slot_schedules[$index] : 0,
+				'post_id' => isset($slot_posts[$index]) ? $slot_posts[$index] : 0,
+				'sort_order' => $index,
+			);
+		}
+
+		$edition_id = $this->repository->save(
+			array(
+				'id' => isset($_POST['edition_id']) ? absint($_POST['edition_id']) : 0,
+				'name' => isset($_POST['name']) ? wp_unslash($_POST['name']) : '',
+				'theme' => isset($_POST['theme']) ? wp_unslash($_POST['theme']) : '',
+				'cadence' => isset($_POST['cadence']) ? wp_unslash($_POST['cadence']) : '',
+				'target_publish_date' => isset($_POST['target_publish_date']) ? wp_unslash($_POST['target_publish_date']) : '',
+				'required_slots' => isset($_POST['required_slots']) ? absint($_POST['required_slots']) : 0,
+				'owner' => isset($_POST['owner']) ? wp_unslash($_POST['owner']) : '',
+				'channel_type' => isset($_POST['channel_type']) ? wp_unslash($_POST['channel_type']) : '',
+				'is_active' => isset($_POST['is_active']) ? 1 : 0,
+			),
+			$slots
+		);
+
+		if (!$edition_id) {
+			wp_send_json_error(array('message' => __('Failed to save edition.', 'ai-post-scheduler')));
+		}
+
+		$edition = $this->repository->get_by_id($edition_id);
+		wp_send_json_success(array(
+			'message' => __('Edition saved successfully.', 'ai-post-scheduler'),
+			'edition' => $edition,
+		));
+	}
+
+	/**
+	 * Delete an edition.
+	 *
+	 * @return void
+	 */
+	public function ajax_delete_edition() {
+		$this->guard_request();
+
+		$edition_id = isset($_POST['edition_id']) ? absint($_POST['edition_id']) : 0;
+		if (!$edition_id) {
+			wp_send_json_error(array('message' => __('Invalid edition ID.', 'ai-post-scheduler')));
+		}
+
+		$result = $this->repository->delete($edition_id);
+		if (!$result) {
+			wp_send_json_error(array('message' => __('Failed to delete edition.', 'ai-post-scheduler')));
+		}
+
+		wp_send_json_success(array('message' => __('Edition deleted.', 'ai-post-scheduler')));
+	}
+
+	/**
+	 * Shared nonce/capability checks.
+	 *
+	 * @return void
+	 */
+	private function guard_request() {
+		check_ajax_referer('aips_ajax_nonce', 'nonce');
+
+		if (!current_user_can('manage_options')) {
+			wp_send_json_error(array('message' => __('Permission denied.', 'ai-post-scheduler')));
+		}
+	}
+}

--- a/ai-post-scheduler/includes/class-aips-editions-repository.php
+++ b/ai-post-scheduler/includes/class-aips-editions-repository.php
@@ -1,0 +1,536 @@
+<?php
+/**
+ * Editions Repository
+ *
+ * Stores editorial package editions and their coordinated story slots.
+ *
+ * @package AI_Post_Scheduler
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+class AIPS_Editions_Repository {
+
+	/**
+	 * @var wpdb
+	 */
+	private $wpdb;
+
+	/**
+	 * @var string
+	 */
+	private $editions_table;
+
+	/**
+	 * @var string
+	 */
+	private $slots_table;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		global $wpdb;
+		$this->wpdb = $wpdb;
+		$this->editions_table = $wpdb->prefix . 'aips_editions';
+		$this->slots_table = $wpdb->prefix . 'aips_edition_slots';
+	}
+
+	/**
+	 * Get the built-in slot types.
+	 *
+	 * @return array
+	 */
+	public static function get_default_slot_types() {
+		return array(
+			'lead_story' => __('Lead Story', 'ai-post-scheduler'),
+			'secondary_analysis' => __('Secondary Analysis', 'ai-post-scheduler'),
+			'roundup' => __('Roundup', 'ai-post-scheduler'),
+			'faq_sidebar' => __('FAQ / Sidebar', 'ai-post-scheduler'),
+			'newsletter_intro' => __('Newsletter Intro', 'ai-post-scheduler'),
+		);
+	}
+
+	/**
+	 * Get every edition with slot/completeness data.
+	 *
+	 * @param bool $include_inactive Whether to include inactive editions.
+	 * @return array
+	 */
+	public function get_all($include_inactive = true) {
+		$where = $include_inactive ? '' : 'WHERE is_active = 1';
+		$editions = $this->wpdb->get_results("SELECT * FROM {$this->editions_table} {$where} ORDER BY target_publish_date ASC, name ASC");
+
+		return $this->hydrate_editions($editions);
+	}
+
+	/**
+	 * Get active editions.
+	 *
+	 * @return array
+	 */
+	public function get_active() {
+		return $this->get_all(false);
+	}
+
+	/**
+	 * Get a single edition by ID.
+	 *
+	 * @param int $edition_id Edition ID.
+	 * @return object|null
+	 */
+	public function get_by_id($edition_id) {
+		$edition = $this->wpdb->get_row($this->wpdb->prepare(
+			"SELECT * FROM {$this->editions_table} WHERE id = %d",
+			$edition_id
+		));
+
+		if (!$edition) {
+			return null;
+		}
+
+		$items = $this->hydrate_editions(array($edition));
+
+		return !empty($items) ? $items[0] : null;
+	}
+
+	/**
+	 * Save an edition and its slots.
+	 *
+	 * @param array $edition_data Edition data.
+	 * @param array $slots        Slot definitions.
+	 * @return int|false
+	 */
+	public function save($edition_data, $slots) {
+		$required_slots = isset($edition_data['required_slots']) ? absint($edition_data['required_slots']) : count($slots);
+		if ($required_slots < 1) {
+			$required_slots = max(1, count($slots));
+		}
+
+		$target_publish_date = isset($edition_data['target_publish_date']) ? str_replace('T', ' ', sanitize_text_field($edition_data['target_publish_date'])) : '';
+
+		$payload = array(
+			'name' => sanitize_text_field($edition_data['name']),
+			'theme' => isset($edition_data['theme']) ? sanitize_text_field($edition_data['theme']) : '',
+			'cadence' => sanitize_text_field($edition_data['cadence']),
+			'target_publish_date' => $target_publish_date,
+			'required_slots' => $required_slots,
+			'owner' => sanitize_text_field($edition_data['owner']),
+			'channel_type' => sanitize_text_field($edition_data['channel_type']),
+			'is_active' => !empty($edition_data['is_active']) ? 1 : 0,
+		);
+
+		$formats = array('%s', '%s', '%s', '%s', '%d', '%s', '%s', '%d');
+		$edition_id = isset($edition_data['id']) ? absint($edition_data['id']) : 0;
+		$clean_slots = $this->sanitize_slots($slots);
+
+		if (empty($payload['name']) || empty($payload['cadence']) || empty($payload['target_publish_date']) || empty($payload['owner']) || empty($payload['channel_type']) || empty($clean_slots)) {
+			return false;
+		}
+
+		if ($edition_id) {
+			$result = $this->wpdb->update(
+				$this->editions_table,
+				$payload,
+				array('id' => $edition_id),
+				$formats,
+				array('%d')
+			);
+
+			if ($result === false) {
+				return false;
+			}
+		} else {
+			$result = $this->wpdb->insert($this->editions_table, $payload, $formats);
+			if (!$result) {
+				return false;
+			}
+			$edition_id = (int) $this->wpdb->insert_id;
+		}
+
+		$this->replace_slots($edition_id, $clean_slots);
+
+		return $edition_id;
+	}
+
+	/**
+	 * Delete an edition and its slots.
+	 *
+	 * @param int $edition_id Edition ID.
+	 * @return bool
+	 */
+	public function delete($edition_id) {
+		$this->wpdb->delete($this->slots_table, array('edition_id' => absint($edition_id)), array('%d'));
+
+		return false !== $this->wpdb->delete($this->editions_table, array('id' => absint($edition_id)), array('%d'));
+	}
+
+	/**
+	 * Update edition active state.
+	 *
+	 * @param int $edition_id Edition ID.
+	 * @param int $is_active  Active flag.
+	 * @return bool
+	 */
+	public function set_active($edition_id, $is_active) {
+		return false !== $this->wpdb->update(
+			$this->editions_table,
+			array('is_active' => $is_active ? 1 : 0),
+			array('id' => absint($edition_id)),
+			array('%d'),
+			array('%d')
+		);
+	}
+
+	/**
+	 * Get the next available slots for planner assignment.
+	 *
+	 * @param int $edition_id Edition ID.
+	 * @param int $limit      Max slots.
+	 * @return array
+	 */
+	public function get_next_unfilled_slots($edition_id, $limit = 0) {
+		$sql = $this->wpdb->prepare(
+			"SELECT * FROM {$this->slots_table} WHERE edition_id = %d AND (assigned_topic = '' OR assigned_topic IS NULL) ORDER BY sort_order ASC, id ASC",
+			$edition_id
+		);
+
+		if ($limit > 0) {
+			$sql .= ' LIMIT ' . absint($limit);
+		}
+
+		return $this->wpdb->get_results($sql);
+	}
+
+	/**
+	 * Attach a schedule/topic/template to a slot.
+	 *
+	 * @param int    $slot_id      Slot ID.
+	 * @param int    $schedule_id  Schedule ID.
+	 * @param string $topic        Assigned topic.
+	 * @param int    $template_id  Template ID.
+	 * @return bool
+	 */
+	public function assign_slot_schedule($slot_id, $schedule_id, $topic, $template_id) {
+		return false !== $this->wpdb->update(
+			$this->slots_table,
+			array(
+				'assigned_topic' => sanitize_text_field($topic),
+				'schedule_id' => absint($schedule_id),
+				'template_id' => absint($template_id),
+			),
+			array('id' => absint($slot_id)),
+			array('%s', '%d', '%d'),
+			array('%d')
+		);
+	}
+
+	/**
+	 * Mark a slot's post after generation.
+	 *
+	 * @param int $schedule_id Schedule ID.
+	 * @param int $post_id     Post ID.
+	 * @return bool
+	 */
+	public function mark_slot_post_generated($schedule_id, $post_id) {
+		$slot = $this->wpdb->get_row($this->wpdb->prepare(
+			"SELECT * FROM {$this->slots_table} WHERE schedule_id = %d ORDER BY id ASC LIMIT 1",
+			$schedule_id
+		));
+
+		if (!$slot) {
+			return false;
+		}
+
+		update_post_meta($post_id, '_aips_edition_id', (int) $slot->edition_id);
+		update_post_meta($post_id, '_aips_edition_slot_id', (int) $slot->id);
+		update_post_meta($post_id, '_aips_edition_slot_key', (string) $slot->slot_key);
+		update_post_meta($post_id, '_aips_edition_slot_label', (string) $slot->slot_label);
+
+		return false !== $this->wpdb->update(
+			$this->slots_table,
+			array('post_id' => absint($post_id)),
+			array('id' => absint($slot->id)),
+			array('%d'),
+			array('%d')
+		);
+	}
+
+	/**
+	 * Get edition prompt context for a scheduled slot.
+	 *
+	 * @param int $schedule_id Schedule ID.
+	 * @return array
+	 */
+	public function get_generation_context_by_schedule_id($schedule_id) {
+		$slot = $this->wpdb->get_row($this->wpdb->prepare(
+			"SELECT s.*, e.name AS edition_name, e.theme, e.cadence, e.target_publish_date, e.required_slots, e.owner, e.channel_type
+			 FROM {$this->slots_table} s
+			 INNER JOIN {$this->editions_table} e ON s.edition_id = e.id
+			 WHERE s.schedule_id = %d
+			 ORDER BY s.id ASC LIMIT 1",
+			$schedule_id
+		));
+
+		if (!$slot) {
+			return array();
+		}
+
+		$related_slots = $this->wpdb->get_results($this->wpdb->prepare(
+			"SELECT slot_label, assigned_topic FROM {$this->slots_table} WHERE edition_id = %d ORDER BY sort_order ASC, id ASC",
+			$slot->edition_id
+		));
+
+		$related_items = array();
+		foreach ($related_slots as $related_slot) {
+			$label = $related_slot->slot_label;
+			if (!empty($related_slot->assigned_topic)) {
+				$label .= ': ' . $related_slot->assigned_topic;
+			}
+			$related_items[] = $label;
+		}
+
+		return array(
+			'edition_id' => (int) $slot->edition_id,
+			'edition_name' => (string) $slot->edition_name,
+			'edition_theme' => !empty($slot->theme) ? (string) $slot->theme : (string) $slot->edition_name,
+			'edition_cadence' => (string) $slot->cadence,
+			'edition_target_publish_date' => (string) $slot->target_publish_date,
+			'edition_required_slots' => (int) $slot->required_slots,
+			'edition_owner' => (string) $slot->owner,
+			'edition_channel_type' => (string) $slot->channel_type,
+			'edition_slot_name' => (string) $slot->slot_label,
+			'edition_slot_key' => (string) $slot->slot_key,
+			'edition_related_items' => $related_items,
+		);
+	}
+
+	/**
+	 * Get edition details by post IDs.
+	 *
+	 * @param array $post_ids Post IDs.
+	 * @return array
+	 */
+	public function get_post_edition_details_map($post_ids) {
+		$post_ids = array_values(array_unique(array_filter(array_map('absint', (array) $post_ids))));
+		if (empty($post_ids)) {
+			return array();
+		}
+
+		$placeholders = implode(', ', array_fill(0, count($post_ids), '%d'));
+		$query = $this->wpdb->prepare(
+			"SELECT s.post_id, s.slot_label, s.slot_key, e.id AS edition_id, e.name, e.theme, e.channel_type, e.target_publish_date
+			 FROM {$this->slots_table} s
+			 INNER JOIN {$this->editions_table} e ON s.edition_id = e.id
+			 WHERE s.post_id IN ({$placeholders})",
+			$post_ids
+		);
+
+		$rows = $this->wpdb->get_results($query);
+		$map = array();
+		foreach ($rows as $row) {
+			$map[(int) $row->post_id] = array(
+				'edition_id' => (int) $row->edition_id,
+				'edition_name' => (string) $row->name,
+				'edition_theme' => !empty($row->theme) ? (string) $row->theme : (string) $row->name,
+				'channel_type' => (string) $row->channel_type,
+				'target_publish_date' => (string) $row->target_publish_date,
+				'slot_label' => (string) $row->slot_label,
+				'slot_key' => (string) $row->slot_key,
+			);
+		}
+
+		return $map;
+	}
+
+	/**
+	 * Hydrate edition stats and slots.
+	 *
+	 * @param array $editions Edition rows.
+	 * @return array
+	 */
+	private function hydrate_editions($editions) {
+		if (empty($editions)) {
+			return array();
+		}
+
+		$edition_ids = array_map(static function ($edition) {
+			return (int) $edition->id;
+		}, $editions);
+
+		$slots_by_edition = $this->get_slots_for_editions($edition_ids);
+		$result = array();
+
+		foreach ($editions as $edition) {
+			$edition_slots = isset($slots_by_edition[$edition->id]) ? $slots_by_edition[$edition->id] : array();
+			$completeness = $this->build_completeness($edition, $edition_slots);
+			$edition->theme = !empty($edition->theme) ? $edition->theme : $edition->name;
+			$edition->slots = $edition_slots;
+			$edition->completeness = $completeness;
+			$edition->slots_filled = $completeness['slots_filled'];
+			$edition->ready_for_review = $completeness['ready_for_review'];
+			$edition->blocked_by_missing_sourcing = $completeness['blocked_by_missing_sourcing'];
+			$edition->ready_to_publish = $completeness['ready_to_publish'];
+			$result[] = $edition;
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Get slots for multiple editions.
+	 *
+	 * @param array $edition_ids Edition IDs.
+	 * @return array
+	 */
+	private function get_slots_for_editions($edition_ids) {
+		$edition_ids = array_values(array_filter(array_map('absint', $edition_ids)));
+		if (empty($edition_ids)) {
+			return array();
+		}
+
+		$placeholders = implode(', ', array_fill(0, count($edition_ids), '%d'));
+		$query = $this->wpdb->prepare(
+			"SELECT * FROM {$this->slots_table} WHERE edition_id IN ({$placeholders}) ORDER BY edition_id ASC, sort_order ASC, id ASC",
+			$edition_ids
+		);
+
+		$rows = $this->wpdb->get_results($query);
+		$grouped = array();
+		foreach ($rows as $row) {
+			$row->post_status = $row->post_id ? get_post_status($row->post_id) : '';
+			$grouped[$row->edition_id][] = $row;
+		}
+
+		return $grouped;
+	}
+
+	/**
+	 * Build completeness indicators.
+	 *
+	 * @param object $edition Edition object.
+	 * @param array  $slots   Slots.
+	 * @return array
+	 */
+	private function build_completeness($edition, $slots) {
+		$required_slots = max(1, (int) $edition->required_slots);
+		$slots_filled = 0;
+		$ready_for_review = 0;
+		$blocked = 0;
+		$ready_to_publish = 0;
+
+		foreach ($slots as $slot) {
+			$is_filled = !empty($slot->assigned_topic) || !empty($slot->schedule_id) || !empty($slot->post_id);
+			if ($is_filled) {
+				$slots_filled++;
+			}
+
+			if ($slot->sourcing_status === 'missing') {
+				$blocked++;
+			}
+
+			if (!empty($slot->post_id)) {
+				$status = get_post_status($slot->post_id);
+				if (in_array($status, array('draft', 'pending'), true)) {
+					$ready_for_review++;
+				}
+				if (in_array($status, array('future', 'publish'), true)) {
+					$ready_to_publish++;
+				}
+			}
+		}
+
+		return array(
+			'required_slots' => $required_slots,
+			'total_slots' => count($slots),
+			'slots_filled' => $slots_filled,
+			'ready_for_review' => $ready_for_review,
+			'blocked_by_missing_sourcing' => $blocked,
+			'ready_to_publish' => $ready_to_publish,
+			'is_ready_for_review' => ($slots_filled >= $required_slots && 0 === $blocked && $ready_for_review > 0),
+			'is_ready_to_publish' => ($slots_filled >= $required_slots && 0 === $blocked && $ready_to_publish >= $required_slots),
+		);
+	}
+
+	/**
+	 * Sanitize slot rows.
+	 *
+	 * @param array $slots Raw slots.
+	 * @return array
+	 */
+	private function sanitize_slots($slots) {
+		$clean = array();
+		$default_types = self::get_default_slot_types();
+
+		foreach ((array) $slots as $index => $slot) {
+			if (!is_array($slot)) {
+				continue;
+			}
+
+			$slot_key = isset($slot['slot_key']) ? sanitize_key($slot['slot_key']) : '';
+			$slot_label = isset($slot['slot_label']) ? sanitize_text_field($slot['slot_label']) : '';
+			if (empty($slot_key) && !empty($slot_label)) {
+				$slot_key = sanitize_key($slot_label);
+			}
+			if (empty($slot_label) && isset($default_types[$slot_key])) {
+				$slot_label = $default_types[$slot_key];
+			}
+
+			if (empty($slot_key) || empty($slot_label)) {
+				continue;
+			}
+
+			$clean[] = array(
+				'slot_key' => $slot_key,
+				'slot_label' => $slot_label,
+				'assigned_topic' => isset($slot['assigned_topic']) ? sanitize_text_field($slot['assigned_topic']) : '',
+				'template_id' => isset($slot['template_id']) ? absint($slot['template_id']) : 0,
+				'schedule_id' => isset($slot['schedule_id']) ? absint($slot['schedule_id']) : 0,
+				'post_id' => isset($slot['post_id']) ? absint($slot['post_id']) : 0,
+				'sourcing_status' => (isset($slot['sourcing_status']) && 'missing' === $slot['sourcing_status']) ? 'missing' : 'ready',
+				'notes' => isset($slot['notes']) ? sanitize_textarea_field($slot['notes']) : '',
+				'sort_order' => isset($slot['sort_order']) ? absint($slot['sort_order']) : absint($index),
+			);
+		}
+
+		return $clean;
+	}
+
+	/**
+	 * Replace all slots for an edition.
+	 *
+	 * @param int   $edition_id Edition ID.
+	 * @param array $slots      Slots.
+	 * @return void
+	 */
+	private function replace_slots($edition_id, $slots) {
+		$existing_slots = $this->wpdb->get_results($this->wpdb->prepare(
+			"SELECT id, template_id, schedule_id, post_id FROM {$this->slots_table} WHERE edition_id = %d ORDER BY sort_order ASC, id ASC",
+			$edition_id
+		));
+
+		$this->wpdb->delete($this->slots_table, array('edition_id' => absint($edition_id)), array('%d'));
+
+		foreach ($slots as $index => $slot) {
+			$existing = isset($existing_slots[$index]) ? $existing_slots[$index] : null;
+			$this->wpdb->insert(
+				$this->slots_table,
+				array(
+					'edition_id' => absint($edition_id),
+					'slot_key' => $slot['slot_key'],
+					'slot_label' => $slot['slot_label'],
+					'assigned_topic' => $slot['assigned_topic'],
+					'template_id' => !empty($slot['template_id']) ? $slot['template_id'] : ($existing ? (int) $existing->template_id : 0),
+					'schedule_id' => !empty($slot['schedule_id']) ? $slot['schedule_id'] : ($existing ? (int) $existing->schedule_id : 0),
+					'post_id' => !empty($slot['post_id']) ? $slot['post_id'] : ($existing ? (int) $existing->post_id : 0),
+					'sourcing_status' => $slot['sourcing_status'],
+					'notes' => $slot['notes'],
+					'sort_order' => absint($index),
+				),
+				array('%d', '%s', '%s', '%s', '%d', '%d', '%d', '%s', '%s', '%d')
+			);
+		}
+	}
+}

--- a/ai-post-scheduler/includes/class-aips-generated-posts-controller.php
+++ b/ai-post-scheduler/includes/class-aips-generated-posts-controller.php
@@ -34,6 +34,11 @@ class AIPS_Generated_Posts_Controller {
 	 * @var AIPS_Post_Review_Repository Repository for post review data
 	 */
 	private $post_review_repository;
+
+	/**
+	 * @var AIPS_Editions_Repository
+	 */
+	private $editions_repository;
 	
 	/**
 	 * @var array Cache for template names to avoid N+1 queries
@@ -57,6 +62,7 @@ class AIPS_Generated_Posts_Controller {
 		$this->history_repository = new AIPS_History_Repository();
 		$this->schedule_repository = new AIPS_Schedule_Repository();
 		$this->post_review_repository = new AIPS_Post_Review_Repository();
+		$this->editions_repository = new AIPS_Editions_Repository();
 		
 		// Register AJAX handlers
 		add_action('wp_ajax_aips_get_post_session', array($this, 'ajax_get_post_session'));
@@ -87,6 +93,8 @@ class AIPS_Generated_Posts_Controller {
 			'template_id' => $template_id,
 		));
 		
+		$post_edition_map = $this->editions_repository->get_post_edition_details_map(wp_list_pluck($history['items'], 'post_id'));
+
 		// Get schedule data for each post
 		$posts_data = array();
 		foreach ($history['items'] as $item) {
@@ -119,6 +127,7 @@ class AIPS_Generated_Posts_Controller {
 				'date_scheduled' => $schedule ? $schedule->next_run : null,
 				'edit_link' => esc_url_raw(get_edit_post_link($item->post_id)),
 				'source' => $source,
+				'edition' => isset($post_edition_map[$item->post_id]) ? $post_edition_map[$item->post_id] : null,
 			);
 		}
 		
@@ -129,6 +138,8 @@ class AIPS_Generated_Posts_Controller {
 			'template_id' => $template_id,
 		));
 
+		$draft_post_edition_map = $this->editions_repository->get_post_edition_details_map(wp_list_pluck($draft_posts['items'], 'post_id'));
+
 		$partial_generations = $this->history_repository->get_partial_generations(array(
 			'page' => $partial_page,
 			'per_page' => 20,
@@ -136,6 +147,8 @@ class AIPS_Generated_Posts_Controller {
 			'author_id' => $author_id,
 			'template_id' => $template_id,
 		));
+
+		$partial_post_edition_map = $this->editions_repository->get_post_edition_details_map(wp_list_pluck($partial_generations['items'], 'post_id'));
 
 		$partial_posts_data = array();
 		foreach ($partial_generations['items'] as $item) {
@@ -159,6 +172,7 @@ class AIPS_Generated_Posts_Controller {
 				'is_currently_incomplete' => ('true' === (string) $item->is_currently_incomplete),
 				'source' => $this->format_source($item),
 				'missing_components' => $this->get_missing_components($item->component_statuses),
+				'edition' => isset($partial_post_edition_map[$item->post_id]) ? $partial_post_edition_map[$item->post_id] : null,
 			);
 		}
 		
@@ -229,6 +243,31 @@ class AIPS_Generated_Posts_Controller {
 		return ucfirst(str_replace('_', ' ', (string) $post_status));
 	}
 	
+
+
+	/**
+	 * Format edition package meta for tables.
+	 *
+	 * @param array|null $edition Edition metadata.
+	 * @return string
+	 */
+	public function format_edition_label($edition) {
+		if (empty($edition) || empty($edition['edition_name'])) {
+			return __('Standalone', 'ai-post-scheduler');
+		}
+
+		if (!empty($edition['slot_label'])) {
+			return sprintf(
+				/* translators: 1: edition name, 2: slot label */
+				__('%1$s — %2$s', 'ai-post-scheduler'),
+				$edition['edition_name'],
+				$edition['slot_label']
+			);
+		}
+
+		return $edition['edition_name'];
+	}
+
 	/**
 	 * AJAX handler to get detailed session data for a post
 	 */

--- a/ai-post-scheduler/includes/class-aips-planner.php
+++ b/ai-post-scheduler/includes/class-aips-planner.php
@@ -82,6 +82,7 @@ class AIPS_Planner {
         $template_id = isset($_POST['template_id']) ? absint($_POST['template_id']) : 0;
         $start_date = isset($_POST['start_date']) ? sanitize_text_field($_POST['start_date']) : '';
         $frequency = isset($_POST['frequency']) ? sanitize_text_field($_POST['frequency']) : 'daily';
+        $edition_id = isset($_POST['edition_id']) ? absint($_POST['edition_id']) : 0;
 
         if (empty($topics) || empty($template_id) || empty($start_date)) {
             wp_send_json_error(array('message' => __('Missing required fields.', 'ai-post-scheduler')));
@@ -102,36 +103,72 @@ class AIPS_Planner {
             $interval = $intervals[$frequency]['interval'];
         }
 
-        global $wpdb;
-        $table_name = $wpdb->prefix . 'aips_schedule';
+        if ($edition_id) {
+            $editions_repository = new AIPS_Editions_Repository();
+            $edition = $editions_repository->get_by_id($edition_id);
+            if (!$edition) {
+                wp_send_json_error(array('message' => __('Selected edition not found.', 'ai-post-scheduler')));
+            }
 
-        // Optimization: Use single bulk INSERT query instead of loop
-        // This reduces N database calls to 1, significantly improving performance for large batches
-        $schedules = array();
+            $available_slots = $editions_repository->get_next_unfilled_slots($edition_id, count($topics));
+            if (count($available_slots) < count($topics)) {
+                wp_send_json_error(array(
+                    'message' => sprintf(
+                        __('Edition has only %1$d open slots for %2$d selected topics.', 'ai-post-scheduler'),
+                        count($available_slots),
+                        count($topics)
+                    )
+                ));
+            }
 
-        foreach ($topics as $index => $topic) {
-            $next_run_timestamp = $base_time + ($index * $interval);
-            $next_run = date('Y-m-d H:i:s', $next_run_timestamp);
+            foreach ($topics as $index => $topic) {
+                $next_run_timestamp = $base_time + ($index * $interval);
+                $next_run = date('Y-m-d H:i:s', $next_run_timestamp);
+                $schedule_id = $scheduler->save_schedule(array(
+                    'template_id' => $template_id,
+                    'frequency' => 'once',
+                    'next_run' => $next_run,
+                    'is_active' => 1,
+                    'topic' => $topic,
+                ));
 
-            $schedules[] = array(
-                'template_id' => $template_id,
-                'frequency' => 'once',
-                'next_run' => $next_run,
-                'is_active' => 1,
-                'topic' => $topic
-            );
+                if (!$schedule_id) {
+                    wp_send_json_error(array('message' => __('Failed to schedule one or more edition slots.', 'ai-post-scheduler')));
+                }
+
+                $slot = $available_slots[$index];
+                $editions_repository->assign_slot_schedule($slot->id, $schedule_id, $topic, $template_id);
+                $count++;
+            }
+        } else {
+            $schedules = array();
+
+            foreach ($topics as $index => $topic) {
+                $next_run_timestamp = $base_time + ($index * $interval);
+                $next_run = date('Y-m-d H:i:s', $next_run_timestamp);
+
+                $schedules[] = array(
+                    'template_id' => $template_id,
+                    'frequency' => 'once',
+                    'next_run' => $next_run,
+                    'is_active' => 1,
+                    'topic' => $topic
+                );
+            }
+
+            $count = $scheduler->save_schedule_bulk($schedules);
+
+            if ($count === false || $count === 0) {
+                wp_send_json_error(array('message' => __('Failed to schedule topics.', 'ai-post-scheduler')));
+            }
         }
 
-        $count = $scheduler->save_schedule_bulk($schedules);
-
-        if ($count === false || $count === 0) {
-            wp_send_json_error(array('message' => __('Failed to schedule topics.', 'ai-post-scheduler')));
-        }
-
-        do_action('aips_planner_bulk_scheduled', $count, $template_id);
+        do_action('aips_planner_bulk_scheduled', $count, $template_id, $edition_id);
 
         wp_send_json_success(array(
-            'message' => sprintf(__('%d topics scheduled successfully.', 'ai-post-scheduler'), $count),
+            'message' => $edition_id
+                ? sprintf(__('%1$d topics scheduled into edition "%2$s".', 'ai-post-scheduler'), $count, $edition->name)
+                : sprintf(__('%d topics scheduled successfully.', 'ai-post-scheduler'), $count),
             'count' => $count
         ));
     }

--- a/ai-post-scheduler/includes/class-aips-schedule-processor.php
+++ b/ai-post-scheduler/includes/class-aips-schedule-processor.php
@@ -294,6 +294,8 @@ class AIPS_Schedule_Processor {
 
         $topic = isset($schedule->topic) ? $schedule->topic : null;
         $creation_method = $is_manual ? 'manual' : 'scheduled';
+        $editions_repository = new AIPS_Editions_Repository();
+        $edition_context = $editions_repository->get_generation_context_by_schedule_id($schedule->schedule_id);
         
         // Create context with creation_method
         $context = new AIPS_Template_Context($template, null, $topic, $creation_method);
@@ -302,10 +304,19 @@ class AIPS_Schedule_Processor {
         $errors = array();
 
         for ($i = 0; $i < $post_quantity; $i++) {
+            if (!empty($edition_context)) {
+                AIPS_Edition_Prompt_Helper::set_current_context($edition_context);
+            }
+
             $result = $this->generator->generate_post($context);
+            AIPS_Edition_Prompt_Helper::clear_current_context();
+
             if (is_wp_error($result)) {
                 $errors[] = $result;
             } else {
+                if (!empty($edition_context)) {
+                    $editions_repository->mark_slot_post_generated($schedule->schedule_id, $result);
+                }
                 $successful_post_ids[] = $result;
             }
         }

--- a/ai-post-scheduler/includes/class-aips-settings.php
+++ b/ai-post-scheduler/includes/class-aips-settings.php
@@ -115,6 +115,15 @@ class AIPS_Settings {
 
         add_submenu_page(
             'ai-post-scheduler',
+            __('Editions', 'ai-post-scheduler'),
+            __('Editions', 'ai-post-scheduler'),
+            'manage_options',
+            'aips-editions',
+            array($this, 'render_editions_page')
+        );
+
+        add_submenu_page(
+            'ai-post-scheduler',
             __('Schedule', 'ai-post-scheduler'),
             __('Schedule', 'ai-post-scheduler'),
             'manage_options',
@@ -1086,6 +1095,17 @@ class AIPS_Settings {
         $templates_handler->render_page();
     }
     
+    /**
+     * Render the Editions management page.
+     *
+     * Includes the editions template file.
+     *
+     * @return void
+     */
+    public function render_editions_page() {
+        include AIPS_PLUGIN_DIR . 'templates/admin/editions.php';
+    }
+
     /**
      * Render the Schedule management page.
      *

--- a/ai-post-scheduler/includes/class-aips-unified-schedule-service.php
+++ b/ai-post-scheduler/includes/class-aips-unified-schedule-service.php
@@ -22,9 +22,10 @@ if (!defined('ABSPATH')) {
 class AIPS_Unified_Schedule_Service {
 
 	/** Schedule type constants */
-	const TYPE_TEMPLATE    = 'template_schedule';
+	const TYPE_TEMPLATE     = 'template_schedule';
 	const TYPE_AUTHOR_TOPIC = 'author_topic_gen';
 	const TYPE_AUTHOR_POST  = 'author_post_gen';
+	const TYPE_EDITION      = 'edition_package';
 
 	/**
 	 * @var AIPS_Schedule_Repository
@@ -42,12 +43,18 @@ class AIPS_Unified_Schedule_Service {
 	private $history_repository;
 
 	/**
+	 * @var AIPS_Editions_Repository
+	 */
+	private $editions_repository;
+
+	/**
 	 * Initialise the service and its dependencies.
 	 */
 	public function __construct() {
 		$this->schedule_repository = new AIPS_Schedule_Repository();
 		$this->authors_repository  = new AIPS_Authors_Repository();
 		$this->history_repository  = new AIPS_History_Repository();
+		$this->editions_repository = new AIPS_Editions_Repository();
 	}
 
 	/**
@@ -70,6 +77,9 @@ class AIPS_Unified_Schedule_Service {
 		}
 		if (empty($type_filter) || $type_filter === self::TYPE_AUTHOR_POST) {
 			$schedules = array_merge($schedules, $this->get_author_post_schedules());
+		}
+		if (empty($type_filter) || $type_filter === self::TYPE_EDITION) {
+			$schedules = array_merge($schedules, $this->get_edition_schedules());
 		}
 
 		// Sort by next_run ascending, nulls last.
@@ -111,6 +121,9 @@ class AIPS_Unified_Schedule_Service {
 			case self::TYPE_AUTHOR_POST:
 				return $this->authors_repository->update_post_generation_active($id, $is_active);
 
+			case self::TYPE_EDITION:
+				return $this->editions_repository->set_active($id, $is_active);
+
 			default:
 				return false;
 		}
@@ -145,6 +158,9 @@ class AIPS_Unified_Schedule_Service {
 					return new WP_Error('not_found', __('Author not found.', 'ai-post-scheduler'));
 				}
 				return $generator->generate_post_for_author($author);
+
+			case self::TYPE_EDITION:
+				return new WP_Error('edition_package', __('Edition packages are coordinated through Planner slot assignments rather than Run Now.', 'ai-post-scheduler'));
 
 			default:
 				return new WP_Error('invalid_type', __('Invalid schedule type.', 'ai-post-scheduler'));
@@ -186,6 +202,9 @@ class AIPS_Unified_Schedule_Service {
 					100
 				);
 				return $this->format_history_logs($logs);
+
+			case self::TYPE_EDITION:
+				return array();
 
 			default:
 				return array();
@@ -381,6 +400,51 @@ class AIPS_Unified_Schedule_Service {
 				'history_id'  => null,
 				'author_id'   => (int) $author->id,
 				'author_name' => $author->name,
+			);
+		}
+
+		return $result;
+	}
+
+
+
+	/**
+	 * Normalise edition package rows.
+	 *
+	 * @return array
+	 */
+	private function get_edition_schedules() {
+		$editions = $this->editions_repository->get_all();
+		$result = array();
+
+		foreach ($editions as $edition) {
+			$result[] = array(
+				'id' => absint($edition->id),
+				'type' => self::TYPE_EDITION,
+				'title' => $edition->name,
+				'subtitle' => sprintf(
+					/* translators: 1: owner, 2: channel type */
+					__('Owner: %1$s · Channel: %2$s', 'ai-post-scheduler'),
+					$edition->owner,
+					$edition->channel_type
+				),
+				'cron_hook' => __('edition package', 'ai-post-scheduler'),
+				'frequency' => $edition->cadence,
+				'last_run' => null,
+				'next_run' => $edition->target_publish_date,
+				'is_active' => (int) $edition->is_active,
+				'status' => !empty($edition->is_active) ? 'active' : 'inactive',
+				'stats_count' => (int) $edition->completeness['slots_filled'],
+				'stats_label' => sprintf(
+					/* translators: 1: filled count, 2: required slots */
+					__('slots filled (%1$d/%2$d)', 'ai-post-scheduler'),
+					(int) $edition->completeness['slots_filled'],
+					(int) $edition->required_slots
+				),
+				'can_delete' => false,
+				'history_id' => null,
+				'edition_id' => (int) $edition->id,
+				'edition' => $edition,
 			);
 		}
 

--- a/ai-post-scheduler/templates/admin/editions.php
+++ b/ai-post-scheduler/templates/admin/editions.php
@@ -1,0 +1,340 @@
+<?php
+/**
+ * Editions admin template.
+ *
+ * @package AI_Post_Scheduler
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+$editions_repository = new AIPS_Editions_Repository();
+$editions = $editions_repository->get_all();
+$default_slot_types = AIPS_Editions_Repository::get_default_slot_types();
+$cadence_options = array(
+	'daily' => __('Daily', 'ai-post-scheduler'),
+	'weekly' => __('Weekly', 'ai-post-scheduler'),
+	'biweekly' => __('Bi-weekly', 'ai-post-scheduler'),
+	'monthly' => __('Monthly', 'ai-post-scheduler'),
+	'quarterly' => __('Quarterly', 'ai-post-scheduler'),
+);
+$channel_types = array(
+	'web' => __('Web', 'ai-post-scheduler'),
+	'newsletter' => __('Newsletter', 'ai-post-scheduler'),
+	'social' => __('Social', 'ai-post-scheduler'),
+	'multi-channel' => __('Multi-channel', 'ai-post-scheduler'),
+);
+?>
+<div class="wrap aips-wrap">
+	<div class="aips-page-container">
+		<div class="aips-page-header">
+			<div class="aips-page-header-top">
+				<div>
+					<h1 class="aips-page-title"><?php esc_html_e('Editions', 'ai-post-scheduler'); ?></h1>
+					<p class="aips-page-description"><?php esc_html_e('Manage coordinated editorial packages with shared themes, ownership, package slots, and completeness indicators.', 'ai-post-scheduler'); ?></p>
+				</div>
+			</div>
+		</div>
+
+		<div class="aips-content-panel" style="margin-bottom:24px;">
+			<div class="aips-panel-header">
+				<div class="aips-panel-header-content">
+					<span class="dashicons dashicons-portfolio dashicons-icon-lg"></span>
+					<div>
+						<h3 class="aips-panel-title"><?php esc_html_e('Edition Package Builder', 'ai-post-scheduler'); ?></h3>
+						<p class="aips-panel-description"><?php esc_html_e('Define the package theme, cadence, launch target, and the package slots your editorial team needs to fill.', 'ai-post-scheduler'); ?></p>
+					</div>
+				</div>
+			</div>
+			<div class="aips-panel-body">
+				<form id="aips-edition-form">
+					<input type="hidden" name="edition_id" id="aips-edition-id" value="0">
+					<div class="aips-form-grid" style="grid-template-columns:repeat(auto-fit, minmax(220px, 1fr)); gap:16px;">
+						<div class="aips-form-field">
+							<label for="aips-edition-name" class="aips-form-label"><?php esc_html_e('Edition Name', 'ai-post-scheduler'); ?></label>
+							<input type="text" class="aips-form-input" id="aips-edition-name" name="name" required>
+						</div>
+						<div class="aips-form-field">
+							<label for="aips-edition-theme" class="aips-form-label"><?php esc_html_e('Edition Theme', 'ai-post-scheduler'); ?></label>
+							<input type="text" class="aips-form-input" id="aips-edition-theme" name="theme" placeholder="<?php echo esc_attr__('Optional. Defaults to the edition name.', 'ai-post-scheduler'); ?>">
+						</div>
+						<div class="aips-form-field">
+							<label for="aips-edition-cadence" class="aips-form-label"><?php esc_html_e('Cadence', 'ai-post-scheduler'); ?></label>
+							<select id="aips-edition-cadence" name="cadence" class="aips-form-input">
+								<?php foreach ($cadence_options as $value => $label): ?>
+								<option value="<?php echo esc_attr($value); ?>"><?php echo esc_html($label); ?></option>
+								<?php endforeach; ?>
+							</select>
+						</div>
+						<div class="aips-form-field">
+							<label for="aips-edition-target" class="aips-form-label"><?php esc_html_e('Target Publish Date', 'ai-post-scheduler'); ?></label>
+							<input type="datetime-local" class="aips-form-input" id="aips-edition-target" name="target_publish_date" value="<?php echo esc_attr(gmdate('Y-m-d\TH:i')); ?>" required>
+						</div>
+						<div class="aips-form-field">
+							<label for="aips-edition-required-slots" class="aips-form-label"><?php esc_html_e('Required Slots', 'ai-post-scheduler'); ?></label>
+							<input type="number" min="1" class="aips-form-input" id="aips-edition-required-slots" name="required_slots" value="5" required>
+						</div>
+						<div class="aips-form-field">
+							<label for="aips-edition-owner" class="aips-form-label"><?php esc_html_e('Owner', 'ai-post-scheduler'); ?></label>
+							<input type="text" class="aips-form-input" id="aips-edition-owner" name="owner" required>
+						</div>
+						<div class="aips-form-field">
+							<label for="aips-edition-channel" class="aips-form-label"><?php esc_html_e('Channel Type', 'ai-post-scheduler'); ?></label>
+							<select id="aips-edition-channel" name="channel_type" class="aips-form-input">
+								<?php foreach ($channel_types as $value => $label): ?>
+								<option value="<?php echo esc_attr($value); ?>"><?php echo esc_html($label); ?></option>
+								<?php endforeach; ?>
+							</select>
+						</div>
+						<div class="aips-form-field" style="align-self:end;">
+							<label><input type="checkbox" name="is_active" id="aips-edition-active" checked> <?php esc_html_e('Edition is active', 'ai-post-scheduler'); ?></label>
+						</div>
+					</div>
+
+					<h4 style="margin-top:24px;"><?php esc_html_e('Story Slots', 'ai-post-scheduler'); ?></h4>
+					<p class="aips-field-description"><?php esc_html_e('These package slots can later be filled from Planner and will roll up into schedule, generated post, and review queue views.', 'ai-post-scheduler'); ?></p>
+					<table class="aips-table" id="aips-edition-slot-table">
+						<thead>
+							<tr>
+								<th><?php esc_html_e('Include', 'ai-post-scheduler'); ?></th>
+								<th><?php esc_html_e('Slot Type', 'ai-post-scheduler'); ?></th>
+								<th><?php esc_html_e('Custom Label', 'ai-post-scheduler'); ?></th>
+								<th><?php esc_html_e('Sourcing', 'ai-post-scheduler'); ?></th>
+								<th><?php esc_html_e('Notes', 'ai-post-scheduler'); ?></th>
+							</tr>
+						</thead>
+						<tbody>
+							<?php $slot_index = 0; foreach ($default_slot_types as $slot_key => $slot_label): ?>
+							<tr data-slot-key="<?php echo esc_attr($slot_key); ?>">
+								<td>
+									<input type="checkbox" class="aips-edition-slot-enabled" checked>
+									<input type="hidden" name="slot_key[]" value="<?php echo esc_attr($slot_key); ?>">
+									<input type="hidden" name="slot_assigned_topic[]" value="">
+									<input type="hidden" name="slot_template_id[]" value="0">
+									<input type="hidden" name="slot_schedule_id[]" value="0">
+									<input type="hidden" name="slot_post_id[]" value="0">
+								</td>
+								<td><?php echo esc_html($slot_label); ?></td>
+								<td><input type="text" class="aips-form-input" name="slot_label[]" value="<?php echo esc_attr($slot_label); ?>"></td>
+								<td>
+									<select name="slot_sourcing_status[]" class="aips-form-input">
+										<option value="ready"><?php esc_html_e('Ready', 'ai-post-scheduler'); ?></option>
+										<option value="missing"><?php esc_html_e('Missing sourcing', 'ai-post-scheduler'); ?></option>
+									</select>
+								</td>
+								<td><input type="text" class="aips-form-input" name="slot_notes[]" value="" placeholder="<?php esc_attr_e('Optional slot guidance', 'ai-post-scheduler'); ?>"></td>
+							</tr>
+							<?php $slot_index++; endforeach; ?>
+						</tbody>
+					</table>
+
+					<div style="margin-top:20px; display:flex; gap:12px; align-items:center;">
+						<button type="submit" class="aips-btn aips-btn-primary" id="aips-save-edition-btn">
+							<span class="dashicons dashicons-saved"></span>
+							<?php esc_html_e('Save Edition', 'ai-post-scheduler'); ?>
+						</button>
+						<button type="button" class="aips-btn aips-btn-secondary" id="aips-reset-edition-btn"><?php esc_html_e('Reset Form', 'ai-post-scheduler'); ?></button>
+						<span class="spinner"></span>
+					</div>
+				</form>
+			</div>
+		</div>
+
+		<div class="aips-content-panel">
+			<div class="aips-panel-header">
+				<div class="aips-panel-header-content">
+					<span class="dashicons dashicons-list-view dashicons-icon-lg"></span>
+					<div>
+						<h3 class="aips-panel-title"><?php esc_html_e('Current Editions', 'ai-post-scheduler'); ?></h3>
+						<p class="aips-panel-description"><?php esc_html_e('Track package readiness across filled slots, review readiness, sourcing blockers, and publish readiness.', 'ai-post-scheduler'); ?></p>
+					</div>
+				</div>
+			</div>
+			<div class="aips-panel-body">
+				<?php if (!empty($editions)): ?>
+					<div class="aips-edition-cards" style="display:grid; gap:16px;">
+						<?php foreach ($editions as $edition): ?>
+							<div class="aips-content-panel" style="margin:0; border:1px solid #dcdcde; box-shadow:none;" data-edition='<?php echo esc_attr(wp_json_encode($edition)); ?>'>
+								<div class="aips-panel-body">
+									<div style="display:flex; justify-content:space-between; gap:16px; flex-wrap:wrap; margin-bottom:12px;">
+										<div>
+											<h3 style="margin:0 0 6px;"><?php echo esc_html($edition->name); ?></h3>
+											<p style="margin:0; color:#646970;">
+												<?php echo esc_html($edition->theme); ?> ·
+												<?php echo esc_html(ucfirst($edition->cadence)); ?> ·
+												<?php echo esc_html($edition->channel_type); ?>
+											</p>
+											<p style="margin:6px 0 0; color:#646970;">
+												<?php echo esc_html(sprintf(__('Owner: %1$s · Target: %2$s', 'ai-post-scheduler'), $edition->owner, date_i18n(get_option('date_format') . ' ' . get_option('time_format'), strtotime($edition->target_publish_date)))); ?>
+											</p>
+										</div>
+										<div style="display:flex; gap:8px; align-items:flex-start;">
+											<span class="aips-badge <?php echo !empty($edition->is_active) ? 'aips-badge-success' : 'aips-badge-neutral'; ?>"><?php echo !empty($edition->is_active) ? esc_html__('Active', 'ai-post-scheduler') : esc_html__('Paused', 'ai-post-scheduler'); ?></span>
+											<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-edit-edition-btn"><?php esc_html_e('Edit', 'ai-post-scheduler'); ?></button>
+											<button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-edition-btn" data-edition-id="<?php echo esc_attr($edition->id); ?>"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></button>
+										</div>
+									</div>
+									<div style="display:grid; grid-template-columns:repeat(auto-fit, minmax(160px, 1fr)); gap:12px; margin-bottom:16px;">
+										<div class="aips-stat-box"><strong><?php echo esc_html($edition->completeness['slots_filled']); ?>/<?php echo esc_html($edition->required_slots); ?></strong><br><span><?php esc_html_e('Slots Filled', 'ai-post-scheduler'); ?></span></div>
+										<div class="aips-stat-box"><strong><?php echo esc_html($edition->completeness['ready_for_review']); ?></strong><br><span><?php esc_html_e('Ready for Review', 'ai-post-scheduler'); ?></span></div>
+										<div class="aips-stat-box"><strong><?php echo esc_html($edition->completeness['blocked_by_missing_sourcing']); ?></strong><br><span><?php esc_html_e('Blocked by Missing Sourcing', 'ai-post-scheduler'); ?></span></div>
+										<div class="aips-stat-box"><strong><?php echo esc_html($edition->completeness['ready_to_publish']); ?></strong><br><span><?php esc_html_e('Ready to Publish', 'ai-post-scheduler'); ?></span></div>
+									</div>
+									<table class="aips-table">
+										<thead>
+											<tr>
+												<th><?php esc_html_e('Slot', 'ai-post-scheduler'); ?></th>
+												<th><?php esc_html_e('Assigned Story', 'ai-post-scheduler'); ?></th>
+												<th><?php esc_html_e('Sourcing', 'ai-post-scheduler'); ?></th>
+												<th><?php esc_html_e('Status', 'ai-post-scheduler'); ?></th>
+											</tr>
+										</thead>
+										<tbody>
+											<?php foreach ($edition->slots as $slot): ?>
+											<tr>
+												<td><?php echo esc_html($slot->slot_label); ?></td>
+												<td><?php echo !empty($slot->assigned_topic) ? esc_html($slot->assigned_topic) : '<span class="aips-muted">' . esc_html__('Unassigned', 'ai-post-scheduler') . '</span>'; ?></td>
+												<td>
+													<span class="aips-badge <?php echo $slot->sourcing_status === 'missing' ? 'aips-badge-warning' : 'aips-badge-success'; ?>">
+														<?php echo $slot->sourcing_status === 'missing' ? esc_html__('Missing', 'ai-post-scheduler') : esc_html__('Ready', 'ai-post-scheduler'); ?>
+													</span>
+												</td>
+												<td>
+													<?php if (!empty($slot->post_id) && in_array($slot->post_status, array('future', 'publish'), true)): ?>
+														<span class="aips-badge aips-badge-success"><?php esc_html_e('Ready to publish', 'ai-post-scheduler'); ?></span>
+													<?php elseif (!empty($slot->post_id) && in_array($slot->post_status, array('draft', 'pending'), true)): ?>
+														<span class="aips-badge aips-badge-info"><?php esc_html_e('Ready for review', 'ai-post-scheduler'); ?></span>
+													<?php elseif (!empty($slot->schedule_id)): ?>
+														<span class="aips-badge aips-badge-neutral"><?php esc_html_e('Scheduled', 'ai-post-scheduler'); ?></span>
+													<?php else: ?>
+														<span class="aips-badge aips-badge-neutral"><?php esc_html_e('Open', 'ai-post-scheduler'); ?></span>
+													<?php endif; ?>
+												</td>
+											</tr>
+											<?php endforeach; ?>
+										</tbody>
+									</table>
+								</div>
+							</div>
+						<?php endforeach; ?>
+					</div>
+				<?php else: ?>
+					<div class="aips-empty-state">
+						<div class="dashicons dashicons-portfolio aips-empty-state-icon"></div>
+						<h3 class="aips-empty-state-title"><?php esc_html_e('No Editions Yet', 'ai-post-scheduler'); ?></h3>
+						<p class="aips-empty-state-description"><?php esc_html_e('Create your first edition package to coordinate lead stories, analysis pieces, roundups, sidebars, and newsletter components as a set.', 'ai-post-scheduler'); ?></p>
+					</div>
+				<?php endif; ?>
+			</div>
+		</div>
+	</div>
+</div>
+<script>
+jQuery(function($) {
+	var $form = $('#aips-edition-form');
+	var $spinner = $form.find('.spinner');
+	var nonce = (window.aipsAjax && window.aipsAjax.nonce) ? window.aipsAjax.nonce : '';
+
+	function resetForm() {
+		$form[0].reset();
+		$('#aips-edition-id').val(0);
+		$('#aips-edition-target').val('<?php echo esc_js(gmdate('Y-m-d\TH:i')); ?>');
+		$('.aips-edition-slot-enabled').prop('checked', true).trigger('change');
+	}
+
+	$(document).on('change', '.aips-edition-slot-enabled', function() {
+		var $row = $(this).closest('tr');
+		var enabled = $(this).is(':checked');
+		$row.find('input, select').not(this).prop('disabled', !enabled);
+	});
+
+	$(document).on('click', '#aips-reset-edition-btn', function() {
+		resetForm();
+	});
+
+	$(document).on('click', '.aips-edit-edition-btn', function() {
+		var raw = $(this).closest('[data-edition]').attr('data-edition');
+		var data = raw ? JSON.parse(raw) : null;
+		if (!data) {
+			return;
+		}
+
+		resetForm();
+		$('#aips-edition-id').val(data.id);
+		$('#aips-edition-name').val(data.name);
+		$('#aips-edition-theme').val(data.theme || '');
+		$('#aips-edition-cadence').val(data.cadence);
+		$('#aips-edition-target').val((data.target_publish_date || '').replace(' ', 'T').slice(0, 16));
+		$('#aips-edition-required-slots').val(data.required_slots);
+		$('#aips-edition-owner').val(data.owner);
+		$('#aips-edition-channel').val(data.channel_type);
+		$('#aips-edition-active').prop('checked', !!parseInt(data.is_active, 10));
+
+		var slots = data.slots || [];
+		$('#aips-edition-slot-table tbody tr').each(function(index) {
+			var $row = $(this);
+			var rowSlot = slots[index];
+			if (!rowSlot) {
+				$row.find('.aips-edition-slot-enabled').prop('checked', false).trigger('change');
+				return;
+			}
+
+			$row.find('.aips-edition-slot-enabled').prop('checked', true).trigger('change');
+			$row.find('input[name="slot_key[]"]').val(rowSlot.slot_key);
+			$row.find('input[name="slot_label[]"]').val(rowSlot.slot_label);
+			$row.find('input[name="slot_notes[]"]').val(rowSlot.notes || '');
+			$row.find('select[name="slot_sourcing_status[]"]').val(rowSlot.sourcing_status || 'ready');
+			$row.find('input[name="slot_assigned_topic[]"]').val(rowSlot.assigned_topic || '');
+			$row.find('input[name="slot_template_id[]"]').val(rowSlot.template_id || 0);
+			$row.find('input[name="slot_schedule_id[]"]').val(rowSlot.schedule_id || 0);
+			$row.find('input[name="slot_post_id[]"]').val(rowSlot.post_id || 0);
+		});
+
+		window.scrollTo({ top: 0, behavior: 'smooth' });
+	});
+
+	$form.on('submit', function(event) {
+		event.preventDefault();
+		var formData = $form.serializeArray();
+		formData.push({ name: 'action', value: 'aips_save_edition' });
+		formData.push({ name: 'nonce', value: nonce });
+
+		$spinner.addClass('is-active');
+		$.post(ajaxurl, formData).done(function(response) {
+			if (response && response.success) {
+				window.location.reload();
+				return;
+			}
+			window.alert(response && response.data && response.data.message ? response.data.message : '<?php echo esc_js(__('Failed to save edition.', 'ai-post-scheduler')); ?>');
+		}).fail(function() {
+			window.alert('<?php echo esc_js(__('Failed to save edition.', 'ai-post-scheduler')); ?>');
+		}).always(function() {
+			$spinner.removeClass('is-active');
+		});
+	});
+
+	$(document).on('click', '.aips-delete-edition-btn', function() {
+		if (!window.confirm('<?php echo esc_js(__('Delete this edition package and all slot assignments?', 'ai-post-scheduler')); ?>')) {
+			return;
+		}
+
+		var editionId = $(this).data('edition-id');
+		$.post(ajaxurl, {
+			action: 'aips_delete_edition',
+			nonce: nonce,
+			edition_id: editionId
+		}).done(function(response) {
+			if (response && response.success) {
+				window.location.reload();
+				return;
+			}
+			window.alert(response && response.data && response.data.message ? response.data.message : '<?php echo esc_js(__('Failed to delete edition.', 'ai-post-scheduler')); ?>');
+		}).fail(function() {
+			window.alert('<?php echo esc_js(__('Failed to delete edition.', 'ai-post-scheduler')); ?>');
+		});
+	});
+
+	resetForm();
+});
+</script>

--- a/ai-post-scheduler/templates/admin/generated-posts.php
+++ b/ai-post-scheduler/templates/admin/generated-posts.php
@@ -95,6 +95,7 @@ if (!defined('ABSPATH')) {
 							<tr>
 								<th scope="col"><?php esc_html_e('Title', 'ai-post-scheduler'); ?></th>
 								<th scope="col"><?php esc_html_e('Source', 'ai-post-scheduler'); ?></th>
+								<th scope="col"><?php esc_html_e('Edition', 'ai-post-scheduler'); ?></th>
 								<th scope="col"><?php esc_html_e('Scheduled', 'ai-post-scheduler'); ?></th>
 								<th scope="col"><?php esc_html_e('Published', 'ai-post-scheduler'); ?></th>
 								<th scope="col"><?php esc_html_e('Generated', 'ai-post-scheduler'); ?></th>
@@ -112,6 +113,11 @@ if (!defined('ABSPATH')) {
 								<td>
 									<span class="aips-badge aips-badge-neutral">
 										<?php echo esc_html($post_data['source']); ?>
+									</span>
+								</td>
+								<td>
+									<span class="aips-badge <?php echo !empty($post_data['edition']) ? 'aips-badge-info' : 'aips-badge-neutral'; ?>">
+										<?php echo esc_html($controller->format_edition_label($post_data['edition'])); ?>
 									</span>
 								</td>
 								<td>
@@ -295,6 +301,7 @@ if (!defined('ABSPATH')) {
 								<th scope="col"><?php esc_html_e('Missing Components', 'ai-post-scheduler'); ?></th>
 								<th scope="col"><?php esc_html_e('State', 'ai-post-scheduler'); ?></th>
 								<th scope="col"><?php esc_html_e('Source', 'ai-post-scheduler'); ?></th>
+								<th scope="col"><?php esc_html_e('Edition', 'ai-post-scheduler'); ?></th>
 								<th scope="col"><?php esc_html_e('Status', 'ai-post-scheduler'); ?></th>
 								<th scope="col"><?php esc_html_e('Updated', 'ai-post-scheduler'); ?></th>
 								<th scope="col"><?php esc_html_e('Generated', 'ai-post-scheduler'); ?></th>
@@ -328,6 +335,11 @@ if (!defined('ABSPATH')) {
 								<td>
 									<span class="aips-badge aips-badge-neutral">
 										<?php echo esc_html($post_data['source']); ?>
+									</span>
+								</td>
+								<td>
+									<span class="aips-badge <?php echo !empty($post_data['edition']) ? 'aips-badge-info' : 'aips-badge-neutral'; ?>">
+										<?php echo esc_html($controller->format_edition_label($post_data['edition'])); ?>
 									</span>
 								</td>
 								<td>
@@ -473,6 +485,7 @@ if (!defined('ABSPATH')) {
 									</th>
 									<th scope="col"><?php esc_html_e('Post', 'ai-post-scheduler'); ?></th>
 									<th scope="col"><?php esc_html_e('Source', 'ai-post-scheduler'); ?></th>
+									<th scope="col"><?php esc_html_e('Edition', 'ai-post-scheduler'); ?></th>
 									<th scope="col"><?php esc_html_e('Created', 'ai-post-scheduler'); ?></th>
 									<th scope="col"><?php esc_html_e('Modified', 'ai-post-scheduler'); ?></th>
 									<th scope="col"><?php esc_html_e('Actions', 'ai-post-scheduler'); ?></th>
@@ -496,6 +509,11 @@ if (!defined('ABSPATH')) {
 									<td>
 										<span class="aips-badge aips-badge-neutral">
 											<?php echo esc_html($controller->format_source($item)); ?>
+										</span>
+									</td>
+									<td>
+										<span class="aips-badge <?php echo !empty($draft_post_edition_map[$item->post_id]) ? 'aips-badge-info' : 'aips-badge-neutral'; ?>">
+											<?php echo esc_html($controller->format_edition_label(isset($draft_post_edition_map[$item->post_id]) ? $draft_post_edition_map[$item->post_id] : null)); ?>
 										</span>
 									</td>
 									<td>

--- a/ai-post-scheduler/templates/admin/planner.php
+++ b/ai-post-scheduler/templates/admin/planner.php
@@ -1,5 +1,7 @@
 <?php
 $default_planner_frequency = 'daily';
+$editions_repository = new AIPS_Editions_Repository();
+$planner_editions = $editions_repository->get_active();
 ?>
 <div class="aips-planner-container">
     <!-- Topic Brainstorming Card -->
@@ -102,7 +104,43 @@ $default_planner_frequency = 'daily';
                         <label for="bulk-frequency" class="aips-form-label"><?php echo esc_html__('Frequency', 'ai-post-scheduler'); ?></label>
                         <?php AIPS_Template_Helper::render_frequency_dropdown( 'bulk-frequency', 'bulk-frequency', $default_planner_frequency, __( 'Frequency', 'ai-post-scheduler' ) ); ?>
                     </div>
+
+                    <div class="aips-form-field">
+                        <label for="bulk-edition" class="aips-form-label"><?php echo esc_html__('Edition Package', 'ai-post-scheduler'); ?></label>
+                        <select id="bulk-edition" class="aips-form-input">
+                            <option value=""><?php echo esc_html__('None — schedule as standalone posts', 'ai-post-scheduler'); ?></option>
+                            <?php foreach ($planner_editions as $edition): ?>
+                                <option value="<?php echo esc_attr($edition->id); ?>">
+                                    <?php echo esc_html(sprintf('%1$s (%2$d/%3$d filled)', $edition->name, $edition->completeness['slots_filled'], $edition->required_slots)); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                        <p class="aips-field-description"><?php echo esc_html__('Choose an edition to map selected planner topics into the next open package slots in order.', 'ai-post-scheduler'); ?></p>
+                    </div>
                 </div>
+
+                <?php if (!empty($planner_editions)): ?>
+                <div class="aips-content-panel" style="margin-top:16px; box-shadow:none; border:1px solid #dcdcde;">
+                    <div class="aips-panel-body">
+                        <h4 style="margin-top:0;"><?php esc_html_e('Edition Readiness Snapshot', 'ai-post-scheduler'); ?></h4>
+                        <div style="display:grid; gap:12px;">
+                            <?php foreach ($planner_editions as $edition): ?>
+                            <div style="display:flex; justify-content:space-between; gap:12px; flex-wrap:wrap; border-bottom:1px solid #f0f0f1; padding-bottom:12px;">
+                                <div>
+                                    <strong><?php echo esc_html($edition->name); ?></strong>
+                                    <div class="aips-muted" style="margin-top:4px;"><?php echo esc_html(sprintf(__('Target: %1$s · Owner: %2$s · Channel: %3$s', 'ai-post-scheduler'), date_i18n(get_option('date_format') . ' ' . get_option('time_format'), strtotime($edition->target_publish_date)), $edition->owner, $edition->channel_type)); ?></div>
+                                </div>
+                                <div style="display:flex; gap:8px; flex-wrap:wrap;">
+                                    <span class="aips-badge aips-badge-neutral"><?php echo esc_html(sprintf(__('Filled %1$d/%2$d', 'ai-post-scheduler'), $edition->completeness['slots_filled'], $edition->required_slots)); ?></span>
+                                    <span class="aips-badge aips-badge-info"><?php echo esc_html(sprintf(__('Review %d', 'ai-post-scheduler'), $edition->completeness['ready_for_review'])); ?></span>
+                                    <span class="aips-badge <?php echo $edition->completeness['blocked_by_missing_sourcing'] ? 'aips-badge-warning' : 'aips-badge-success'; ?>"><?php echo esc_html(sprintf(__('Missing sourcing %d', 'ai-post-scheduler'), $edition->completeness['blocked_by_missing_sourcing'])); ?></span>
+                                </div>
+                            </div>
+                            <?php endforeach; ?>
+                        </div>
+                    </div>
+                </div>
+                <?php endif; ?>
 
                 <div class="aips-planner-actions">
                     <button type="button" id="btn-bulk-schedule" class="aips-btn aips-btn-primary aips-btn-lg">

--- a/ai-post-scheduler/templates/admin/schedule.php
+++ b/ai-post-scheduler/templates/admin/schedule.php
@@ -49,6 +49,8 @@ if (!function_exists('aips_type_badge')) {
 				return '<span class="aips-badge aips-badge-type-topic">' . esc_html__('Author Topics', 'ai-post-scheduler') . '</span>';
 			case AIPS_Unified_Schedule_Service::TYPE_AUTHOR_POST:
 				return '<span class="aips-badge aips-badge-type-post">' . esc_html__('Author Posts', 'ai-post-scheduler') . '</span>';
+			case AIPS_Unified_Schedule_Service::TYPE_EDITION:
+				return '<span class="aips-badge aips-badge-type-template">' . esc_html__('Edition Package', 'ai-post-scheduler') . '</span>';
 		}
 		return '';
 	}
@@ -71,6 +73,12 @@ if (!function_exists('aips_run_output_label')) {
 				: __('Expected output: approved-topic post', 'ai-post-scheduler');
 		}
 
+		if ($type === AIPS_Unified_Schedule_Service::TYPE_EDITION) {
+			return 'last' === $context
+				? __('Tracked package completeness', 'ai-post-scheduler')
+				: __('Expected output: coordinated package launch', 'ai-post-scheduler');
+		}
+
 		return 'last' === $context
 			? __('Generated post from template', 'ai-post-scheduler')
 			: __('Expected output: generated post', 'ai-post-scheduler');
@@ -85,7 +93,7 @@ if (!function_exists('aips_run_output_label')) {
 			<div class="aips-page-header-top">
 				<div>
 					<h1 class="aips-page-title"><?php esc_html_e('Schedules', 'ai-post-scheduler'); ?></h1>
-					<p class="aips-page-description"><?php esc_html_e('All scheduled processes — template post generation, author topic generation, and author post generation — in one view.', 'ai-post-scheduler'); ?></p>
+					<p class="aips-page-description"><?php esc_html_e('All scheduled processes — template post generation, author topic generation, author post generation, and edition package launches — in one view.', 'ai-post-scheduler'); ?></p>
 				</div>
 				<div class="aips-page-actions">
 					<?php if (!empty($templates)): ?>
@@ -119,6 +127,9 @@ if (!function_exists('aips_run_output_label')) {
 						</option>
 						<option value="<?php echo esc_attr(AIPS_Unified_Schedule_Service::TYPE_AUTHOR_POST); ?>" <?php selected($type_filter, AIPS_Unified_Schedule_Service::TYPE_AUTHOR_POST); ?>>
 							<?php esc_html_e('Author Posts', 'ai-post-scheduler'); ?>
+						</option>
+						<option value="<?php echo esc_attr(AIPS_Unified_Schedule_Service::TYPE_EDITION); ?>" <?php selected($type_filter, AIPS_Unified_Schedule_Service::TYPE_EDITION); ?>>
+							<?php esc_html_e('Edition Packages', 'ai-post-scheduler'); ?>
 						</option>
 					</select>
 				</div>

--- a/ai-post-scheduler/tests/test-db-schema.php
+++ b/ai-post-scheduler/tests/test-db-schema.php
@@ -272,4 +272,32 @@ class Test_AIPS_DB_Schema extends WP_UnitTestCase {
 		// Clean up
 		$wpdb->query($wpdb->prepare("DELETE FROM {$table_name} WHERE id = %d", $template->id));
 	}
+
+	/**
+	 * Test that edition tables exist with core columns.
+	 */
+	public function test_edition_tables_exist() {
+		global $wpdb;
+		$editions_table = $wpdb->prefix . 'aips_editions';
+		$slots_table = $wpdb->prefix . 'aips_edition_slots';
+
+		$this->assertEquals($editions_table, $wpdb->get_var("SHOW TABLES LIKE '{$editions_table}'"));
+		$this->assertEquals($slots_table, $wpdb->get_var("SHOW TABLES LIKE '{$slots_table}'"));
+
+		$edition_columns = array_map(function($col) {
+			return $col->Field;
+		}, $wpdb->get_results("SHOW COLUMNS FROM {$editions_table}"));
+
+		$slot_columns = array_map(function($col) {
+			return $col->Field;
+		}, $wpdb->get_results("SHOW COLUMNS FROM {$slots_table}"));
+
+		foreach (array('name', 'cadence', 'target_publish_date', 'required_slots', 'owner', 'channel_type') as $column) {
+			$this->assertContains($column, $edition_columns, "Edition column '{$column}' should exist");
+		}
+
+		foreach (array('edition_id', 'slot_key', 'slot_label', 'schedule_id', 'post_id', 'sourcing_status') as $column) {
+			$this->assertContains($column, $slot_columns, "Edition slot column '{$column}' should exist");
+		}
+	}
 }

--- a/ai-post-scheduler/tests/test-template-processor.php
+++ b/ai-post-scheduler/tests/test-template-processor.php
@@ -136,6 +136,35 @@ class Test_AIPS_Template_Processor extends WP_UnitTestCase {
         }
     }
 
+
+    /**
+     * Test edition prompt helper variables.
+     */
+    public function test_edition_prompt_helper_variables() {
+        new AIPS_Edition_Prompt_Helper();
+        AIPS_Edition_Prompt_Helper::set_current_context(array(
+            'edition_name' => 'Election Night Package',
+            'edition_theme' => 'Election Night Package',
+            'edition_cadence' => 'weekly',
+            'edition_target_publish_date' => '2026-11-03 18:00:00',
+            'edition_required_slots' => 5,
+            'edition_owner' => 'Politics Desk',
+            'edition_channel_type' => 'newsletter',
+            'edition_slot_name' => 'Lead Story',
+            'edition_related_items' => array('Lead Story: Results', 'FAQ / Sidebar: How to read the map'),
+        ));
+
+        $template = 'Edition {{edition_name}} / {{edition_slot_name}} / {{edition_related_items}}';
+        $result = $this->processor->process($template, 'Election Results');
+
+        $this->assertStringContainsString('Election Night Package', $result);
+        $this->assertStringContainsString('Lead Story', $result);
+        $this->assertStringContainsString('FAQ / Sidebar', $result);
+
+        AIPS_Edition_Prompt_Helper::clear_current_context();
+        remove_all_filters('aips_template_variables');
+    }
+
     /**
      * Test validate_template with valid template
      */


### PR DESCRIPTION
### Motivation

- Support editorial packages that publish coordinated sets of related stories (editions) instead of isolated posts.  
- Provide structured edition metadata (name, cadence, target date, required slots, owner, channel) and named story slots to coordinate planning and publishing.  
- Surface edition context across Planner, Unified Schedule, Generated Posts, and the generation prompt system so generation and review workflows become package-aware.

### Description

- Added new DB tables `aips_editions` and `aips_edition_slots` and wired them into `AIPS_DB_Manager::get_schema()` so editions are part of the plugin schema.  
- Implemented `AIPS_Editions_Repository` for persistence and slot management, `AIPS_Editions_Controller` for AJAX CRUD, and `templates/admin/editions.php` for an admin UI to create/manage editions and slots.  
- Added `AIPS_Edition_Prompt_Helper` which injects edition variables into `AIPS_Template_Processor` during generation when an edition context is present.  
- Integrated editions into Planner (UI + AJAX) so planner bulk-schedule can optionally assign scheduled topics into the next open edition slots, and updated `admin-planner.js`, `AIPS_Planner`, and `templates/admin/planner.php`.  
- Integrated editions into generation and post flows by: setting edition context during schedule processing (`AIPS_Schedule_Processor`), marking slots when posts are generated (`AIPS_Editions_Repository::mark_slot_post_generated`), and showing edition data in Unified Schedule and Generated Posts views (`AIPS_Unified_Schedule_Service`, `AIPS_Generated_Posts_Controller`, `templates/admin/generated-posts.php`).  
- Added completeness indicators for editions and slots (slots filled, ready for review, blocked by missing sourcing, ready to publish) in the repository and admin templates.  
- Added tests: edition-aware template variable test added to `tests/test-template-processor.php`, and a schema expectation test added to `tests/test-db-schema.php` for edition tables/columns.

### Testing

- Ran syntax checks with `php -l` on modified/added PHP and template files and confirmed no syntax errors.  
- Ran the focused PHPUnit run for template processor with `vendor/bin/phpunit --filter Test_AIPS_Template_Processor` from `ai-post-scheduler/` and the test suite passed (`OK (34 tests, 106 assertions)`).  
- Ran the DB schema tests with `vendor/bin/phpunit --filter Test_AIPS_DB_Schema`; these tests error in this environment because the WordPress test library and `wp-admin/includes/upgrade.php` are not available (the code and tests are present and lint clean, but creating/applying schema requires WordPress test bootstrap in CI).  
- Notes: local `php -l` checks and `composer install` were executed successfully and the new files were added and validated; full DB-level CI (with WordPress test library) is required to run `Test_AIPS_DB_Schema` end-to-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf5a83ca408321b6f7f8084f14cb17)