### PR TITLE
Add multi-stage review workflow admin queue with DB tables and actions

### DIFF
--- a/ai-post-scheduler/ai-post-scheduler.php
+++ b/ai-post-scheduler/ai-post-scheduler.php
@@ -3,7 +3,7 @@
  * Plugin Name: AI Post Scheduler
  * Plugin URI: https://nunezserver.com/nunezscheduler
  * Description: Schedule AI-generated posts using advanced features & scheduling options.
- * Version: 2.2.0
+ * Version: 2.3.0
  * Author: Raymond Nunez
  * Author URI: https://nunezserver.com
  * License: GPL v2 or later
@@ -19,7 +19,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('AIPS_VERSION', '2.2.0');
+define('AIPS_VERSION', '2.3.0');
 define('AIPS_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('AIPS_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('AIPS_PLUGIN_BASENAME', plugin_basename(__FILE__));
@@ -311,6 +311,9 @@ final class AI_Post_Scheduler {
             new AIPS_Planner();
             new AIPS_Schedule_Controller();
             new AIPS_Generated_Posts_Controller();
+            // Initialize Review Workflow controller globally to avoid duplicate AJAX registration.
+            global $aips_review_workflow_controller;
+            $aips_review_workflow_controller = new AIPS_Review_Workflow_Controller();
             new AIPS_Research_Controller();
             new AIPS_Seeder_Admin();
             new AIPS_Data_Management();
@@ -357,6 +360,9 @@ final class AI_Post_Scheduler {
 
         // Admin toolbar (visible on both admin and frontend for users with manage_options)
         new AIPS_Admin_Bar();
+
+        // Review workflow hooks run in all contexts (cron + admin + frontend).
+        new AIPS_Review_Workflow_Service();
     }
 }
 

--- a/ai-post-scheduler/assets/css/admin-review-workflow.css
+++ b/ai-post-scheduler/assets/css/admin-review-workflow.css
@@ -1,0 +1,131 @@
+.aips-rw-stats {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin-top: 10px;
+}
+
+.aips-rw-overdue {
+	color: #b32d2e;
+	font-weight: 600;
+}
+
+.aips-rw-drawer {
+	position: fixed;
+	top: 32px;
+	right: 0;
+	width: 520px;
+	max-width: 92vw;
+	height: calc(100vh - 32px);
+	background: #fff;
+	border-left: 1px solid #dcdcde;
+	box-shadow: -8px 0 24px rgba(0, 0, 0, 0.08);
+	z-index: 100000;
+	transform: translateX(100%);
+	transition: transform 160ms ease;
+	display: flex;
+	flex-direction: column;
+}
+
+.aips-rw-drawer.is-open {
+	transform: translateX(0);
+}
+
+.aips-rw-drawer-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 10px;
+	padding: 12px 14px;
+	border-bottom: 1px solid #dcdcde;
+}
+
+.aips-rw-drawer-title {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	min-width: 0;
+}
+
+#aips-rw-drawer-post-title {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.aips-rw-drawer-body {
+	overflow: auto;
+	padding: 12px 14px 20px;
+}
+
+.aips-rw-section {
+	margin-bottom: 18px;
+}
+
+.aips-rw-section h3 {
+	margin: 0 0 8px 0;
+}
+
+.aips-rw-controls {
+	display: grid;
+	grid-template-columns: 120px 1fr;
+	gap: 8px 10px;
+	align-items: center;
+	margin-bottom: 10px;
+}
+
+.aips-rw-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin: 10px 0;
+}
+
+.aips-rw-preview img {
+	max-width: 100%;
+	height: auto;
+	border-radius: 4px;
+}
+
+.aips-rw-stage-notes textarea,
+.aips-rw-section textarea {
+	width: 100%;
+}
+
+.aips-rw-notes-actions {
+	margin-top: 8px;
+	display: flex;
+	gap: 8px;
+}
+
+.aips-rw-checklist h4 {
+	margin: 0 0 8px 0;
+}
+
+.aips-rw-checklist-item {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin: 6px 0;
+}
+
+.aips-rw-comments {
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+	padding: 10px;
+	background: #f6f7f7;
+	max-height: 220px;
+	overflow: auto;
+	margin-bottom: 10px;
+}
+
+.aips-rw-comment {
+	margin-bottom: 10px;
+}
+
+.aips-rw-comment-meta {
+	font-size: 12px;
+	color: #646970;
+	margin-bottom: 2px;
+}
+

--- a/ai-post-scheduler/assets/js/admin-review-workflow.js
+++ b/ai-post-scheduler/assets/js/admin-review-workflow.js
@@ -1,0 +1,400 @@
+(function($) {
+	'use strict';
+
+	var state = {
+		currentItemId: 0,
+		currentStageKey: '',
+		item: null,
+		stageData: {},
+		stages: (window.aipsReviewWorkflowL10n && window.aipsReviewWorkflowL10n.stages) ? window.aipsReviewWorkflowL10n.stages : {}
+	};
+
+	function ajax(data, onSuccess, onError) {
+		$.ajax({
+			url: aipsReviewWorkflowL10n.ajaxUrl,
+			type: 'POST',
+			data: $.extend({
+				nonce: aipsReviewWorkflowL10n.nonce
+			}, data),
+			success: function(resp) {
+				if (resp && resp.success) {
+					onSuccess && onSuccess(resp.data);
+				} else {
+					onError && onError(resp && resp.data ? resp.data : { message: aipsReviewWorkflowL10n.errorTryAgain });
+				}
+			},
+			error: function() {
+				onError && onError({ message: aipsReviewWorkflowL10n.errorTryAgain });
+			}
+		});
+	}
+
+	function openDrawer() {
+		$('#aips-rw-drawer').addClass('is-open').attr('aria-hidden', 'false');
+	}
+
+	function closeDrawer() {
+		$('#aips-rw-drawer').removeClass('is-open').attr('aria-hidden', 'true');
+		state.currentItemId = 0;
+		state.currentStageKey = '';
+	}
+
+	function setLoading() {
+		$('#aips-rw-drawer-post-title').text(aipsReviewWorkflowL10n.loading || 'Loading...');
+		$('#aips-rw-preview').html('');
+		$('#aips-rw-comments').html('');
+		$('#aips-rw-checklist-items').html('');
+		$('#aips-rw-notes').val('');
+		$('#aips-rw-schedule-section').hide();
+	}
+
+	function renderStageSelect(currentKey) {
+		var $sel = $('#aips-rw-stage-select');
+		$sel.empty();
+		Object.keys(state.stages).forEach(function(k) {
+			var label = state.stages[k].label || k;
+			$sel.append($('<option>').attr('value', k).text(label));
+		});
+		$sel.val(currentKey);
+	}
+
+	function renderChecklist(stageKey) {
+		var $wrap = $('#aips-rw-checklist-items');
+		$wrap.empty();
+
+		var def = state.stages[stageKey];
+		var list = def && def.checklist ? def.checklist : [];
+		var stageState = state.stageData[stageKey] ? state.stageData[stageKey].checklist_state : {};
+
+		if (!list.length) {
+			$wrap.append($('<div>').text('—'));
+			return;
+		}
+
+		list.forEach(function(item) {
+			var checked = !!(stageState && stageState[item.key]);
+			var $row = $('<label class="aips-rw-checklist-item">');
+			var $cb = $('<input type="checkbox" class="aips-rw-check">')
+				.attr('data-check-key', item.key)
+				.prop('checked', checked);
+			$row.append($cb).append($('<span>').text(item.label || item.key));
+			$wrap.append($row);
+		});
+	}
+
+	function renderComments(comments) {
+		var $wrap = $('#aips-rw-comments');
+		$wrap.empty();
+
+		if (!comments || !comments.length) {
+			$wrap.append($('<div>').text('—'));
+			return;
+		}
+
+		comments.forEach(function(c) {
+			var who = c.user_label ? c.user_label : ('User #' + (c.user_id || ''));
+			var when = c.created_at || '';
+			var $c = $('<div class="aips-rw-comment">');
+			$c.append($('<div class="aips-rw-comment-meta">').text(who + (when ? (' • ' + when) : '')));
+			$c.append($('<div class="aips-rw-comment-body">').text(c.comment || ''));
+			$wrap.append($c);
+		});
+	}
+
+	function renderPreview(preview) {
+		var html = '';
+		if (preview.featured_image) {
+			html += '<p><img src="' + String(preview.featured_image).replace(/"/g, '&quot;') + '" alt="" /></p>';
+		}
+		html += '<h2>' + $('<div>').text(preview.title || '').html() + '</h2>';
+		if (preview.excerpt) {
+			html += '<p><em>' + $('<div>').text(preview.excerpt).html() + '</em></p>';
+		}
+		if (preview.content) {
+			html += '<div class="aips-rw-preview-content">' + preview.content + '</div>';
+		}
+		if (preview.edit_url) {
+			html += '<p><a class="aips-btn aips-btn-sm aips-btn-secondary" href="' + String(preview.edit_url).replace(/"/g, '&quot;') + '" target="_blank">Edit Post</a></p>';
+		}
+		$('#aips-rw-preview').html(html);
+	}
+
+	function applyItemToUI(data) {
+		state.item = data.item;
+		state.stageData = data.stage_data || {};
+		state.currentItemId = data.item.id;
+		state.currentStageKey = data.item.stage;
+
+		$('#aips-rw-drawer-post-title').text(data.item.post_title || '');
+		$('#aips-rw-drawer-stage-badge').text(state.stages[state.currentStageKey] ? state.stages[state.currentStageKey].label : state.currentStageKey);
+
+		renderStageSelect(state.currentStageKey);
+
+		$('#aips-rw-assignee-select').val(data.item.assigned_to ? String(data.item.assigned_to) : '');
+		$('#aips-rw-priority-select').val(data.item.priority || 'normal');
+
+		if (data.item.due_at) {
+			$('#aips-rw-due-input').val(String(data.item.due_at).replace(' ', 'T').slice(0, 16));
+		} else {
+			$('#aips-rw-due-input').val('');
+		}
+
+		var stageNotes = state.stageData[state.currentStageKey] ? (state.stageData[state.currentStageKey].notes || '') : '';
+		$('#aips-rw-notes').val(stageNotes);
+
+		renderChecklist(state.currentStageKey);
+		renderComments(data.comments || []);
+		renderPreview(data.preview || {});
+
+		if (state.currentStageKey === 'ready' && data.item.closed_state === 'open') {
+			$('#aips-rw-schedule-section').show();
+		} else {
+			$('#aips-rw-schedule-section').hide();
+		}
+	}
+
+	function loadItem(reviewItemId, postId) {
+		openDrawer();
+		setLoading();
+
+		var payload = {
+			action: 'aips_review_workflow_get_item'
+		};
+		if (reviewItemId) {
+			payload.review_item_id = reviewItemId;
+		}
+		if (postId) {
+			payload.post_id = postId;
+		}
+
+		ajax(payload, function(data) {
+			applyItemToUI(data);
+		}, function(err) {
+			AIPS.Utilities.showToast((err && err.message) ? err.message : aipsReviewWorkflowL10n.errorTryAgain, 'error');
+			closeDrawer();
+		});
+	}
+
+	function refreshRow(reviewItemId) {
+		var $row = $('tr[data-review-item-id="' + reviewItemId + '"]');
+		if (!$row.length) return;
+
+		ajax({ action: 'aips_review_workflow_get_item', review_item_id: reviewItemId }, function(data) {
+			var stageLabel = state.stages[data.item.stage] ? state.stages[data.item.stage].label : data.item.stage;
+			$row.find('td').eq(1).find('.aips-badge').first().text(stageLabel);
+			if (data.item.closed_state !== 'open') {
+				$row.fadeOut(200, function() { $(this).remove(); });
+			}
+		});
+	}
+
+	function updateMeta() {
+		if (!state.currentItemId) return;
+
+		var assignee = $('#aips-rw-assignee-select').val();
+		var priority = $('#aips-rw-priority-select').val();
+		var due = $('#aips-rw-due-input').val();
+
+		ajax({
+			action: 'aips_review_workflow_update_item_meta',
+			review_item_id: state.currentItemId,
+			assigned_to: assignee ? parseInt(assignee, 10) : 0,
+			priority: priority,
+			due_at: due ? due.replace('T', ' ') + ':00' : ''
+		}, function() {
+			refreshRow(state.currentItemId);
+		});
+	}
+
+	$(document).ready(function() {
+		$(document).on('click', '.aips-rw-open', function() {
+			var $tr = $(this).closest('tr');
+			var id = parseInt($tr.data('review-item-id'), 10);
+			loadItem(id, 0);
+		});
+
+		$(document).on('click', '.aips-rw-close', function() {
+			closeDrawer();
+		});
+
+		$('#aips-rw-stage-select').on('change', function() {
+			if (!state.currentItemId) return;
+			var stageKey = $(this).val();
+			ajax({
+				action: 'aips_review_workflow_set_stage',
+				review_item_id: state.currentItemId,
+				stage_key: stageKey
+			}, function() {
+				loadItem(state.currentItemId, 0);
+				refreshRow(state.currentItemId);
+			}, function(err) {
+				AIPS.Utilities.showToast(err.message || aipsReviewWorkflowL10n.errorTryAgain, 'error');
+			});
+		});
+
+		$('#aips-rw-assignee-select, #aips-rw-priority-select, #aips-rw-due-input').on('change', function() {
+			updateMeta();
+		});
+
+		$(document).on('change', '.aips-rw-check', function() {
+			if (!state.currentItemId) return;
+			var key = $(this).data('check-key');
+			var checked = $(this).is(':checked') ? 1 : 0;
+			ajax({
+				action: 'aips_review_workflow_toggle_checklist',
+				review_item_id: state.currentItemId,
+				stage_key: state.currentStageKey,
+				check_key: key,
+				checked: checked
+			}, function(data) {
+				if (!state.stageData[state.currentStageKey]) state.stageData[state.currentStageKey] = {};
+				state.stageData[state.currentStageKey].checklist_state = data.checklist_state || {};
+			});
+		});
+
+		function stageAction(actionName, force) {
+			if (!state.currentItemId) return;
+			var notes = $('#aips-rw-notes').val();
+
+			ajax({
+				action: actionName,
+				review_item_id: state.currentItemId,
+				stage_key: state.currentStageKey,
+				notes: notes,
+				force: force ? 1 : 0
+			}, function() {
+				AIPS.Utilities.showToast('Saved', 'success');
+				loadItem(state.currentItemId, 0);
+				refreshRow(state.currentItemId);
+			}, function(err) {
+				if (err && err.code === 'checklist_incomplete') {
+					AIPS.Utilities.confirm(aipsReviewWorkflowL10n.confirmApproveIncomplete, 'Notice', [
+						{ label: 'Cancel', className: 'aips-btn aips-btn-primary' },
+						{ label: 'Approve anyway', className: 'aips-btn aips-btn-danger-solid', action: function() {
+							stageAction(actionName, true);
+						}}
+					]);
+					return;
+				}
+				AIPS.Utilities.showToast(err.message || aipsReviewWorkflowL10n.errorTryAgain, 'error');
+			});
+		}
+
+		$(document).on('click', '.aips-rw-approve', function() {
+			stageAction('aips_review_workflow_approve_stage', false);
+		});
+
+		$(document).on('click', '.aips-rw-request-changes', function() {
+			stageAction('aips_review_workflow_request_changes', false);
+		});
+
+		$(document).on('click', '.aips-rw-skip', function() {
+			stageAction('aips_review_workflow_skip_stage', true);
+		});
+
+		$(document).on('click', '.aips-rw-save-notes', function() {
+			if (!state.currentItemId) return;
+			var notes = $('#aips-rw-notes').val();
+			ajax({
+				action: 'aips_review_workflow_save_stage_notes',
+				review_item_id: state.currentItemId,
+				stage_key: state.currentStageKey,
+				notes: notes
+			}, function() {
+				AIPS.Utilities.showToast('Saved', 'success');
+			}, function(err) {
+				AIPS.Utilities.showToast(err.message || aipsReviewWorkflowL10n.errorTryAgain, 'error');
+			});
+		});
+
+		$(document).on('click', '.aips-rw-add-comment', function() {
+			if (!state.currentItemId) return;
+			var comment = $('#aips-rw-new-comment').val();
+			if (!comment) return;
+			ajax({
+				action: 'aips_review_workflow_add_comment',
+				review_item_id: state.currentItemId,
+				comment: comment
+			}, function() {
+				$('#aips-rw-new-comment').val('');
+				loadItem(state.currentItemId, 0);
+			}, function(err) {
+				AIPS.Utilities.showToast(err.message || aipsReviewWorkflowL10n.errorTryAgain, 'error');
+			});
+		});
+
+		$(document).on('click', '.aips-rw-publish-now', function() {
+			if (!state.currentItemId) return;
+			AIPS.Utilities.confirm(aipsReviewWorkflowL10n.confirmPublish, 'Notice', [
+				{ label: 'Cancel', className: 'aips-btn aips-btn-primary' },
+				{ label: 'Publish now', className: 'aips-btn aips-btn-danger-solid', action: function() {
+					ajax({
+						action: 'aips_review_workflow_publish_now',
+						review_item_id: state.currentItemId
+					}, function(data) {
+						AIPS.Utilities.showToast(data.message || 'Published', 'success');
+						refreshRow(state.currentItemId);
+						closeDrawer();
+					}, function(err) {
+						AIPS.Utilities.showToast(err.message || aipsReviewWorkflowL10n.errorTryAgain, 'error');
+					});
+				}}
+			]);
+		});
+
+		$(document).on('click', '.aips-rw-schedule', function() {
+			if (!state.currentItemId) return;
+			var at = $('#aips-rw-schedule-at').val();
+			if (!at) {
+				AIPS.Utilities.showToast('Select a date/time first.', 'warning');
+				return;
+			}
+			AIPS.Utilities.confirm(aipsReviewWorkflowL10n.confirmSchedule, 'Notice', [
+				{ label: 'Cancel', className: 'aips-btn aips-btn-primary' },
+				{ label: 'Schedule', className: 'aips-btn aips-btn-danger-solid', action: function() {
+					ajax({
+						action: 'aips_review_workflow_schedule',
+						review_item_id: state.currentItemId,
+						schedule_at: at
+					}, function(data) {
+						AIPS.Utilities.showToast(data.message || 'Scheduled', 'success');
+						refreshRow(state.currentItemId);
+						closeDrawer();
+					}, function(err) {
+						AIPS.Utilities.showToast(err.message || aipsReviewWorkflowL10n.errorTryAgain, 'error');
+					});
+				}}
+			]);
+		});
+
+		$(document).on('click', '.aips-rw-archive', function() {
+			if (!state.currentItemId) return;
+			AIPS.Utilities.confirm(aipsReviewWorkflowL10n.confirmArchive, 'Notice', [
+				{ label: 'Cancel', className: 'aips-btn aips-btn-primary' },
+				{ label: 'Archive', className: 'aips-btn aips-btn-danger-solid', action: function() {
+					ajax({
+						action: 'aips_review_workflow_archive',
+						review_item_id: state.currentItemId
+					}, function(data) {
+						AIPS.Utilities.showToast(data.message || 'Archived', 'success');
+						refreshRow(state.currentItemId);
+						closeDrawer();
+					}, function(err) {
+						AIPS.Utilities.showToast(err.message || aipsReviewWorkflowL10n.errorTryAgain, 'error');
+					});
+				}}
+			]);
+		});
+
+		// Deep-link auto open.
+		var params = new URLSearchParams(window.location.search || '');
+		if (params.get('page') === 'aips-review-workflow' && params.get('post_id')) {
+			var postId = parseInt(params.get('post_id'), 10);
+			if (postId) {
+				loadItem(0, postId);
+			}
+		}
+	});
+
+})(jQuery);
+

--- a/ai-post-scheduler/includes/class-aips-admin-assets.php
+++ b/ai-post-scheduler/includes/class-aips-admin-assets.php
@@ -578,6 +578,39 @@ class AIPS_Admin_Assets {
             ));
         }
 
