### PR TITLE
Fix admin rendering regressions

### DIFF
--- a/ai-post-scheduler/includes/class-aips-admin-bar.php
+++ b/ai-post-scheduler/includes/class-aips-admin-bar.php
@@ -20,9 +20,16 @@ if (!defined('ABSPATH')) {
 class AIPS_Admin_Bar {
 
 	/**
+	 * @var AIPS_Notifications_Repository
+	 */
+	private $repository;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
+		$this->repository = AIPS_Notifications_Repository::instance();
+
 		add_action('admin_bar_menu', array($this, 'add_toolbar_node'), 100);
 		add_action('wp_ajax_aips_mark_notification_read', array($this, 'ajax_mark_read'));
 		add_action('wp_ajax_aips_mark_all_notifications_read', array($this, 'ajax_mark_all_read'));

--- a/ai-post-scheduler/includes/class-aips-admin-menu.php
+++ b/ai-post-scheduler/includes/class-aips-admin-menu.php
@@ -92,15 +92,18 @@ class AIPS_Admin_Menu {
             array($this, 'render_authors_page')
         );
 
-        // Author Topics page - hidden from menu navigation, accessible via URL
+        // Author Topics page - register under plugin parent, then hide from submenu.
         add_submenu_page(
-            null,
+            'ai-post-scheduler',
             __('Author Topics', 'ai-post-scheduler'),
             __('Author Topics', 'ai-post-scheduler'),
             'manage_options',
             'aips-author-topics',
             array($this, 'render_author_topics_page')
         );
+
+        // Keep this page URL-accessible without showing an extra submenu item.
+        remove_submenu_page('ai-post-scheduler', 'aips-author-topics');
 
         add_submenu_page(
             'ai-post-scheduler',

--- a/ai-post-scheduler/includes/class-aips-onboarding-wizard.php
+++ b/ai-post-scheduler/includes/class-aips-onboarding-wizard.php
@@ -56,13 +56,16 @@ class AIPS_Onboarding_Wizard {
 
 	public function register_page() {
 		add_submenu_page(
-			null,
+			'ai-post-scheduler',
 			__('Onboarding Wizard', 'ai-post-scheduler'),
 			__('Onboarding Wizard', 'ai-post-scheduler'),
 			'manage_options',
 			self::PAGE_SLUG,
 			array($this, 'render_page')
 		);
+
+		// Keep wizard accessible by URL without adding a visible submenu item.
+		remove_submenu_page('ai-post-scheduler', self::PAGE_SLUG);
 	}
 
 	/**
@@ -482,4 +485,3 @@ class AIPS_Onboarding_Wizard {
 		));
 	}
 }
-


### PR DESCRIPTION
Fix admin rendering regressions by correcting hidden submenu registration and initializing admin-bar notification repository access.

### Files Changed

- ai-post-scheduler/includes/class-aips-admin-menu.php

**Problem**: Hidden page registration used add_submenu_page(null, ...), which triggered PHP 8.2 deprecation noise during admin_menu.
**Change**: Register aips-author-topics under 'ai-post-scheduler' and immediately hide it with remove_submenu_page(...).
**Impact**: Keeps URL-accessible hidden page behavior while avoiding null parent slug deprecations.

- ai-post-scheduler/includes/class-aips-onboarding-wizard.php

**Problem**: Onboarding page used add_submenu_page(null, ...), same deprecation path as above.
**Change**: Register onboarding under 'ai-post-scheduler' and hide with remove_submenu_page(...).
**Impact**: Preserves onboarding URL access and removes deprecated null parent slug usage.

- ai-post-scheduler/includes/class-aips-admin-bar.php

**Problem**: AIPS_Admin_Bar::add_toolbar_node() accessed $this->repository before initialization, which could terminate admin page rendering early.
**Change**: Added private $repository and initialized it in __construct() via AIPS_Notifications_Repository::instance().
**Impact**: Prevents admin-page truncation and restores full plugin dashboard rendering.

### Validation

- PHP lint passed for updated files.
- Reproduced and rechecked plugin admin page output:
- Full markup restored (id="wpbody", id="wpfooter", aips-wrap present).