+        // Review Workflow Page Scripts
+        if (strpos($hook, 'aips-review-workflow') !== false) {
+            wp_enqueue_style(
+                'aips-admin-review-workflow',
+                AIPS_PLUGIN_URL . 'assets/css/admin-review-workflow.css',
+                array('aips-admin-style'),
+                AIPS_VERSION
+            );
+
+            wp_enqueue_script(
+                'aips-admin-review-workflow',
+                AIPS_PLUGIN_URL . 'assets/js/admin-review-workflow.js',
+                array('jquery', 'aips-admin-script', 'aips-utilities-script'),
+                AIPS_VERSION,
+                true
+            );
+
+            // Provide stage definitions and UI strings.
+            $defs = AIPS_Review_Workflow_Controller::get_stage_definitions();
+
+            wp_localize_script('aips-admin-review-workflow', 'aipsReviewWorkflowL10n', array(
+                'ajaxUrl' => admin_url('admin-ajax.php'),
+                'nonce'   => wp_create_nonce('aips_ajax_nonce'),
+                'stages'  => $defs,
+                'confirmApproveIncomplete' => __('Checklist is incomplete. Approve anyway?', 'ai-post-scheduler'),
+                'confirmPublish' => __('Publish this post now?', 'ai-post-scheduler'),
+                'confirmSchedule' => __('Schedule this post for the selected time?', 'ai-post-scheduler'),
+                'confirmArchive' => __('Archive this workflow item? (The WordPress post is unchanged.)', 'ai-post-scheduler'),
+                'loading' => __('Loading...', 'ai-post-scheduler'),
+                'errorTryAgain' => __('An error occurred. Please try again.', 'ai-post-scheduler'),
+            ));
+        }
+
         // Calendar Page Scripts
         if (strpos($hook, 'aips-schedule-calendar') !== false) {
             wp_enqueue_style(

--- a/ai-post-scheduler/includes/class-aips-admin-menu-helper.php
+++ b/ai-post-scheduler/includes/class-aips-admin-menu-helper.php
@@ -30,6 +30,7 @@ class AIPS_Admin_Menu_Helper {
 		'authors'              => 'aips-authors',
 		'schedule'             => 'aips-schedule',
 		'generated_posts'      => 'aips-generated-posts',
+		'review_workflow'      => 'aips-review-workflow',
 		'author_topics'        => 'aips-author-topics',
 		'system_status'        => 'aips-status',
 		'settings'             => 'aips-settings',

--- a/ai-post-scheduler/includes/class-aips-admin-menu.php
+++ b/ai-post-scheduler/includes/class-aips-admin-menu.php
@@ -140,6 +140,15 @@ class AIPS_Admin_Menu {
 
         add_submenu_page(
             'ai-post-scheduler',
+            __('Review Workflow', 'ai-post-scheduler'),
+            __('Review Workflow', 'ai-post-scheduler'),
+            'manage_options',
+            'aips-review-workflow',
+            array($this, 'render_review_workflow_page')
+        );
+
+        add_submenu_page(
+            'ai-post-scheduler',
             __('History', 'ai-post-scheduler'),
             __('History', 'ai-post-scheduler'),
             'manage_options',
@@ -338,6 +347,17 @@ class AIPS_Admin_Menu {
      */
     public function render_generated_posts_page() {
         $controller = new AIPS_Generated_Posts_Controller();
+        $controller->render_page();
+    }
+
+    /**
+     * Render the Review Workflow page.
+     *
+     * @return void
+     */
+    public function render_review_workflow_page() {
+        global $aips_review_workflow_controller;
+        $controller = isset($aips_review_workflow_controller) ? $aips_review_workflow_controller : new AIPS_Review_Workflow_Controller();
         $controller->render_page();
     }
 

--- a/ai-post-scheduler/includes/class-aips-db-manager.php
+++ b/ai-post-scheduler/includes/class-aips-db-manager.php
@@ -19,6 +19,9 @@ class AIPS_DB_Manager {
         'aips_author_topic_logs',
         'aips_topic_feedback',
         'aips_notifications',
+        'aips_post_review_items',
+        'aips_post_review_stage_data',
+        'aips_post_review_comments',
         'aips_sources',
         'aips_source_group_terms',
         'aips_taxonomy',
@@ -68,6 +71,9 @@ class AIPS_DB_Manager {
         $table_author_topic_logs = $tables['aips_author_topic_logs'];
         $table_topic_feedback = $tables['aips_topic_feedback'];
         $table_notifications        = $tables['aips_notifications'];
+        $table_post_review_items    = $tables['aips_post_review_items'];
+        $table_post_review_stage    = $tables['aips_post_review_stage_data'];
+        $table_post_review_comments = $tables['aips_post_review_comments'];
         $table_sources              = $tables['aips_sources'];
         $table_source_group_terms   = $tables['aips_source_group_terms'];
         $table_taxonomy             = $tables['aips_taxonomy'];
@@ -341,6 +347,60 @@ class AIPS_DB_Manager {
             KEY level (level),
             KEY dedupe_key (dedupe_key),
             KEY is_read (is_read),
+            KEY created_at (created_at)
+        ) $charset_collate;";
+
+        $sql[] = "CREATE TABLE $table_post_review_items (
+            id bigint(20) NOT NULL AUTO_INCREMENT,
+            post_id bigint(20) NOT NULL,
+            history_id bigint(20) DEFAULT NULL,
+            template_id bigint(20) DEFAULT NULL,
+            author_id bigint(20) DEFAULT NULL,
+            topic_id bigint(20) DEFAULT NULL,
+            stage varchar(50) NOT NULL DEFAULT 'brief',
+            stage_state varchar(50) NOT NULL DEFAULT 'pending',
+            assigned_to bigint(20) DEFAULT NULL,
+            priority varchar(20) NOT NULL DEFAULT 'normal',
+            due_at datetime DEFAULT NULL,
+            closed_state varchar(20) NOT NULL DEFAULT 'open',
+            created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            PRIMARY KEY  (id),
+            UNIQUE KEY post_id (post_id),
+            KEY history_id (history_id),
+            KEY stage (stage),
+            KEY assigned_to (assigned_to),
+            KEY due_at (due_at),
+            KEY closed_state (closed_state),
+            KEY updated_at (updated_at)
+        ) $charset_collate;";
+
+        $sql[] = "CREATE TABLE $table_post_review_stage (
+            id bigint(20) NOT NULL AUTO_INCREMENT,
+            review_item_id bigint(20) NOT NULL,
+            stage_key varchar(50) NOT NULL,
+            state varchar(50) NOT NULL DEFAULT 'pending',
+            checklist_state longtext,
+            notes text DEFAULT NULL,
+            reviewed_by bigint(20) DEFAULT NULL,
+            reviewed_at datetime DEFAULT NULL,
+            updated_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            PRIMARY KEY  (id),
+            UNIQUE KEY review_item_stage (review_item_id, stage_key),
+            KEY review_item_id (review_item_id),
+            KEY stage_key (stage_key),
+            KEY state (state),
+            KEY updated_at (updated_at)
+        ) $charset_collate;";
+
+        $sql[] = "CREATE TABLE $table_post_review_comments (
+            id bigint(20) NOT NULL AUTO_INCREMENT,
+            review_item_id bigint(20) NOT NULL,
+            user_id bigint(20) DEFAULT NULL,
+            comment text NOT NULL,
+            created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY  (id),
+            KEY review_item_id (review_item_id),
             KEY created_at (created_at)
         ) $charset_collate;";
 

--- a/ai-post-scheduler/includes/class-aips-notifications.php
+++ b/ai-post-scheduler/includes/class-aips-notifications.php
@@ -584,7 +584,9 @@ class AIPS_Notifications {
 
 		$title = sprintf(__('Post ready for review: %s', 'ai-post-scheduler'), $post_title);
 		$message = sprintf(__('Generated post "%s" is awaiting review.', 'ai-post-scheduler'), $post_title);
-		$url = $post_id ? esc_url_raw(get_edit_post_link($post_id, 'raw')) : AIPS_Admin_Menu_Helper::get_page_url('generated_posts');
+		$url = $post_id
+			? AIPS_Admin_Menu_Helper::get_page_url('review_workflow', array('post_id' => $post_id))
+			: AIPS_Admin_Menu_Helper::get_page_url('review_workflow');
 
 		$this->dispatch_notification('post_ready_for_review', array(
 			'title'         => $title,

--- a/ai-post-scheduler/includes/class-aips-review-workflow-controller.php
+++ b/ai-post-scheduler/includes/class-aips-review-workflow-controller.php
@@ -1,0 +1,522 @@
+<?php
+/**
+ * Review Workflow Controller
+ *
+ * Admin UI + AJAX endpoints for the multi-stage post review workflow.
+ *
+ * @package AI_Post_Scheduler
+ * @since 2.3.0
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+class AIPS_Review_Workflow_Controller {
+
+	/**
+	 * @var AIPS_Review_Workflow_Repository
+	 */
+	private $repository;
+
+	public function __construct($repository = null) {
+		$this->repository = $repository instanceof AIPS_Review_Workflow_Repository ? $repository : new AIPS_Review_Workflow_Repository();
+
+		add_action('wp_ajax_aips_review_workflow_get_item', array($this, 'ajax_get_item'));
+		add_action('wp_ajax_aips_review_workflow_update_item_meta', array($this, 'ajax_update_item_meta'));
+		add_action('wp_ajax_aips_review_workflow_set_stage', array($this, 'ajax_set_stage'));
+		add_action('wp_ajax_aips_review_workflow_approve_stage', array($this, 'ajax_approve_stage'));
+		add_action('wp_ajax_aips_review_workflow_request_changes', array($this, 'ajax_request_changes'));
+		add_action('wp_ajax_aips_review_workflow_skip_stage', array($this, 'ajax_skip_stage'));
+		add_action('wp_ajax_aips_review_workflow_toggle_checklist', array($this, 'ajax_toggle_checklist'));
+		add_action('wp_ajax_aips_review_workflow_save_stage_notes', array($this, 'ajax_save_stage_notes'));
+		add_action('wp_ajax_aips_review_workflow_add_comment', array($this, 'ajax_add_comment'));
+		add_action('wp_ajax_aips_review_workflow_publish_now', array($this, 'ajax_publish_now'));
+		add_action('wp_ajax_aips_review_workflow_schedule', array($this, 'ajax_schedule'));
+		add_action('wp_ajax_aips_review_workflow_archive', array($this, 'ajax_archive'));
+	}
+
+	/**
+	 * Render the Review Workflow admin page.
+	 *
+	 * @return void
+	 */
+	public function render_page() {
+		if (!current_user_can('manage_options')) {
+			wp_die(esc_html__('Permission denied.', 'ai-post-scheduler'));
+		}
+
+		$stage       = isset($_GET['stage']) ? sanitize_key(wp_unslash($_GET['stage'])) : '';
+		$closed      = isset($_GET['closed_state']) ? sanitize_key(wp_unslash($_GET['closed_state'])) : 'open';
+		$assigned_to = isset($_GET['assigned_to']) ? absint($_GET['assigned_to']) : 0;
+		$template_id = isset($_GET['template_id']) ? absint($_GET['template_id']) : 0;
+		$search      = isset($_GET['s']) ? sanitize_text_field(wp_unslash($_GET['s'])) : '';
+		$page        = isset($_GET['paged']) ? absint($_GET['paged']) : 1;
+
+		if (!in_array($stage, AIPS_Review_Workflow_Repository::get_stages(), true)) {
+			$stage = '';
+		}
+
+		if (!in_array($closed, array('open','scheduled','published','archived'), true)) {
+			$closed = 'open';
+		}
+
+		$items = $this->repository->get_items(array(
+			'page'         => $page,
+			'per_page'     => 20,
+			'stage'        => $stage,
+			'closed_state' => $closed,
+			'assigned_to'  => $assigned_to,
+			'template_id'  => $template_id,
+			'search'       => $search,
+		));
+
+		$template_repository = new AIPS_Template_Repository();
+		$templates           = $template_repository->get_all();
+
+		$users = get_users(array(
+			'fields' => array('ID','display_name'),
+		));
+
+		$counts = $this->repository->get_stage_counts();
+
+		$stages = self::get_stage_definitions();
+
+		include AIPS_PLUGIN_DIR . 'templates/admin/review-workflow.php';
+	}
+
+	/**
+	 * Stage definitions for UI (labels + checklist items).
+	 *
+	 * @return array
+	 */
+	public static function get_stage_definitions() {
+		return array(
+			'brief' => array(
+				'label' => __('Needs Brief Approval', 'ai-post-scheduler'),
+				'checklist' => array(
+					array('key' => 'audience', 'label' => __('Audience is clear', 'ai-post-scheduler')),
+					array('key' => 'angle', 'label' => __('Angle / goal defined', 'ai-post-scheduler')),
+					array('key' => 'cta', 'label' => __('CTA specified', 'ai-post-scheduler')),
+				),
+			),
+			'outline' => array(
+				'label' => __('Needs Outline Approval', 'ai-post-scheduler'),
+				'checklist' => array(
+					array('key' => 'structure', 'label' => __('Outline matches structure', 'ai-post-scheduler')),
+					array('key' => 'coverage', 'label' => __('Key points covered', 'ai-post-scheduler')),
+					array('key' => 'links', 'label' => __('Internal links identified', 'ai-post-scheduler')),
+				),
+			),
+			'fact_check' => array(
+				'label' => __('Needs Fact Check', 'ai-post-scheduler'),
+				'checklist' => array(
+					array('key' => 'claims', 'label' => __('Claims verified', 'ai-post-scheduler')),
+					array('key' => 'numbers', 'label' => __('Stats / numbers verified', 'ai-post-scheduler')),
+					array('key' => 'sources', 'label' => __('Sources reviewed', 'ai-post-scheduler')),
+				),
+			),
+			'seo' => array(
+				'label' => __('Needs SEO Pass', 'ai-post-scheduler'),
+				'checklist' => array(
+					array('key' => 'title', 'label' => __('Title optimized', 'ai-post-scheduler')),
+					array('key' => 'headings', 'label' => __('Headings organized', 'ai-post-scheduler')),
+					array('key' => 'meta', 'label' => __('Excerpt / snippet ready', 'ai-post-scheduler')),
+				),
+			),
+			'ready' => array(
+				'label' => __('Ready to Schedule', 'ai-post-scheduler'),
+				'checklist' => array(
+					array('key' => 'final_read', 'label' => __('Final read-through complete', 'ai-post-scheduler')),
+					array('key' => 'formatting', 'label' => __('Formatting checked', 'ai-post-scheduler')),
+					array('key' => 'image', 'label' => __('Featured image checked', 'ai-post-scheduler')),
+				),
+			),
+		);
+	}
+
+	private function check_ajax() {
+		check_ajax_referer('aips_ajax_nonce', 'nonce');
+
+		if (!current_user_can('manage_options')) {
+			wp_send_json_error(array('message' => __('Permission denied.', 'ai-post-scheduler')));
+		}
+	}
+
+	public function ajax_get_item() {
+		$this->check_ajax();
+
+		$review_item_id = isset($_POST['review_item_id']) ? absint($_POST['review_item_id']) : 0;
+		$post_id        = isset($_POST['post_id']) ? absint($_POST['post_id']) : 0;
+
+		$item = $review_item_id ? $this->repository->get_item_row($review_item_id) : null;
+		if (!$item && $post_id) {
+			$by_post = $this->repository->get_item_row_by_post_id($post_id);
+			$item    = $by_post ? $this->repository->get_item_row((int) $by_post->id) : null;
+		}
+
+		if (!$item) {
+			wp_send_json_error(array('message' => __('Item not found.', 'ai-post-scheduler')));
+		}
+
+		$this->repository->sync_closed_state_from_post_status((int) $item->post_id);
+
+		$stage_rows = $this->repository->get_stage_rows((int) $item->id);
+		$comments   = $this->repository->get_comments((int) $item->id);
+		$stages     = self::get_stage_definitions();
+
+		$preview = array(
+			'title'          => get_the_title((int) $item->post_id),
+			'content'        => apply_filters('the_content', (string) $item->post_content),
+			'excerpt'        => get_the_excerpt((int) $item->post_id),
+			'featured_image' => esc_url_raw(get_the_post_thumbnail_url((int) $item->post_id, 'full')),
+			'edit_url'       => esc_url_raw(get_edit_post_link((int) $item->post_id)),
+		);
+
+		$stage_payload = array();
+		foreach (AIPS_Review_Workflow_Repository::get_stages() as $stage_key) {
+			$row = isset($stage_rows[$stage_key]) ? $stage_rows[$stage_key] : null;
+			$check_state = array();
+			if ($row && !empty($row->checklist_state)) {
+				$tmp = json_decode((string) $row->checklist_state, true);
+				if (is_array($tmp)) {
+					$check_state = $tmp;
+				}
+			}
+			$stage_payload[$stage_key] = array(
+				'state'          => $row ? (string) $row->state : 'pending',
+				'notes'          => $row ? (string) $row->notes : '',
+				'checklist_state'=> $check_state,
+				'reviewed_by'    => $row ? (int) $row->reviewed_by : 0,
+				'reviewed_at'    => $row ? (string) $row->reviewed_at : '',
+			);
+		}
+
+		$comment_payload = array();
+		foreach ($comments as $c) {
+			$user_label = '';
+			if (!empty($c->user_id)) {
+				$u = get_userdata((int) $c->user_id);
+				$user_label = $u ? $u->display_name : '';
+			}
+			$comment_payload[] = array(
+				'id'         => (int) $c->id,
+				'user_id'    => (int) $c->user_id,
+				'user_label' => $user_label,
+				'comment'    => (string) $c->comment,
+				'created_at' => (string) $c->created_at,
+			);
+		}
+
+		wp_send_json_success(array(
+			'item' => array(
+				'id'           => (int) $item->id,
+				'post_id'      => (int) $item->post_id,
+				'post_title'   => (string) $item->post_title,
+				'post_status'  => (string) $item->post_status,
+				'template_id'  => (int) $item->template_id,
+				'template_name'=> (string) $item->template_name,
+				'stage'        => (string) $item->stage,
+				'stage_state'  => (string) $item->stage_state,
+				'assigned_to'  => (int) $item->assigned_to,
+				'priority'     => (string) $item->priority,
+				'due_at'       => (string) $item->due_at,
+				'closed_state' => (string) $item->closed_state,
+			),
+			'preview'  => $preview,
+			'stages'   => $stages,
+			'stage_data' => $stage_payload,
+			'comments' => $comment_payload,
+		));
+	}
+
+	public function ajax_update_item_meta() {
+		$this->check_ajax();
+
+		$review_item_id = isset($_POST['review_item_id']) ? absint($_POST['review_item_id']) : 0;
+		if (!$review_item_id) {
+			wp_send_json_error(array('message' => __('Invalid item.', 'ai-post-scheduler')));
+		}
+
+		$assigned_to = isset($_POST['assigned_to']) ? absint($_POST['assigned_to']) : null;
+		$priority    = isset($_POST['priority']) ? sanitize_key(wp_unslash($_POST['priority'])) : null;
+		$due_at      = isset($_POST['due_at']) ? sanitize_text_field(wp_unslash($_POST['due_at'])) : null;
+
+		$fields = array();
+		if (null !== $assigned_to) {
+			$fields['assigned_to'] = $assigned_to;
+		}
+		if (null !== $priority) {
+			$fields['priority'] = $priority;
+		}
+		if (null !== $due_at) {
+			$fields['due_at'] = $due_at;
+		}
+
+		$ok = $this->repository->update_item_meta($review_item_id, $fields);
+		if (!$ok) {
+			wp_send_json_error(array('message' => __('Failed to update item.', 'ai-post-scheduler')));
+		}
+
+		wp_send_json_success(array('message' => __('Updated.', 'ai-post-scheduler')));
+	}
+
+	public function ajax_set_stage() {
+		$this->check_ajax();
+
+		$review_item_id = isset($_POST['review_item_id']) ? absint($_POST['review_item_id']) : 0;
+		$stage_key      = isset($_POST['stage_key']) ? sanitize_key(wp_unslash($_POST['stage_key'])) : '';
+
+		if (!$review_item_id || !$stage_key) {
+			wp_send_json_error(array('message' => __('Invalid request.', 'ai-post-scheduler')));
+		}
+
+		$ok = $this->repository->set_stage($review_item_id, $stage_key);
+		if (!$ok) {
+			wp_send_json_error(array('message' => __('Failed to update stage.', 'ai-post-scheduler')));
+		}
+
+		wp_send_json_success(array('message' => __('Stage updated.', 'ai-post-scheduler')));
+	}
+
+	private function get_missing_checklist_keys($review_item_id, $stage_key) {
+		$review_item_id = absint($review_item_id);
+		$stage_key      = sanitize_key($stage_key);
+
+		$defs = self::get_stage_definitions();
+		if (!isset($defs[$stage_key])) {
+			return array();
+		}
+
+		$rows = $this->repository->get_stage_rows($review_item_id);
+		$row  = isset($rows[$stage_key]) ? $rows[$stage_key] : null;
+
+		$state = array();
+		if ($row && !empty($row->checklist_state)) {
+			$tmp = json_decode((string) $row->checklist_state, true);
+			if (is_array($tmp)) {
+				$state = $tmp;
+			}
+		}
+
+		$missing = array();
+		foreach ($defs[$stage_key]['checklist'] as $check) {
+			$key = $check['key'];
+			if (empty($state[$key])) {
+				$missing[] = $key;
+			}
+		}
+
+		return $missing;
+	}
+
+	public function ajax_approve_stage() {
+		$this->check_ajax();
+
+		$review_item_id = isset($_POST['review_item_id']) ? absint($_POST['review_item_id']) : 0;
+		$stage_key      = isset($_POST['stage_key']) ? sanitize_key(wp_unslash($_POST['stage_key'])) : '';
+		$notes          = isset($_POST['notes']) ? wp_kses_post(wp_unslash($_POST['notes'])) : '';
+		$force          = isset($_POST['force']) ? (bool) absint($_POST['force']) : false;
+
+		if (!$review_item_id || !$stage_key) {
+			wp_send_json_error(array('message' => __('Invalid request.', 'ai-post-scheduler')));
+		}
+
+		$missing = $this->get_missing_checklist_keys($review_item_id, $stage_key);
+		if (!empty($missing) && !$force) {
+			wp_send_json_error(array(
+				'code'    => 'checklist_incomplete',
+				'message' => __('Checklist is incomplete for this stage.', 'ai-post-scheduler'),
+				'missing' => $missing,
+			));
+		}
+
+		$ok = $this->repository->set_stage_state($review_item_id, $stage_key, 'approved', $notes, get_current_user_id(), true);
+		if (!$ok) {
+			wp_send_json_error(array('message' => __('Failed to approve stage.', 'ai-post-scheduler')));
+		}
+
+		wp_send_json_success(array('message' => __('Stage approved.', 'ai-post-scheduler')));
+	}
+
+	public function ajax_request_changes() {
+		$this->check_ajax();
+
+		$review_item_id = isset($_POST['review_item_id']) ? absint($_POST['review_item_id']) : 0;
+		$stage_key      = isset($_POST['stage_key']) ? sanitize_key(wp_unslash($_POST['stage_key'])) : '';
+		$notes          = isset($_POST['notes']) ? wp_kses_post(wp_unslash($_POST['notes'])) : '';
+
+		if (!$review_item_id || !$stage_key) {
+			wp_send_json_error(array('message' => __('Invalid request.', 'ai-post-scheduler')));
+		}
+
+		$ok = $this->repository->set_stage_state($review_item_id, $stage_key, 'changes_requested', $notes, get_current_user_id(), false);
+		if (!$ok) {
+			wp_send_json_error(array('message' => __('Failed to request changes.', 'ai-post-scheduler')));
+		}
+
+		wp_send_json_success(array('message' => __('Changes requested.', 'ai-post-scheduler')));
+	}
+
+	public function ajax_skip_stage() {
+		$this->check_ajax();
+
+		$review_item_id = isset($_POST['review_item_id']) ? absint($_POST['review_item_id']) : 0;
+		$stage_key      = isset($_POST['stage_key']) ? sanitize_key(wp_unslash($_POST['stage_key'])) : '';
+		$notes          = isset($_POST['notes']) ? wp_kses_post(wp_unslash($_POST['notes'])) : '';
+
+		if (!$review_item_id || !$stage_key) {
+			wp_send_json_error(array('message' => __('Invalid request.', 'ai-post-scheduler')));
+		}
+
+		$ok = $this->repository->set_stage_state($review_item_id, $stage_key, 'skipped', $notes, get_current_user_id(), true);
+		if (!$ok) {
+			wp_send_json_error(array('message' => __('Failed to skip stage.', 'ai-post-scheduler')));
+		}
+
+		wp_send_json_success(array('message' => __('Stage skipped.', 'ai-post-scheduler')));
+	}
+
+	public function ajax_toggle_checklist() {
+		$this->check_ajax();
+
+		$review_item_id = isset($_POST['review_item_id']) ? absint($_POST['review_item_id']) : 0;
+		$stage_key      = isset($_POST['stage_key']) ? sanitize_key(wp_unslash($_POST['stage_key'])) : '';
+		$check_key      = isset($_POST['check_key']) ? sanitize_key(wp_unslash($_POST['check_key'])) : '';
+		$checked        = isset($_POST['checked']) ? (bool) absint($_POST['checked']) : false;
+
+		if (!$review_item_id || !$stage_key || !$check_key) {
+			wp_send_json_error(array('message' => __('Invalid request.', 'ai-post-scheduler')));
+		}
+
+		$updated = $this->repository->toggle_checklist_item($review_item_id, $stage_key, $check_key, $checked);
+		wp_send_json_success(array('checklist_state' => $updated));
+	}
+
+	public function ajax_save_stage_notes() {
+		$this->check_ajax();
+
+		$review_item_id = isset($_POST['review_item_id']) ? absint($_POST['review_item_id']) : 0;
+		$stage_key      = isset($_POST['stage_key']) ? sanitize_key(wp_unslash($_POST['stage_key'])) : '';
+		$notes          = isset($_POST['notes']) ? wp_kses_post(wp_unslash($_POST['notes'])) : '';
+
+		if (!$review_item_id || !$stage_key) {
+			wp_send_json_error(array('message' => __('Invalid request.', 'ai-post-scheduler')));
+		}
+
+		$ok = $this->repository->save_stage_notes($review_item_id, $stage_key, $notes);
+		if (!$ok) {
+			wp_send_json_error(array('message' => __('Failed to save notes.', 'ai-post-scheduler')));
+		}
+
+		wp_send_json_success(array('message' => __('Saved.', 'ai-post-scheduler')));
+	}
+
+	public function ajax_add_comment() {
+		$this->check_ajax();
+
+		$review_item_id = isset($_POST['review_item_id']) ? absint($_POST['review_item_id']) : 0;
+		$comment        = isset($_POST['comment']) ? sanitize_textarea_field(wp_unslash($_POST['comment'])) : '';
+
+		if (!$review_item_id || '' === $comment) {
+			wp_send_json_error(array('message' => __('Invalid request.', 'ai-post-scheduler')));
+		}
+
+		$id = $this->repository->add_comment($review_item_id, get_current_user_id(), $comment);
+		if (!$id) {
+			wp_send_json_error(array('message' => __('Failed to add comment.', 'ai-post-scheduler')));
+		}
+
+		wp_send_json_success(array('message' => __('Comment added.', 'ai-post-scheduler')));
+	}
+
+	public function ajax_publish_now() {
+		$this->check_ajax();
+
+		$review_item_id = isset($_POST['review_item_id']) ? absint($_POST['review_item_id']) : 0;
+		if (!$review_item_id) {
+			wp_send_json_error(array('message' => __('Invalid item.', 'ai-post-scheduler')));
+		}
+
+		$item = $this->repository->get_item_row($review_item_id);
+		if (!$item) {
+			wp_send_json_error(array('message' => __('Item not found.', 'ai-post-scheduler')));
+		}
+
+		if (!current_user_can('publish_post', (int) $item->post_id)) {
+			wp_send_json_error(array('message' => __('You do not have permission to publish this post.', 'ai-post-scheduler')));
+		}
+
+		$result = wp_update_post(array(
+			'ID'          => (int) $item->post_id,
+			'post_status' => 'publish',
+		), true);
+
+		if (is_wp_error($result)) {
+			wp_send_json_error(array('message' => $result->get_error_message()));
+		}
+
+		$this->repository->close_item($review_item_id, 'published');
+
+		wp_send_json_success(array('message' => __('Post published.', 'ai-post-scheduler')));
+	}
+
+	public function ajax_schedule() {
+		$this->check_ajax();
+
+		$review_item_id = isset($_POST['review_item_id']) ? absint($_POST['review_item_id']) : 0;
+		$schedule_at    = isset($_POST['schedule_at']) ? sanitize_text_field(wp_unslash($_POST['schedule_at'])) : '';
+
+		if (!$review_item_id || '' === $schedule_at) {
+			wp_send_json_error(array('message' => __('Invalid request.', 'ai-post-scheduler')));
+		}
+
+		$item = $this->repository->get_item_row($review_item_id);
+		if (!$item) {
+			wp_send_json_error(array('message' => __('Item not found.', 'ai-post-scheduler')));
+		}
+
+		$schedule_at = str_replace('T', ' ', $schedule_at);
+
+		try {
+			$tz = wp_timezone();
+			$dt = new DateTimeImmutable($schedule_at, $tz);
+		} catch (Exception $e) {
+			wp_send_json_error(array('message' => __('Invalid date/time.', 'ai-post-scheduler')));
+		}
+
+		$local = $dt->format('Y-m-d H:i:s');
+		$gmt   = $dt->setTimezone(new DateTimeZone('UTC'))->format('Y-m-d H:i:s');
+
+		$result = wp_update_post(array(
+			'ID'            => (int) $item->post_id,
+			'post_status'   => 'future',
+			'post_date'     => $local,
+			'post_date_gmt' => $gmt,
+		), true);
+
+		if (is_wp_error($result)) {
+			wp_send_json_error(array('message' => $result->get_error_message()));
+		}
+
+		$this->repository->close_item($review_item_id, 'scheduled');
+
+		wp_send_json_success(array('message' => __('Post scheduled.', 'ai-post-scheduler')));
+	}
+
+	public function ajax_archive() {
+		$this->check_ajax();
+
+		$review_item_id = isset($_POST['review_item_id']) ? absint($_POST['review_item_id']) : 0;
+		if (!$review_item_id) {
+			wp_send_json_error(array('message' => __('Invalid item.', 'ai-post-scheduler')));
+		}
+
+		$ok = $this->repository->close_item($review_item_id, 'archived');
+		if (!$ok) {
+			wp_send_json_error(array('message' => __('Failed to archive.', 'ai-post-scheduler')));
+		}
+
+		wp_send_json_success(array('message' => __('Archived.', 'ai-post-scheduler')));
+	}
+}

--- a/ai-post-scheduler/includes/class-aips-review-workflow-repository.php
+++ b/ai-post-scheduler/includes/class-aips-review-workflow-repository.php
@@ -1,0 +1,798 @@
+<?php
+/**
+ * Review Workflow Repository
+ *
+ * Persists and queries multi-stage review workflow data for generated posts.
+ *
+ * @package AI_Post_Scheduler
+ * @since 2.3.0
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+class AIPS_Review_Workflow_Repository {
+
+	/**
+	 * @var wpdb
+	 */
+	private $wpdb;
+
+	/**
+	 * @var string
+	 */
+	private $items_table;
+
+	/**
+	 * @var string
+	 */
+	private $stage_table;
+
+	/**
+	 * @var string
+	 */
+	private $comments_table;
+
+	public function __construct() {
+		global $wpdb;
+		$this->wpdb           = $wpdb;
+		$this->items_table    = $wpdb->prefix . 'aips_post_review_items';
+		$this->stage_table    = $wpdb->prefix . 'aips_post_review_stage_data';
+		$this->comments_table = $wpdb->prefix . 'aips_post_review_comments';
+	}
+
+	/**
+	 * Fixed v1 workflow stages.
+	 *
+	 * @return string[]
+	 */
+	public static function get_stages() {
+		return array( 'brief', 'outline', 'fact_check', 'seo', 'ready' );
+	}
+
+	/**
+	 * Get a paginated list of review items.
+	 *
+	 * @param array $args Query args.
+	 * @return array{items:array,total:int,pages:int,current_page:int}
+	 */
+	public function get_items($args = array()) {
+		$defaults = array(
+			'per_page'    => 20,
+			'page'        => 1,
+			'stage'       => '',
+			'closed_state'=> 'open',
+			'assigned_to' => 0,
+			'template_id' => 0,
+			'search'      => '',
+			'orderby'     => 'updated_at',
+			'order'       => 'DESC',
+		);
+
+		$args   = wp_parse_args($args, $defaults);
+		$offset = ($args['page'] - 1) * $args['per_page'];
+
+		$where      = array( '1=1' );
+		$where_args = array();
+
+		if (!empty($args['closed_state'])) {
+			$where[]      = 'i.closed_state = %s';
+			$where_args[] = $args['closed_state'];
+		}
+
+		if (!empty($args['stage'])) {
+			$where[]      = 'i.stage = %s';
+			$where_args[] = $args['stage'];
+		}
+
+		if (!empty($args['assigned_to'])) {
+			$where[]      = 'i.assigned_to = %d';
+			$where_args[] = (int) $args['assigned_to'];
+		}
+
+		if (!empty($args['template_id'])) {
+			$where[]      = 'i.template_id = %d';
+			$where_args[] = (int) $args['template_id'];
+		}
+
+		if (!empty($args['search'])) {
+			$like         = '%' . $this->wpdb->esc_like($args['search']) . '%';
+			$where[]      = 'p.post_title LIKE %s';
+			$where_args[] = $like;
+		}
+
+		$where_sql = implode(' AND ', $where);
+
+		$orderby = in_array($args['orderby'], array('updated_at', 'due_at', 'created_at', 'post_title'), true) ? $args['orderby'] : 'updated_at';
+		$order   = strtoupper($args['order']) === 'ASC' ? 'ASC' : 'DESC';
+
+		if ('post_title' === $orderby) {
+			$orderby_sql = "p.post_title $order";
+		} else {
+			$orderby_sql = "i.$orderby $order";
+		}
+
+		$posts_table     = $this->wpdb->posts;
+		$templates_table = $this->wpdb->prefix . 'aips_templates';
+
+		$query_args   = $where_args;
+		$query_args[] = (int) $args['per_page'];
+		$query_args[] = (int) $offset;
+
+		$items = $this->wpdb->get_results($this->wpdb->prepare("
+			SELECT
+				i.*,
+				p.post_title,
+				p.post_status,
+				p.post_modified,
+				t.name AS template_name
+			FROM {$this->items_table} i
+			INNER JOIN {$posts_table} p ON i.post_id = p.ID
+			LEFT JOIN {$templates_table} t ON i.template_id = t.id
+			WHERE {$where_sql}
+			ORDER BY {$orderby_sql}
+			LIMIT %d OFFSET %d
+		", $query_args));
+
+		if (!empty($where_args)) {
+			$total = (int) $this->wpdb->get_var($this->wpdb->prepare("
+				SELECT COUNT(*)
+				FROM {$this->items_table} i
+				INNER JOIN {$posts_table} p ON i.post_id = p.ID
+				WHERE {$where_sql}
+			", $where_args));
+		} else {
+			$total = (int) $this->wpdb->get_var("
+				SELECT COUNT(*)
+				FROM {$this->items_table} i
+				INNER JOIN {$posts_table} p ON i.post_id = p.ID
+				WHERE {$where_sql}
+			");
+		}
+
+		return array(
+			'items'        => is_array($items) ? $items : array(),
+			'total'        => $total,
+			'pages'        => (int) ceil($total / max(1, (int) $args['per_page'])),
+			'current_page' => (int) $args['page'],
+		);
+	}
+
+	/**
+	 * Get stage counts for open items.
+	 *
+	 * @return array<string,int> stage => count plus 'overdue'
+	 */
+	public function get_stage_counts() {
+		$counts = array();
+		foreach (self::get_stages() as $stage) {
+			$counts[$stage] = 0;
+		}
+
+		$rows = $this->wpdb->get_results($this->wpdb->prepare("
+			SELECT stage, COUNT(*) AS cnt
+			FROM {$this->items_table}
+			WHERE closed_state = %s
+			GROUP BY stage
+		", 'open'));
+
+		if (is_array($rows)) {
+			foreach ($rows as $row) {
+				if (!empty($row->stage) && isset($counts[$row->stage])) {
+					$counts[$row->stage] = (int) $row->cnt;
+				}
+			}
+		}
+
+		$overdue = (int) $this->wpdb->get_var($this->wpdb->prepare("
+			SELECT COUNT(*)
+			FROM {$this->items_table}
+			WHERE closed_state = %s
+			AND due_at IS NOT NULL
+			AND due_at < %s
+		", 'open', current_time('mysql')));
+
+		$counts['overdue'] = $overdue;
+
+		return $counts;
+	}
+
+	/**
+	 * Get a single review item by ID.
+	 *
+	 * @param int $review_item_id
+	 * @return object|null
+	 */
+	public function get_item_row($review_item_id) {
+		$review_item_id = absint($review_item_id);
+		if (!$review_item_id) {
+			return null;
+		}
+
+		$posts_table     = $this->wpdb->posts;
+		$templates_table = $this->wpdb->prefix . 'aips_templates';
+
+		return $this->wpdb->get_row($this->wpdb->prepare("
+			SELECT
+				i.*,
+				p.post_title,
+				p.post_content,
+				p.post_excerpt,
+				p.post_status,
+				p.post_modified,
+				t.name AS template_name
+			FROM {$this->items_table} i
+			INNER JOIN {$posts_table} p ON i.post_id = p.ID
+			LEFT JOIN {$templates_table} t ON i.template_id = t.id
+			WHERE i.id = %d
+			LIMIT 1
+		", $review_item_id));
+	}
+
+	/**
+	 * Get a review item by post ID.
+	 *
+	 * @param int $post_id
+	 * @return object|null
+	 */
+	public function get_item_row_by_post_id($post_id) {
+		$post_id = absint($post_id);
+		if (!$post_id) {
+			return null;
+		}
+
+		return $this->wpdb->get_row($this->wpdb->prepare("
+			SELECT *
+			FROM {$this->items_table}
+			WHERE post_id = %d
+			LIMIT 1
+		", $post_id));
+	}
+
+	/**
+	 * Get all stage rows for an item keyed by stage_key.
+	 *
+	 * @param int $review_item_id
+	 * @return array<string,object>
+	 */
+	public function get_stage_rows($review_item_id) {
+		$review_item_id = absint($review_item_id);
+		if (!$review_item_id) {
+			return array();
+		}
+
+		$rows = $this->wpdb->get_results($this->wpdb->prepare("
+			SELECT *
+			FROM {$this->stage_table}
+			WHERE review_item_id = %d
+		", $review_item_id));
+
+		$map = array();
+		if (is_array($rows)) {
+			foreach ($rows as $row) {
+				$map[(string) $row->stage_key] = $row;
+			}
+		}
+
+		return $map;
+	}
+
+	/**
+	 * Get comments for an item.
+	 *
+	 * @param int $review_item_id
+	 * @return array
+	 */
+	public function get_comments($review_item_id) {
+		$review_item_id = absint($review_item_id);
+		if (!$review_item_id) {
+			return array();
+		}
+
+		$rows = $this->wpdb->get_results($this->wpdb->prepare("
+			SELECT *
+			FROM {$this->comments_table}
+			WHERE review_item_id = %d
+			ORDER BY created_at ASC
+		", $review_item_id));
+
+		return is_array($rows) ? $rows : array();
+	}
+
+	/**
+	 * Idempotently create or update a review workflow item for a post.
+	 *
+	 * @param int   $post_id
+	 * @param int   $history_id Optional.
+	 * @param array $context_fields Optional: template_id/author_id/topic_id.
+	 * @return int Review item ID.
+	 */
+	public function get_or_create_item_for_post($post_id, $history_id = 0, $context_fields = array()) {
+		$post_id   = absint($post_id);
+		$history_id = absint($history_id);
+
+		if (!$post_id) {
+			return 0;
+		}
+
+		$existing = $this->get_item_row_by_post_id($post_id);
+
+		$update = array(
+			'history_id'  => $history_id ? $history_id : null,
+			'template_id' => !empty($context_fields['template_id']) ? absint($context_fields['template_id']) : null,
+			'author_id'   => !empty($context_fields['author_id']) ? absint($context_fields['author_id']) : null,
+			'topic_id'    => !empty($context_fields['topic_id']) ? absint($context_fields['topic_id']) : null,
+			'updated_at'  => current_time('mysql'),
+		);
+
+		$update_formats = array('%d', '%d', '%d', '%d', '%s');
+
+		if ($existing) {
+			$this->wpdb->update(
+				$this->items_table,
+				$update,
+				array('id' => (int) $existing->id),
+				$update_formats,
+				array('%d')
+			);
+			$review_item_id = (int) $existing->id;
+		} else {
+			$insert = array(
+				'post_id'      => $post_id,
+				'history_id'   => $history_id ? $history_id : null,
+				'template_id'  => !empty($context_fields['template_id']) ? absint($context_fields['template_id']) : null,
+				'author_id'    => !empty($context_fields['author_id']) ? absint($context_fields['author_id']) : null,
+				'topic_id'     => !empty($context_fields['topic_id']) ? absint($context_fields['topic_id']) : null,
+				'stage'        => 'brief',
+				'stage_state'  => 'pending',
+				'priority'     => 'normal',
+				'closed_state' => 'open',
+				'created_at'   => current_time('mysql'),
+				'updated_at'   => current_time('mysql'),
+			);
+
+			$this->wpdb->insert(
+				$this->items_table,
+				$insert,
+				array('%d','%d','%d','%d','%d','%s','%s','%s','%s','%s','%s')
+			);
+
+			$review_item_id = (int) $this->wpdb->insert_id;
+		}
+
+		if ($review_item_id) {
+			$this->ensure_stage_rows($review_item_id);
+		}
+
+		return $review_item_id;
+	}
+
+	/**
+	 * Ensure stage rows exist for a review item.
+	 *
+	 * @param int $review_item_id
+	 * @return void
+	 */
+	private function ensure_stage_rows($review_item_id) {
+		$review_item_id = absint($review_item_id);
+		if (!$review_item_id) {
+			return;
+		}
+
+		$existing = $this->get_stage_rows($review_item_id);
+
+		foreach (self::get_stages() as $stage_key) {
+			if (isset($existing[$stage_key])) {
+				continue;
+			}
+
+			$this->wpdb->insert(
+				$this->stage_table,
+				array(
+					'review_item_id'  => $review_item_id,
+					'stage_key'       => $stage_key,
+					'state'           => 'pending',
+					'checklist_state' => wp_json_encode(array()),
+					'updated_at'      => current_time('mysql'),
+				),
+				array('%d','%s','%s','%s','%s')
+			);
+		}
+	}
+
+	/**
+	 * Update item meta (assignee/priority/due).
+	 *
+	 * @param int   $review_item_id
+	 * @param array $fields
+	 * @return bool
+	 */
+	public function update_item_meta($review_item_id, $fields) {
+		$review_item_id = absint($review_item_id);
+		if (!$review_item_id) {
+			return false;
+		}
+
+		$allowed = array('assigned_to', 'priority', 'due_at');
+		$data    = array();
+		$formats = array();
+
+		foreach ($allowed as $key) {
+			if (!array_key_exists($key, $fields)) {
+				continue;
+			}
+
+			if ('assigned_to' === $key) {
+				$data[$key] = $fields[$key] ? absint($fields[$key]) : null;
+				$formats[]  = '%d';
+			} elseif ('priority' === $key) {
+				$priority = in_array($fields[$key], array('low','normal','high'), true) ? $fields[$key] : 'normal';
+				$data[$key] = $priority;
+				$formats[]  = '%s';
+			} elseif ('due_at' === $key) {
+				$data[$key] = !empty($fields[$key]) ? $fields[$key] : null;
+				$formats[]  = '%s';
+			}
+		}
+
+		if (empty($data)) {
+			return false;
+		}
+
+		$data['updated_at'] = current_time('mysql');
+		$formats[]          = '%s';
+
+		$result = $this->wpdb->update(
+			$this->items_table,
+			$data,
+			array('id' => $review_item_id),
+			$formats,
+			array('%d')
+		);
+
+		return $result !== false;
+	}
+
+	/**
+	 * Set the current stage for an item.
+	 *
+	 * @param int    $review_item_id
+	 * @param string $stage_key
+	 * @return bool
+	 */
+	public function set_stage($review_item_id, $stage_key) {
+		$review_item_id = absint($review_item_id);
+		$stage_key      = sanitize_key($stage_key);
+
+		if (!$review_item_id || !in_array($stage_key, self::get_stages(), true)) {
+			return false;
+		}
+
+		$stage_rows = $this->get_stage_rows($review_item_id);
+		$state      = isset($stage_rows[$stage_key]) ? (string) $stage_rows[$stage_key]->state : 'pending';
+
+		$result = $this->wpdb->update(
+			$this->items_table,
+			array(
+				'stage'       => $stage_key,
+				'stage_state' => $state,
+				'updated_at'  => current_time('mysql'),
+			),
+			array('id' => $review_item_id),
+			array('%s','%s','%s'),
+			array('%d')
+		);
+
+		return $result !== false;
+	}
+
+	/**
+	 * Save stage notes.
+	 *
+	 * @param int    $review_item_id
+	 * @param string $stage_key
+	 * @param string $notes
+	 * @return bool
+	 */
+	public function save_stage_notes($review_item_id, $stage_key, $notes) {
+		$review_item_id = absint($review_item_id);
+		$stage_key      = sanitize_key($stage_key);
+
+		if (!$review_item_id || !in_array($stage_key, self::get_stages(), true)) {
+			return false;
+		}
+
+		$result = $this->wpdb->update(
+			$this->stage_table,
+			array(
+				'notes'      => $notes,
+				'updated_at' => current_time('mysql'),
+			),
+			array(
+				'review_item_id' => $review_item_id,
+				'stage_key'      => $stage_key,
+			),
+			array('%s','%s'),
+			array('%d','%s')
+		);
+
+		return $result !== false;
+	}
+
+	/**
+	 * Toggle a checklist item.
+	 *
+	 * @param int    $review_item_id
+	 * @param string $stage_key
+	 * @param string $check_key
+	 * @param bool   $checked
+	 * @return array Updated checklist map.
+	 */
+	public function toggle_checklist_item($review_item_id, $stage_key, $check_key, $checked) {
+		$review_item_id = absint($review_item_id);
+		$stage_key      = sanitize_key($stage_key);
+		$check_key      = sanitize_key($check_key);
+		$checked        = (bool) $checked;
+
+		if (!$review_item_id || !in_array($stage_key, self::get_stages(), true) || empty($check_key)) {
+			return array();
+		}
+
+		$row = $this->wpdb->get_row($this->wpdb->prepare("
+			SELECT checklist_state
+			FROM {$this->stage_table}
+			WHERE review_item_id = %d AND stage_key = %s
+			LIMIT 1
+		", $review_item_id, $stage_key));
+
+		$decoded = array();
+		if ($row && !empty($row->checklist_state)) {
+			$tmp = json_decode((string) $row->checklist_state, true);
+			if (is_array($tmp)) {
+				$decoded = $tmp;
+			}
+		}
+
+		$decoded[$check_key] = $checked;
+
+		$this->wpdb->update(
+			$this->stage_table,
+			array(
+				'checklist_state' => wp_json_encode($decoded),
+				'updated_at'      => current_time('mysql'),
+			),
+			array(
+				'review_item_id' => $review_item_id,
+				'stage_key'      => $stage_key,
+			),
+			array('%s','%s'),
+			array('%d','%s')
+		);
+
+		return $decoded;
+	}
+
+	/**
+	 * Update stage state (approve/request changes/skip) and advance when applicable.
+	 *
+	 * @param int    $review_item_id
+	 * @param string $stage_key
+	 * @param string $state
+	 * @param string $notes
+	 * @param int    $reviewed_by
+	 * @param bool   $advance
+	 * @return bool
+	 */
+	public function set_stage_state($review_item_id, $stage_key, $state, $notes, $reviewed_by = 0, $advance = false) {
+		$review_item_id = absint($review_item_id);
+		$stage_key      = sanitize_key($stage_key);
+		$state          = sanitize_key($state);
+		$reviewed_by    = absint($reviewed_by);
+		$advance        = (bool) $advance;
+
+		if (!$review_item_id || !in_array($stage_key, self::get_stages(), true)) {
+			return false;
+		}
+
+		if (!in_array($state, array('pending','approved','changes_requested','skipped'), true)) {
+			$state = 'pending';
+		}
+
+		$this->wpdb->update(
+			$this->stage_table,
+			array(
+				'state'       => $state,
+				'notes'       => $notes,
+				'reviewed_by' => $reviewed_by ? $reviewed_by : null,
+				'reviewed_at' => in_array($state, array('approved','skipped'), true) ? current_time('mysql') : null,
+				'updated_at'  => current_time('mysql'),
+			),
+			array(
+				'review_item_id' => $review_item_id,
+				'stage_key'      => $stage_key,
+			),
+			array('%s','%s','%d','%s','%s'),
+			array('%d','%s')
+		);
+
+		if ($advance) {
+			$next = $this->get_next_stage($stage_key);
+			if ($next) {
+				$this->set_stage($review_item_id, $next);
+			} else {
+				$this->set_stage($review_item_id, $stage_key);
+			}
+			return true;
+		}
+
+		// Update item stage_state if this is the current stage.
+		$item = $this->get_item_row($review_item_id);
+		if ($item && (string) $item->stage === $stage_key) {
+			$this->wpdb->update(
+				$this->items_table,
+				array(
+					'stage_state' => $state,
+					'updated_at'  => current_time('mysql'),
+				),
+				array('id' => $review_item_id),
+				array('%s','%s'),
+				array('%d')
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Add a comment.
+	 *
+	 * @param int    $review_item_id
+	 * @param int    $user_id
+	 * @param string $comment
+	 * @return int Comment ID.
+	 */
+	public function add_comment($review_item_id, $user_id, $comment) {
+		$review_item_id = absint($review_item_id);
+		$user_id        = absint($user_id);
+		$comment        = trim((string) $comment);
+
+		if (!$review_item_id || '' === $comment) {
+			return 0;
+		}
+
+		$this->wpdb->insert(
+			$this->comments_table,
+			array(
+				'review_item_id' => $review_item_id,
+				'user_id'        => $user_id ? $user_id : null,
+				'comment'        => $comment,
+				'created_at'     => current_time('mysql'),
+			),
+			array('%d','%d','%s','%s')
+		);
+
+		$this->wpdb->update(
+			$this->items_table,
+			array('updated_at' => current_time('mysql')),
+			array('id' => $review_item_id),
+			array('%s'),
+			array('%d')
+		);
+
+		return (int) $this->wpdb->insert_id;
+	}
+
+	/**
+	 * Close an item.
+	 *
+	 * @param int    $review_item_id
+	 * @param string $closed_state
+	 * @return bool
+	 */
+	public function close_item($review_item_id, $closed_state) {
+		$review_item_id = absint($review_item_id);
+		$closed_state   = sanitize_key($closed_state);
+
+		if (!$review_item_id || !in_array($closed_state, array('open','scheduled','published','archived'), true)) {
+			return false;
+		}
+
+		$result = $this->wpdb->update(
+			$this->items_table,
+			array(
+				'closed_state' => $closed_state,
+				'updated_at'   => current_time('mysql'),
+			),
+			array('id' => $review_item_id),
+			array('%s','%s'),
+			array('%d')
+		);
+
+		return $result !== false;
+	}
+
+	/**
+	 * Sync closed_state based on WordPress post_status.
+	 *
+	 * @param int $post_id
+	 * @return void
+	 */
+	public function sync_closed_state_from_post_status($post_id) {
+		$post_id = absint($post_id);
+		if (!$post_id) {
+			return;
+		}
+
+		$item = $this->get_item_row_by_post_id($post_id);
+		if (!$item) {
+			return;
+		}
+
+		$post = get_post($post_id);
+		if (!$post) {
+			return;
+		}
+
+		$new_state = 'open';
+		if ('publish' === $post->post_status) {
+			$new_state = 'published';
+		} elseif ('future' === $post->post_status) {
+			$new_state = 'scheduled';
+		} elseif ('trash' === $post->post_status) {
+			$new_state = 'archived';
+		}
+
+		if ((string) $item->closed_state !== $new_state) {
+			$this->close_item((int) $item->id, $new_state);
+		}
+	}
+
+	/**
+	 * Fetch basic generation context fields from a history record.
+	 *
+	 * @param int $history_id
+	 * @return array{template_id:int,author_id:int,topic_id:int}
+	 */
+	public function get_context_fields_from_history($history_id) {
+		$history_id = absint($history_id);
+		if (!$history_id) {
+			return array('template_id' => 0, 'author_id' => 0, 'topic_id' => 0);
+		}
+
+		$history_table = $this->wpdb->prefix . 'aips_history';
+		$row = $this->wpdb->get_row($this->wpdb->prepare("
+			SELECT template_id, author_id, topic_id
+			FROM {$history_table}
+			WHERE id = %d
+			LIMIT 1
+		", $history_id));
+
+		return array(
+			'template_id' => $row && !empty($row->template_id) ? (int) $row->template_id : 0,
+			'author_id'   => $row && !empty($row->author_id) ? (int) $row->author_id : 0,
+			'topic_id'    => $row && !empty($row->topic_id) ? (int) $row->topic_id : 0,
+		);
+	}
+
+	/**
+	 * Get next stage key.
+	 *
+	 * @param string $stage_key
+	 * @return string|null
+	 */
+	private function get_next_stage($stage_key) {
+		$stages = self::get_stages();
+		$idx = array_search($stage_key, $stages, true);
+		if ($idx === false) {
+			return null;
+		}
+
+		$next_idx = $idx + 1;
+		if (!isset($stages[$next_idx])) {
+			return null;
+		}
+
+		return $stages[$next_idx];
+	}
+}

--- a/ai-post-scheduler/includes/class-aips-review-workflow-repository.php
+++ b/ai-post-scheduler/includes/class-aips-review-workflow-repository.php
@@ -70,8 +70,10 @@ class AIPS_Review_Workflow_Repository {
 			'order'       => 'DESC',
 		);
 
-		$args   = wp_parse_args($args, $defaults);
-		$offset = ($args['page'] - 1) * $args['per_page'];
+		$args              = wp_parse_args($args, $defaults);
+		$args['page']      = max(1, (int) $args['page']);
+		$args['per_page']  = max(1, (int) $args['per_page']);
+		$offset            = ($args['page'] - 1) * $args['per_page'];
 
 		$where      = array( '1=1' );
 		$where_args = array();

--- a/ai-post-scheduler/includes/class-aips-review-workflow-service.php
+++ b/ai-post-scheduler/includes/class-aips-review-workflow-service.php
@@ -16,6 +16,31 @@ if (!defined('ABSPATH')) {
 class AIPS_Review_Workflow_Service {
 
 	/**
+	 * WP-Cron hook name for the incremental backfill.
+	 */
+	const BACKFILL_CRON_HOOK = 'aips_review_workflow_backfill_batch';
+
+	/**
+	 * Option that tracks incremental backfill progress.
+	 */
+	const BACKFILL_STATE_OPTION = 'aips_review_workflow_backfill_state';
+
+	/**
+	 * Option that marks the backfill as fully complete.
+	 */
+	const BACKFILL_DONE_OPTION = 'aips_review_workflow_backfill_done';
+
+	/**
+	 * Number of posts to process per cron batch.
+	 */
+	const BACKFILL_BATCH_SIZE = 50;
+
+	/**
+	 * Seconds to wait before scheduling the next backfill batch.
+	 */
+	const BACKFILL_SCHEDULE_DELAY = 5;
+
+	/**
 	 * @var AIPS_Review_Workflow_Repository
 	 */
 	private $repository;
@@ -28,8 +53,12 @@ class AIPS_Review_Workflow_Service {
 		add_action('aips_post_review_deleted', array($this, 'handle_post_deleted'), 10, 2);
 		add_action('transition_post_status', array($this, 'handle_transition_post_status'), 10, 3);
 
+		// Register the WP-Cron callback so it fires even during cron/frontend contexts.
+		add_action(self::BACKFILL_CRON_HOOK, array($this, 'run_backfill_batch'));
+
+		// On admin_init, only schedule the cron event if the backfill hasn't run yet.
 		if (is_admin()) {
-			add_action('admin_init', array($this, 'maybe_backfill'), 20);
+			add_action('admin_init', array($this, 'maybe_schedule_backfill'), 20);
 		}
 	}
 
@@ -121,57 +150,94 @@ class AIPS_Review_Workflow_Service {
 	}
 
 	/**
-	 * Backfill existing draft posts in the legacy review queue into workflow items.
+	 * Schedule the WP-Cron backfill event if the backfill has not yet completed.
+	 *
+	 * Called on admin_init – performs only an option-check and a single
+	 * wp_schedule_single_event() call so it never blocks the admin request.
 	 *
 	 * @return void
 	 */
-	public function maybe_backfill() {
+	public function maybe_schedule_backfill() {
 		if (!current_user_can('manage_options')) {
 			return;
 		}
 
-		if ((bool) get_option('aips_review_workflow_backfill_done', false)) {
+		if ((bool) get_option(self::BACKFILL_DONE_OPTION, false)) {
 			return;
 		}
 
-		$repo = new AIPS_Post_Review_Repository();
+		// Only schedule if not already queued.
+		if (!wp_next_scheduled(self::BACKFILL_CRON_HOOK)) {
+			wp_schedule_single_event(time() + self::BACKFILL_SCHEDULE_DELAY, self::BACKFILL_CRON_HOOK);
+		}
+	}
 
-		$page     = 1;
-		$per_page = 200;
-		$seen     = 0;
+	/**
+	 * Process a single batch of the backfill via WP-Cron.
+	 *
+	 * Reads the current page from the persisted state option, processes
+	 * up to BACKFILL_BATCH_SIZE items, then either reschedules the next
+	 * batch or marks the backfill as complete.
+	 *
+	 * @return void
+	 */
+	public function run_backfill_batch() {
+		if ((bool) get_option(self::BACKFILL_DONE_OPTION, false)) {
+			return;
+		}
 
-		do {
-			$result = $repo->get_draft_posts(array(
-				'page'     => $page,
-				'per_page' => $per_page,
-			));
+		$state = get_option(self::BACKFILL_STATE_OPTION, array());
+		$state = is_array($state) ? $state : array();
 
-			$items = !empty($result['items']) && is_array($result['items']) ? $result['items'] : array();
+		$page = !empty($state['page']) ? max(1, absint($state['page'])) : 1;
+		$seen = !empty($state['seen']) ? absint($state['seen']) : 0;
 
-			foreach ($items as $row) {
-				$post_id = !empty($row->post_id) ? absint($row->post_id) : 0;
-				$history_id = !empty($row->id) ? absint($row->id) : 0;
-				if (!$post_id) {
-					continue;
-				}
+		$repo   = new AIPS_Post_Review_Repository();
+		$result = $repo->get_draft_posts(array(
+			'page'     => $page,
+			'per_page' => self::BACKFILL_BATCH_SIZE,
+		));
 
-				$this->repository->get_or_create_item_for_post($post_id, $history_id, array(
-					'template_id' => !empty($row->template_id) ? absint($row->template_id) : 0,
-					'author_id'   => !empty($row->author_id) ? absint($row->author_id) : 0,
-					'topic_id'    => !empty($row->topic_id) ? absint($row->topic_id) : 0,
-				));
-				$seen++;
+		$items = !empty($result['items']) && is_array($result['items']) ? $result['items'] : array();
+
+		foreach ($items as $row) {
+			$post_id    = !empty($row->post_id) ? absint($row->post_id) : 0;
+			$history_id = !empty($row->id) ? absint($row->id) : 0;
+			if (!$post_id) {
+				continue;
 			}
 
-			$page++;
-		} while (!empty($items) && count($items) === $per_page);
+			$this->repository->get_or_create_item_for_post($post_id, $history_id, array(
+				'template_id' => !empty($row->template_id) ? absint($row->template_id) : 0,
+				'author_id'   => !empty($row->author_id) ? absint($row->author_id) : 0,
+				'topic_id'    => !empty($row->topic_id) ? absint($row->topic_id) : 0,
+			));
+			$seen++;
+		}
 
-		update_option('aips_review_workflow_backfill_done', 1, false);
+		if (count($items) === self::BACKFILL_BATCH_SIZE) {
+			// More pages may remain – persist progress and schedule the next batch.
+			update_option(
+				self::BACKFILL_STATE_OPTION,
+				array(
+					'page' => $page + 1,
+					'seen' => $seen,
+				),
+				false
+			);
+
+			wp_schedule_single_event(time() + self::BACKFILL_SCHEDULE_DELAY, self::BACKFILL_CRON_HOOK);
+			return;
+		}
+
+		// All batches processed – clean up state and mark done.
+		delete_option(self::BACKFILL_STATE_OPTION);
+		update_option(self::BACKFILL_DONE_OPTION, 1, false);
 
 		/**
 		 * Fires after the workflow backfill completes.
 		 *
-		 * @param int $count Number of posts backfilled.
+		 * @param int $count Total number of posts backfilled.
 		 */
 		do_action('aips_review_workflow_backfilled', $seen);
 	}

--- a/ai-post-scheduler/includes/class-aips-review-workflow-service.php
+++ b/ai-post-scheduler/includes/class-aips-review-workflow-service.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Review Workflow Service
+ *
+ * Hooks generation/publish events to keep the review workflow in sync and
+ * performs a one-time backfill of existing draft review-queue posts.
+ *
+ * @package AI_Post_Scheduler
+ * @since 2.3.0
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+class AIPS_Review_Workflow_Service {
+
+	/**
+	 * @var AIPS_Review_Workflow_Repository
+	 */
+	private $repository;
+
+	public function __construct($repository = null) {
+		$this->repository = $repository instanceof AIPS_Review_Workflow_Repository ? $repository : new AIPS_Review_Workflow_Repository();
+
+		add_action('aips_post_generated', array($this, 'handle_post_generated'), 10, 4);
+		add_action('aips_post_review_published', array($this, 'handle_post_published'), 10, 1);
+		add_action('aips_post_review_deleted', array($this, 'handle_post_deleted'), 10, 2);
+		add_action('transition_post_status', array($this, 'handle_transition_post_status'), 10, 3);
+
+		if (is_admin()) {
+			add_action('admin_init', array($this, 'maybe_backfill'), 20);
+		}
+	}
+
+	/**
+	 * Create/update workflow item when a post is generated.
+	 *
+	 * @param int        $post_id
+	 * @param mixed      $template_or_context
+	 * @param int        $history_id
+	 * @param mixed|null $context
+	 * @return void
+	 */
+	public function handle_post_generated($post_id, $template_or_context = null, $history_id = 0, $context = null) {
+		$post_id   = absint($post_id);
+		$history_id = absint($history_id);
+
+		if (!$post_id) {
+			return;
+		}
+
+		$post = get_post($post_id);
+		if (!$post) {
+			return;
+		}
+
+		if (!in_array($post->post_status, array('draft', 'pending'), true)) {
+			return;
+		}
+
+		$fields = $history_id ? $this->repository->get_context_fields_from_history($history_id) : array('template_id' => 0, 'author_id' => 0, 'topic_id' => 0);
+		$this->repository->get_or_create_item_for_post($post_id, $history_id, $fields);
+	}
+
+	/**
+	 * Close workflow item when published via review queue.
+	 *
+	 * @param int $post_id
+	 * @return void
+	 */
+	public function handle_post_published($post_id) {
+		$post_id = absint($post_id);
+		if (!$post_id) {
+			return;
+		}
+
+		$item = $this->repository->get_item_row_by_post_id($post_id);
+		if ($item) {
+			$this->repository->close_item((int) $item->id, 'published');
+		}
+	}
+
+	/**
+	 * Close workflow item when deleted from review queue.
+	 *
+	 * @param int   $post_id
+	 * @param array $meta
+	 * @return void
+	 */
+	public function handle_post_deleted($post_id, $meta = array()) {
+		$post_id = absint($post_id);
+		if (!$post_id) {
+			return;
+		}
+
+		$item = $this->repository->get_item_row_by_post_id($post_id);
+		if ($item) {
+			$this->repository->close_item((int) $item->id, 'archived');
+		}
+	}
+
+	/**
+	 * Sync closed_state when a post is updated outside the workflow UI.
+	 *
+	 * @param string  $new_status
+	 * @param string  $old_status
+	 * @param WP_Post $post
+	 * @return void
+	 */
+	public function handle_transition_post_status($new_status, $old_status, $post) {
+		if (!($post instanceof WP_Post)) {
+			return;
+		}
+
+		if ($new_status === $old_status) {
+			return;
+		}
+
+		$this->repository->sync_closed_state_from_post_status($post->ID);
+	}
+
+	/**
+	 * Backfill existing draft posts in the legacy review queue into workflow items.
+	 *
+	 * @return void
+	 */
+	public function maybe_backfill() {
+		if (!current_user_can('manage_options')) {
+			return;
+		}
+
+		if ((bool) get_option('aips_review_workflow_backfill_done', false)) {
+			return;
+		}
+
+		$repo = new AIPS_Post_Review_Repository();
+
+		$page     = 1;
+		$per_page = 200;
+		$seen     = 0;
+
+		do {
+			$result = $repo->get_draft_posts(array(
+				'page'     => $page,
+				'per_page' => $per_page,
+			));
+
+			$items = !empty($result['items']) && is_array($result['items']) ? $result['items'] : array();
+
+			foreach ($items as $row) {
+				$post_id = !empty($row->post_id) ? absint($row->post_id) : 0;
+				$history_id = !empty($row->id) ? absint($row->id) : 0;
+				if (!$post_id) {
+					continue;
+				}
+
+				$this->repository->get_or_create_item_for_post($post_id, $history_id, array(
+					'template_id' => !empty($row->template_id) ? absint($row->template_id) : 0,
+					'author_id'   => !empty($row->author_id) ? absint($row->author_id) : 0,
+					'topic_id'    => !empty($row->topic_id) ? absint($row->topic_id) : 0,
+				));
+				$seen++;
+			}
+
+			$page++;
+		} while (!empty($items) && count($items) === $per_page);
+
+		update_option('aips_review_workflow_backfill_done', 1, false);
+
+		/**
+		 * Fires after the workflow backfill completes.
+		 *
+		 * @param int $count Number of posts backfilled.
+		 */
+		do_action('aips_review_workflow_backfilled', $seen);
+	}
+}
+

--- a/ai-post-scheduler/templates/admin/review-workflow.php
+++ b/ai-post-scheduler/templates/admin/review-workflow.php
@@ -1,0 +1,401 @@
+<?php
+/**
+ * Review Workflow Admin Template
+ *
+ * @package AI_Post_Scheduler
+ * @since 2.3.0
+ *
+ * @var AIPS_Review_Workflow_Controller $this
+ * @var array $items
+ * @var array $templates
+ * @var array $users
+ * @var array $counts
+ * @var array $stages
+ * @var string $stage
+ * @var string $closed
+ * @var int $assigned_to
+ * @var int $template_id
+ * @var string $search
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+$page_url = AIPS_Admin_Menu_Helper::get_page_url('review_workflow');
+?>
+
+<div class="wrap aips-wrap">
+	<div class="aips-page-container">
+		<div class="aips-page-header">
+			<div class="aips-page-header-top">
+				<div>
+					<h1 class="aips-page-title"><?php esc_html_e('Review Workflow', 'ai-post-scheduler'); ?></h1>
+					<p class="aips-page-description"><?php esc_html_e('Move AI-generated drafts through a multi-stage editorial workflow.', 'ai-post-scheduler'); ?></p>
+				</div>
+			</div>
+			<div class="aips-rw-stats">
+				<?php foreach (AIPS_Review_Workflow_Repository::get_stages() as $stage_key): ?>
+					<span class="aips-badge aips-badge-neutral">
+						<?php echo esc_html($stages[$stage_key]['label']); ?>:
+						<strong><?php echo esc_html(isset($counts[$stage_key]) ? (int) $counts[$stage_key] : 0); ?></strong>
+					</span>
+				<?php endforeach; ?>
+				<span class="aips-badge aips-badge-warning">
+					<?php esc_html_e('Overdue', 'ai-post-scheduler'); ?>:
+					<strong><?php echo esc_html(isset($counts['overdue']) ? (int) $counts['overdue'] : 0); ?></strong>
+				</span>
+			</div>
+		</div>
+
+		<div class="aips-filter-bar">
+			<form method="get" class="aips-filter-form">
+				<input type="hidden" name="page" value="aips-review-workflow">
+				<div class="aips-filter-left">
+					<label class="screen-reader-text" for="aips-rw-stage"><?php esc_html_e('Stage', 'ai-post-scheduler'); ?></label>
+					<select name="stage" id="aips-rw-stage" class="aips-form-select">
+						<option value=""><?php esc_html_e('All Stages', 'ai-post-scheduler'); ?></option>
+						<?php foreach (AIPS_Review_Workflow_Repository::get_stages() as $k): ?>
+							<option value="<?php echo esc_attr($k); ?>" <?php selected($stage, $k); ?>>
+								<?php echo esc_html($stages[$k]['label']); ?>
+							</option>
+						<?php endforeach; ?>
+					</select>
+
+					<label class="screen-reader-text" for="aips-rw-closed"><?php esc_html_e('State', 'ai-post-scheduler'); ?></label>
+					<select name="closed_state" id="aips-rw-closed" class="aips-form-select">
+						<option value="open" <?php selected($closed, 'open'); ?>><?php esc_html_e('Open', 'ai-post-scheduler'); ?></option>
+						<option value="scheduled" <?php selected($closed, 'scheduled'); ?>><?php esc_html_e('Scheduled', 'ai-post-scheduler'); ?></option>
+						<option value="published" <?php selected($closed, 'published'); ?>><?php esc_html_e('Published', 'ai-post-scheduler'); ?></option>
+						<option value="archived" <?php selected($closed, 'archived'); ?>><?php esc_html_e('Archived', 'ai-post-scheduler'); ?></option>
+					</select>
+
+					<label class="screen-reader-text" for="aips-rw-assignee"><?php esc_html_e('Assignee', 'ai-post-scheduler'); ?></label>
+					<select name="assigned_to" id="aips-rw-assignee" class="aips-form-select">
+						<option value=""><?php esc_html_e('All Assignees', 'ai-post-scheduler'); ?></option>
+						<?php foreach ($users as $u): ?>
+							<option value="<?php echo esc_attr($u->ID); ?>" <?php selected($assigned_to, (int) $u->ID); ?>>
+								<?php echo esc_html($u->display_name); ?>
+							</option>
+						<?php endforeach; ?>
+					</select>
+
+					<?php if (!empty($templates)): ?>
+					<label class="screen-reader-text" for="aips-rw-template"><?php esc_html_e('Template', 'ai-post-scheduler'); ?></label>
+					<select name="template_id" id="aips-rw-template" class="aips-form-select">
+						<option value=""><?php esc_html_e('All Templates', 'ai-post-scheduler'); ?></option>
+						<?php foreach ($templates as $t): ?>
+							<option value="<?php echo esc_attr($t->id); ?>" <?php selected($template_id, (int) $t->id); ?>>
+								<?php echo esc_html($t->name); ?>
+							</option>
+						<?php endforeach; ?>
+					</select>
+					<?php endif; ?>
+
+					<button type="submit" class="aips-btn aips-btn-sm aips-btn-secondary">
+						<span class="dashicons dashicons-filter"></span>
+						<?php esc_html_e('Filter', 'ai-post-scheduler'); ?>
+					</button>
+					<?php
+					$has_filters = !empty($stage) || 'open' !== $closed || !empty($assigned_to) || !empty($template_id) || !empty($search);
+					if ($has_filters):
+					?>
+						<a class="aips-btn aips-btn-sm aips-btn-ghost" href="<?php echo esc_url($page_url); ?>"><?php esc_html_e('Clear', 'ai-post-scheduler'); ?></a>
+					<?php endif; ?>
+				</div>
+
+				<div class="aips-filter-right">
+					<label class="screen-reader-text" for="aips-rw-search"><?php esc_html_e('Search', 'ai-post-scheduler'); ?></label>
+					<input type="search" id="aips-rw-search" name="s" value="<?php echo esc_attr($search); ?>" class="aips-form-input" placeholder="<?php esc_attr_e('Search posts...', 'ai-post-scheduler'); ?>">
+					<button type="submit" class="aips-btn aips-btn-sm aips-btn-secondary">
+						<span class="dashicons dashicons-search"></span>
+						<?php esc_html_e('Search', 'ai-post-scheduler'); ?>
+					</button>
+				</div>
+			</form>
+		</div>
+
+		<div class="aips-content-panel">
+			<div class="aips-panel-body no-padding">
+				<?php if (!empty($items['items'])): ?>
+				<table class="aips-table aips-rw-table">
+					<thead>
+						<tr>
+							<th scope="col"><?php esc_html_e('Post', 'ai-post-scheduler'); ?></th>
+							<th scope="col"><?php esc_html_e('Stage', 'ai-post-scheduler'); ?></th>
+							<th scope="col"><?php esc_html_e('Assignee', 'ai-post-scheduler'); ?></th>
+							<th scope="col"><?php esc_html_e('Due', 'ai-post-scheduler'); ?></th>
+							<th scope="col"><?php esc_html_e('Source', 'ai-post-scheduler'); ?></th>
+							<th scope="col"><?php esc_html_e('Updated', 'ai-post-scheduler'); ?></th>
+							<th scope="col"><?php esc_html_e('Actions', 'ai-post-scheduler'); ?></th>
+						</tr>
+					</thead>
+					<tbody>
+						<?php foreach ($items['items'] as $row): ?>
+							<?php
+							$assignee_label = '';
+							if (!empty($row->assigned_to)) {
+								$assignee = get_userdata((int) $row->assigned_to);
+								$assignee_label = $assignee ? $assignee->display_name : '';
+							}
+
+							$due_label = '';
+							$is_overdue = false;
+							if (!empty($row->due_at)) {
+								$is_overdue = (strtotime((string) $row->due_at) < current_time('timestamp'));
+								$due_label = date_i18n(get_option('date_format') . ' ' . get_option('time_format'), strtotime((string) $row->due_at));
+							}
+
+							$updated_label = '';
+							if (!empty($row->updated_at)) {
+								$updated_label = date_i18n(get_option('date_format') . ' ' . get_option('time_format'), strtotime((string) $row->updated_at));
+							}
+
+							$stage_key = (string) $row->stage;
+							$stage_label = isset($stages[$stage_key]) ? $stages[$stage_key]['label'] : $stage_key;
+							?>
+							<tr data-review-item-id="<?php echo esc_attr($row->id); ?>" data-post-id="<?php echo esc_attr($row->post_id); ?>">
+								<td>
+									<a class="cell-primary" href="<?php echo esc_url(get_edit_post_link((int) $row->post_id)); ?>">
+										<?php echo esc_html($row->post_title); ?>
+									</a>
+									<div class="cell-meta">
+										<span class="aips-badge aips-badge-neutral"><?php echo esc_html($row->post_status); ?></span>
+										<?php if (!empty($row->priority) && 'normal' !== $row->priority): ?>
+											<span class="aips-badge aips-badge-warning"><?php echo esc_html(ucfirst((string) $row->priority)); ?></span>
+										<?php endif; ?>
+									</div>
+								</td>
+								<td>
+									<span class="aips-badge aips-badge-neutral">
+										<?php echo esc_html($stage_label); ?>
+									</span>
+									<?php if (!empty($row->stage_state) && 'pending' !== $row->stage_state): ?>
+										<div class="cell-meta"><?php echo esc_html(str_replace('_', ' ', (string) $row->stage_state)); ?></div>
+									<?php endif; ?>
+								</td>
+								<td>
+									<?php echo $assignee_label ? esc_html($assignee_label) : '—'; ?>
+								</td>
+								<td>
+									<?php if ($due_label): ?>
+										<span class="<?php echo $is_overdue ? esc_attr('aips-rw-overdue') : ''; ?>"><?php echo esc_html($due_label); ?></span>
+									<?php else: ?>
+										—
+									<?php endif; ?>
+								</td>
+								<td>
+									<?php if (!empty($row->template_name)): ?>
+										<span class="aips-badge aips-badge-neutral"><?php echo esc_html(sprintf(__('Template: %s', 'ai-post-scheduler'), $row->template_name)); ?></span>
+									<?php else: ?>
+										<span class="aips-badge aips-badge-neutral"><?php esc_html_e('Unknown', 'ai-post-scheduler'); ?></span>
+									<?php endif; ?>
+								</td>
+								<td><?php echo $updated_label ? esc_html($updated_label) : '—'; ?></td>
+								<td>
+									<div class="aips-btn-group aips-btn-group-inline">
+										<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-rw-open">
+											<span class="dashicons dashicons-visibility"></span>
+											<?php esc_html_e('Open', 'ai-post-scheduler'); ?>
+										</button>
+										<?php if ('ready' === $stage_key && 'open' === (string) $row->closed_state): ?>
+											<button type="button" class="aips-btn aips-btn-sm aips-btn-primary aips-rw-open">
+												<span class="dashicons dashicons-calendar-alt"></span>
+												<?php esc_html_e('Schedule/Publish', 'ai-post-scheduler'); ?>
+											</button>
+										<?php endif; ?>
+									</div>
+								</td>
+							</tr>
+						<?php endforeach; ?>
+					</tbody>
+				</table>
+				<?php else: ?>
+					<div class="aips-empty-state">
+						<div class="dashicons dashicons-yes-alt aips-empty-state-icon" aria-hidden="true"></div>
+						<h3 class="aips-empty-state-title"><?php esc_html_e('No Items', 'ai-post-scheduler'); ?></h3>
+						<p class="aips-empty-state-description"><?php esc_html_e('No posts match the current filters.', 'ai-post-scheduler'); ?></p>
+					</div>
+				<?php endif; ?>
+			</div>
+
+			<div class="tablenav">
+				<span class="aips-table-footer-count">
+					<?php printf( esc_html( _n( '%d item', '%d items', (int) $items['total'], 'ai-post-scheduler' ) ), (int) $items['total'] ); ?>
+				</span>
+				<?php if (!empty($items['pages']) && $items['pages'] > 1): ?>
+				<?php
+				$current = (int) $items['current_page'];
+				$pages   = (int) $items['pages'];
+				$start   = max(1, $current - 3);
+				$end     = min($pages, $current + 3);
+				$build_url = static function($page_number) use ($page_url, $stage, $closed, $assigned_to, $template_id, $search) {
+					return add_query_arg(array_filter(array(
+						'paged'       => absint($page_number),
+						'stage'       => $stage ? $stage : false,
+						'closed_state'=> $closed ? $closed : false,
+						'assigned_to' => $assigned_to ? $assigned_to : false,
+						'template_id' => $template_id ? $template_id : false,
+						's'           => $search ? $search : false,
+					)), $page_url);
+				};
+				?>
+				<div class="aips-history-pagination-links">
+					<?php if ($current > 1): ?>
+						<a class="aips-btn aips-btn-sm aips-btn-secondary" href="<?php echo esc_url($build_url($current - 1)); ?>" aria-label="<?php esc_attr_e('Previous page', 'ai-post-scheduler'); ?>">
+							<span class="dashicons dashicons-arrow-left-alt2"></span>
+						</a>
+					<?php else: ?>
+						<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary" disabled aria-label="<?php esc_attr_e('Previous page', 'ai-post-scheduler'); ?>">
+							<span class="dashicons dashicons-arrow-left-alt2"></span>
+						</button>
+					<?php endif; ?>
+
+					<span class="aips-history-page-numbers">
+						<?php if ($start > 1): ?>
+							<a class="aips-btn aips-btn-sm aips-btn-secondary aips-history-page-link" href="<?php echo esc_url($build_url(1)); ?>">1</a>
+							<?php if ($start > 2): ?><span class="aips-history-page-ellipsis">…</span><?php endif; ?>
+						<?php endif; ?>
+
+						<?php for ($p = $start; $p <= $end; $p++): ?>
+							<?php if ($p === $current): ?>
+								<span class="aips-btn aips-btn-sm aips-btn-primary" aria-current="page"><?php echo esc_html($p); ?></span>
+							<?php else: ?>
+								<a class="aips-btn aips-btn-sm aips-btn-secondary aips-history-page-link" href="<?php echo esc_url($build_url($p)); ?>"><?php echo esc_html($p); ?></a>
+							<?php endif; ?>
+						<?php endfor; ?>
+
+						<?php if ($end < $pages): ?>
+							<?php if ($end < $pages - 1): ?><span class="aips-history-page-ellipsis">…</span><?php endif; ?>
+							<a class="aips-btn aips-btn-sm aips-btn-secondary aips-history-page-link" href="<?php echo esc_url($build_url($pages)); ?>"><?php echo esc_html($pages); ?></a>
+						<?php endif; ?>
+					</span>
+
+					<?php if ($current < $pages): ?>
+						<a class="aips-btn aips-btn-sm aips-btn-secondary" href="<?php echo esc_url($build_url($current + 1)); ?>" aria-label="<?php esc_attr_e('Next page', 'ai-post-scheduler'); ?>">
+							<span class="dashicons dashicons-arrow-right-alt2"></span>
+						</a>
+					<?php else: ?>
+						<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary" disabled aria-label="<?php esc_attr_e('Next page', 'ai-post-scheduler'); ?>">
+							<span class="dashicons dashicons-arrow-right-alt2"></span>
+						</button>
+					<?php endif; ?>
+				</div>
+				<?php endif; ?>
+			</div>
+		</div>
+	</div>
+</div>
+
+<!-- Drawer -->
+<div id="aips-rw-drawer" class="aips-rw-drawer" aria-hidden="true">
+	<div class="aips-rw-drawer-header">
+		<div class="aips-rw-drawer-title">
+			<strong id="aips-rw-drawer-post-title"><?php esc_html_e('Loading…', 'ai-post-scheduler'); ?></strong>
+			<span id="aips-rw-drawer-stage-badge" class="aips-badge aips-badge-neutral"></span>
+		</div>
+		<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-rw-close">
+			<span class="dashicons dashicons-no-alt"></span>
+			<?php esc_html_e('Close', 'ai-post-scheduler'); ?>
+		</button>
+	</div>
+
+	<div class="aips-rw-drawer-body">
+		<div class="aips-rw-section">
+			<h3><?php esc_html_e('Preview', 'ai-post-scheduler'); ?></h3>
+			<div id="aips-rw-preview" class="aips-rw-preview"></div>
+		</div>
+
+		<div class="aips-rw-section">
+			<h3><?php esc_html_e('Workflow', 'ai-post-scheduler'); ?></h3>
+			<div class="aips-rw-controls">
+				<label for="aips-rw-stage-select"><?php esc_html_e('Stage', 'ai-post-scheduler'); ?></label>
+				<select id="aips-rw-stage-select" class="aips-form-select"></select>
+
+				<label for="aips-rw-assignee-select"><?php esc_html_e('Assignee', 'ai-post-scheduler'); ?></label>
+				<select id="aips-rw-assignee-select" class="aips-form-select">
+					<option value=""><?php esc_html_e('Unassigned', 'ai-post-scheduler'); ?></option>
+					<?php foreach ($users as $u): ?>
+						<option value="<?php echo esc_attr($u->ID); ?>"><?php echo esc_html($u->display_name); ?></option>
+					<?php endforeach; ?>
+				</select>
+
+				<label for="aips-rw-due-input"><?php esc_html_e('Due', 'ai-post-scheduler'); ?></label>
+				<input type="datetime-local" id="aips-rw-due-input" class="aips-form-input">
+			</div>
+
+			<div class="aips-rw-controls">
+				<label for="aips-rw-priority-select"><?php esc_html_e('Priority', 'ai-post-scheduler'); ?></label>
+				<select id="aips-rw-priority-select" class="aips-form-select">
+					<option value="low"><?php esc_html_e('Low', 'ai-post-scheduler'); ?></option>
+					<option value="normal"><?php esc_html_e('Normal', 'ai-post-scheduler'); ?></option>
+					<option value="high"><?php esc_html_e('High', 'ai-post-scheduler'); ?></option>
+				</select>
+			</div>
+
+			<div class="aips-rw-actions">
+				<button type="button" class="aips-btn aips-btn-sm aips-btn-primary aips-rw-approve">
+					<span class="dashicons dashicons-yes"></span>
+					<?php esc_html_e('Approve', 'ai-post-scheduler'); ?>
+				</button>
+				<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-rw-request-changes">
+					<span class="dashicons dashicons-warning"></span>
+					<?php esc_html_e('Request changes', 'ai-post-scheduler'); ?>
+				</button>
+				<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-rw-skip">
+					<span class="dashicons dashicons-arrow-right-alt"></span>
+					<?php esc_html_e('Skip', 'ai-post-scheduler'); ?>
+				</button>
+				<button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-rw-archive">
+					<span class="dashicons dashicons-archive"></span>
+					<?php esc_html_e('Archive', 'ai-post-scheduler'); ?>
+				</button>
+			</div>
+
+			<div class="aips-rw-stage-notes">
+				<label for="aips-rw-notes"><?php esc_html_e('Notes', 'ai-post-scheduler'); ?></label>
+				<textarea id="aips-rw-notes" class="aips-form-input" rows="4"></textarea>
+				<div class="aips-rw-notes-actions">
+					<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-rw-save-notes">
+						<span class="dashicons dashicons-saved"></span>
+						<?php esc_html_e('Save notes', 'ai-post-scheduler'); ?>
+					</button>
+				</div>
+			</div>
+
+			<div class="aips-rw-checklist">
+				<h4><?php esc_html_e('Checklist', 'ai-post-scheduler'); ?></h4>
+				<div id="aips-rw-checklist-items"></div>
+			</div>
+		</div>
+
+		<div id="aips-rw-schedule-section" class="aips-rw-section" style="display:none;">
+			<h3><?php esc_html_e('Schedule / Publish', 'ai-post-scheduler'); ?></h3>
+			<div class="aips-rw-controls">
+				<label for="aips-rw-schedule-at"><?php esc_html_e('Publish at', 'ai-post-scheduler'); ?></label>
+				<input type="datetime-local" id="aips-rw-schedule-at" class="aips-form-input">
+				<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-rw-schedule">
+					<span class="dashicons dashicons-calendar-alt"></span>
+					<?php esc_html_e('Schedule', 'ai-post-scheduler'); ?>
+				</button>
+				<button type="button" class="aips-btn aips-btn-sm aips-btn-primary aips-rw-publish-now">
+					<span class="dashicons dashicons-upload"></span>
+					<?php esc_html_e('Publish now', 'ai-post-scheduler'); ?>
+				</button>
+			</div>
+		</div>
+
+		<div class="aips-rw-section">
+			<h3><?php esc_html_e('Comments', 'ai-post-scheduler'); ?></h3>
+			<div id="aips-rw-comments" class="aips-rw-comments"></div>
+			<textarea id="aips-rw-new-comment" class="aips-form-input" rows="3" placeholder="<?php esc_attr_e('Add a comment…', 'ai-post-scheduler'); ?>"></textarea>
+			<div class="aips-rw-notes-actions">
+				<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-rw-add-comment">
+					<span class="dashicons dashicons-admin-comments"></span>
+					<?php esc_html_e('Add comment', 'ai-post-scheduler'); ?>
+				</button>
+			</div>
+		</div>
+	</div>
+</div>
+

--- a/ai-post-scheduler/templates/admin/tab-pending-review.php
+++ b/ai-post-scheduler/templates/admin/tab-pending-review.php
@@ -45,6 +45,10 @@ if (!defined('ABSPATH')) {
 							<?php endif; ?>
 						</div>
 						<div class="aips-filter-right">
+							<a href="<?php echo esc_url(AIPS_Admin_Menu_Helper::get_page_url('review_workflow')); ?>" class="aips-btn aips-btn-sm aips-btn-primary" style="margin-right: 8px;">
+								<span class="dashicons dashicons-yes"></span>
+								<?php esc_html_e('Open Review Workflow', 'ai-post-scheduler'); ?>
+							</a>
 							<label class="screen-reader-text" for="aips-post-search-input"><?php esc_html_e('Search Posts:', 'ai-post-scheduler'); ?></label>
 							<input type="search" id="aips-post-search-input" name="s" value="<?php echo esc_attr($search_query); ?>" class="aips-form-input" placeholder="<?php esc_attr_e('Search posts...', 'ai-post-scheduler'); ?>">
 							<button type="submit" id="aips-post-search-btn" class="aips-btn aips-btn-sm aips-btn-secondary">

--- a/ai-post-scheduler/tests/test-db-schema.php
+++ b/ai-post-scheduler/tests/test-db-schema.php
@@ -178,6 +178,62 @@ class Test_AIPS_DB_Schema extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that review workflow tables exist.
+	 */
+	public function test_review_workflow_tables_exist() {
+		global $wpdb;
+
+		$items_table    = $wpdb->prefix . 'aips_post_review_items';
+		$stage_table    = $wpdb->prefix . 'aips_post_review_stage_data';
+		$comments_table = $wpdb->prefix . 'aips_post_review_comments';
+
+		$this->assertEquals($items_table, $wpdb->get_var("SHOW TABLES LIKE '{$items_table}'"), 'Items table should exist');
+		$this->assertEquals($stage_table, $wpdb->get_var("SHOW TABLES LIKE '{$stage_table}'"), 'Stage table should exist');
+		$this->assertEquals($comments_table, $wpdb->get_var("SHOW TABLES LIKE '{$comments_table}'"), 'Comments table should exist');
+	}
+
+	/**
+	 * Test that items table has unique index on post_id.
+	 */
+	public function test_review_workflow_items_unique_post_id() {
+		global $wpdb;
+		$table = $wpdb->prefix . 'aips_post_review_items';
+
+		$indexes = $wpdb->get_results("SHOW INDEX FROM {$table} WHERE Key_name = 'post_id'");
+		$this->assertNotEmpty($indexes, 'Index post_id should exist');
+
+		$unique = false;
+		foreach ($indexes as $idx) {
+			if ((int) $idx->Non_unique === 0) {
+				$unique = true;
+				break;
+			}
+		}
+
+		$this->assertTrue($unique, 'post_id index should be unique');
+	}
+
+	/**
+	 * Test that stage table has unique composite index (review_item_id, stage_key).
+	 */
+	public function test_review_workflow_stage_unique_composite_index() {
+		global $wpdb;
+		$table = $wpdb->prefix . 'aips_post_review_stage_data';
+
+		$indexes = $wpdb->get_results("SHOW INDEX FROM {$table} WHERE Key_name = 'review_item_stage'");
+		$this->assertNotEmpty($indexes, 'Composite index review_item_stage should exist');
+
+		$this->assertCount(2, $indexes, 'Composite index should have 2 columns');
+		$cols = array();
+		foreach ($indexes as $idx) {
+			$cols[(int) $idx->Seq_in_index] = $idx->Column_name;
+		}
+
+		$this->assertEquals('review_item_id', $cols[1], 'First column should be review_item_id');
+		$this->assertEquals('stage_key', $cols[2], 'Second column should be stage_key');
+	}
+
+	/**
 	 * Test that aips_templates table has description column.
 	 */
 	public function test_templates_table_has_description_column() {

--- a/ai-post-scheduler/tests/test-review-workflow-controller-actions.php
+++ b/ai-post-scheduler/tests/test-review-workflow-controller-actions.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Tests for Review Workflow Controller actions (schedule/publish).
+ *
+ * @package AI_Post_Scheduler
+ */
+
+class Test_AIPS_Review_Workflow_Controller_Actions extends WP_UnitTestCase {
+
+	/** @var int */
+	private $admin_user_id;
+
+	/** @var AIPS_Review_Workflow_Controller */
+	private $controller;
+
+	/** @var AIPS_Review_Workflow_Repository */
+	private $repository;
+
+	/** @var int[] */
+	private $post_ids = array();
+
+	/** @var int[] */
+	private $history_ids = array();
+
+	public function setUp(): void {
+		parent::setUp();
+		AIPS_DB_Manager::install_tables();
+		$this->admin_user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$this->repository    = new AIPS_Review_Workflow_Repository();
+		$this->controller    = new AIPS_Review_Workflow_Controller( $this->repository );
+	}
+
+	public function tearDown(): void {
+		$_POST    = array();
+		$_REQUEST = array();
+
+		foreach ($this->post_ids as $post_id) {
+			wp_delete_post($post_id, true);
+		}
+
+		global $wpdb;
+		$history_table = $wpdb->prefix . 'aips_history';
+		foreach ($this->history_ids as $hid) {
+			$wpdb->delete($history_table, array('id' => $hid), array('%d'));
+		}
+
+		parent::tearDown();
+	}
+
+	private function call_ajax(callable $callable) {
+		ob_start();
+		try {
+			$callable();
+		} catch (WPAjaxDieContinueException $e) {
+			// Expected.
+		}
+		$out = ob_get_clean();
+		return json_decode($out, true);
+	}
+
+	private function create_workflow_item_at_ready() {
+		$post_id = wp_insert_post(array(
+			'post_title'   => 'Ready Post ' . uniqid(),
+			'post_content' => 'Hello',
+			'post_status'  => 'draft',
+			'post_type'    => 'post',
+		));
+		$this->post_ids[] = $post_id;
+
+		global $wpdb;
+		$history_table = $wpdb->prefix . 'aips_history';
+		$wpdb->insert($history_table, array(
+			'post_id'        => $post_id,
+			'template_id'    => 1,
+			'status'         => 'completed',
+			'generated_title'=> 'Generated',
+			'generated_content' => 'Generated content',
+			'created_at'     => current_time('mysql'),
+			'completed_at'   => current_time('mysql'),
+		));
+		$history_id = (int) $wpdb->insert_id;
+		$this->history_ids[] = $history_id;
+
+		$review_item_id = $this->repository->get_or_create_item_for_post($post_id, $history_id, array('template_id' => 1));
+		$this->repository->set_stage($review_item_id, 'ready');
+
+		return array($post_id, $review_item_id);
+	}
+
+	public function test_ajax_schedule_sets_future_status_and_closes_item() {
+		wp_set_current_user($this->admin_user_id);
+		list($post_id, $review_item_id) = $this->create_workflow_item_at_ready();
+
+		$dt = new DateTimeImmutable('now', wp_timezone());
+		$dt = $dt->modify('+2 hours');
+		$schedule_at = $dt->format('Y-m-d\\TH:i');
+
+		$_POST = array(
+			'nonce'         => wp_create_nonce('aips_ajax_nonce'),
+			'review_item_id'=> $review_item_id,
+			'schedule_at'   => $schedule_at,
+		);
+		$_REQUEST = $_POST;
+
+		$response = $this->call_ajax(array($this->controller, 'ajax_schedule'));
+		$this->assertTrue($response['success']);
+
+		$post = get_post($post_id);
+		$this->assertEquals('future', $post->post_status);
+
+		$item = $this->repository->get_item_row($review_item_id);
+		$this->assertEquals('scheduled', $item->closed_state);
+	}
+
+	public function test_ajax_publish_now_sets_publish_status_and_closes_item() {
+		wp_set_current_user($this->admin_user_id);
+		list($post_id, $review_item_id) = $this->create_workflow_item_at_ready();
+
+		$_POST = array(
+			'nonce'         => wp_create_nonce('aips_ajax_nonce'),
+			'review_item_id'=> $review_item_id,
+		);
+		$_REQUEST = $_POST;
+
+		$response = $this->call_ajax(array($this->controller, 'ajax_publish_now'));
+		$this->assertTrue($response['success']);
+
+		$post = get_post($post_id);
+		$this->assertEquals('publish', $post->post_status);
+
+		$item = $this->repository->get_item_row($review_item_id);
+		$this->assertEquals('published', $item->closed_state);
+	}
+}
+

--- a/ai-post-scheduler/tests/test-review-workflow-repository.php
+++ b/ai-post-scheduler/tests/test-review-workflow-repository.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Tests for Review Workflow Repository
+ *
+ * @package AI_Post_Scheduler
+ */
+
+class Test_AIPS_Review_Workflow_Repository extends WP_UnitTestCase {
+
+	/** @var AIPS_Review_Workflow_Repository */
+	private $repository;
+
+	/** @var int[] */
+	private $post_ids = array();
+
+	/** @var int[] */
+	private $history_ids = array();
+
+	public function setUp(): void {
+		parent::setUp();
+		AIPS_DB_Manager::install_tables();
+		$this->repository = new AIPS_Review_Workflow_Repository();
+	}
+
+	public function tearDown(): void {
+		foreach ($this->post_ids as $post_id) {
+			wp_delete_post($post_id, true);
+		}
+
+		global $wpdb;
+		$history_table = $wpdb->prefix . 'aips_history';
+		foreach ($this->history_ids as $hid) {
+			$wpdb->delete($history_table, array('id' => $hid), array('%d'));
+		}
+
+		parent::tearDown();
+	}
+
+	private function create_test_post_with_history($status = 'draft') {
+		$post_id = wp_insert_post(array(
+			'post_title'   => 'Workflow Test ' . uniqid(),
+			'post_content' => 'Hello',
+			'post_status'  => $status,
+			'post_type'    => 'post',
+		));
+
+		$this->post_ids[] = $post_id;
+
+		global $wpdb;
+		$history_table = $wpdb->prefix . 'aips_history';
+		$wpdb->insert($history_table, array(
+			'post_id'        => $post_id,
+			'template_id'    => 1,
+			'status'         => 'completed',
+			'generated_title'=> 'Generated',
+			'generated_content' => 'Generated content',
+			'created_at'     => current_time('mysql'),
+			'completed_at'   => current_time('mysql'),
+		));
+
+		$history_id = (int) $wpdb->insert_id;
+		$this->history_ids[] = $history_id;
+
+		return array($post_id, $history_id);
+	}
+
+	public function test_get_or_create_item_creates_stage_rows() {
+		list($post_id, $history_id) = $this->create_test_post_with_history('draft');
+
+		$review_item_id = $this->repository->get_or_create_item_for_post($post_id, $history_id, array('template_id' => 1));
+		$this->assertGreaterThan(0, $review_item_id);
+
+		$item = $this->repository->get_item_row($review_item_id);
+		$this->assertEquals('brief', $item->stage);
+		$this->assertEquals('pending', $item->stage_state);
+		$this->assertEquals('open', $item->closed_state);
+
+		$stages = $this->repository->get_stage_rows($review_item_id);
+		foreach (AIPS_Review_Workflow_Repository::get_stages() as $stage_key) {
+			$this->assertArrayHasKey($stage_key, $stages, "Stage row missing for {$stage_key}");
+		}
+	}
+
+	public function test_toggle_checklist_item_persists() {
+		list($post_id, $history_id) = $this->create_test_post_with_history('draft');
+		$review_item_id = $this->repository->get_or_create_item_for_post($post_id, $history_id, array('template_id' => 1));
+
+		$updated = $this->repository->toggle_checklist_item($review_item_id, 'brief', 'audience', true);
+		$this->assertArrayHasKey('audience', $updated);
+		$this->assertTrue($updated['audience']);
+
+		$rows = $this->repository->get_stage_rows($review_item_id);
+		$decoded = json_decode((string) $rows['brief']->checklist_state, true);
+		$this->assertTrue((bool) $decoded['audience']);
+	}
+
+	public function test_approve_stage_advances_to_next() {
+		list($post_id, $history_id) = $this->create_test_post_with_history('draft');
+		$review_item_id = $this->repository->get_or_create_item_for_post($post_id, $history_id, array('template_id' => 1));
+
+		$ok = $this->repository->set_stage_state($review_item_id, 'brief', 'approved', 'ok', 0, true);
+		$this->assertTrue($ok);
+
+		$item = $this->repository->get_item_row($review_item_id);
+		$this->assertEquals('outline', $item->stage, 'Should advance to outline');
+	}
+
+	public function test_request_changes_does_not_advance() {
+		list($post_id, $history_id) = $this->create_test_post_with_history('draft');
+		$review_item_id = $this->repository->get_or_create_item_for_post($post_id, $history_id, array('template_id' => 1));
+
+		$ok = $this->repository->set_stage_state($review_item_id, 'brief', 'changes_requested', 'needs edits', 0, false);
+		$this->assertTrue($ok);
+
+		$item = $this->repository->get_item_row($review_item_id);
+		$this->assertEquals('brief', $item->stage, 'Should remain on brief');
+		$this->assertEquals('changes_requested', $item->stage_state, 'Item stage_state should reflect current stage state');
+	}
+}
+


### PR DESCRIPTION
Implemented the Human Review Workflow feature end-to-end (menu + UI + DB + hooks + tests scaffolding).

New admin page: AI Post Scheduler → Review Workflow (page=aips-review-workflow) with queue table + right-side drawer UI at C:\Users\rpnunez\.codex\worktrees\9dc8\wp-ai-scheduler\ai-post-scheduler\templates\admin\review-workflow.php.
New DB tables added via AIPS_DB_Manager in C:\Users\rpnunez\.codex\worktrees\9dc8\wp-ai-scheduler\ai-post-scheduler\includes\class-aips-db-manager.php: aips_post_review_items, aips_post_review_stage_data, aips_post_review_comments.
New workflow backend:
Repo: C:\Users\rpnunez\.codex\worktrees\9dc8\wp-ai-scheduler\ai-post-scheduler\includes\class-aips-review-workflow-repository.php
Service (hooks + one-time backfill): C:\Users\rpnunez\.codex\worktrees\9dc8\wp-ai-scheduler\ai-post-scheduler\includes\class-aips-review-workflow-service.php
Controller (AJAX + render): C:\Users\rpnunez\.codex\worktrees\9dc8\wp-ai-scheduler\ai-post-scheduler\includes\class-aips-review-workflow-controller.php
Admin assets wired:
JS: C:\Users\rpnunez\.codex\worktrees\9dc8\wp-ai-scheduler\ai-post-scheduler\assets\js\admin-review-workflow.js
CSS: C:\Users\rpnunez\.codex\worktrees\9dc8\wp-ai-scheduler\ai-post-scheduler\assets\css\admin-review-workflow.css
Enqueue/localization: C:\Users\rpnunez\.codex\worktrees\9dc8\wp-ai-scheduler\ai-post-scheduler\includes\class-aips-admin-assets.php
Notifications now link to the new workflow page (deep-links auto-open the drawer) in C:\Users\rpnunez\.codex\worktrees\9dc8\wp-ai-scheduler\ai-post-scheduler\includes\class-aips-notifications.php.
Legacy “Content → Pending Review” now includes a button to open the workflow at C:\Users\rpnunez\.codex\worktrees\9dc8\wp-ai-scheduler\ai-post-scheduler\templates\admin\tab-pending-review.php.
Version bumped to 2.3.0 to trigger dbDelta upgrades: C:\Users\rpnunez\.codex\worktrees\9dc8\wp-ai-scheduler\ai-post-scheduler\ai-post-scheduler.php.
Tests added/updated:
Schema assertions: C:\Users\rpnunez\.codex\worktrees\9dc8\wp-ai-scheduler\ai-post-scheduler\tests\test-db-schema.php
Repository tests: C:\Users\rpnunez\.codex\worktrees\9dc8\wp-ai-scheduler\ai-post-scheduler\tests\test-review-workflow-repository.php
Controller action tests: C:\Users\rpnunez\.codex\worktrees\9dc8\wp-ai-scheduler\ai-post-scheduler\tests\test-review-workflow-controller-actions.php