### PR TITLE
🐞 Hunter: Add object checks for get_row results to prevent TypeErrors

### DIFF
--- a/.jules/hunter.md
+++ b/.jules/hunter.md
@@ -1,3 +1,7 @@
 ## 2026-04-27 - Handle Template Data Object Type Error
 **Learning:** Legacy template variables might receive class instances instead of expected associative arrays, causing fatal `Cannot use object of type class as array` errors in PHP 8+.
 **Action:** Always check `is_object($data)` before accessing elements via `$data['key']` in templates. If it is an object, use getter methods (e.g. `$handler->get_data()`) to retrieve an array context.
+
+## 2026-05-06 - [Fix TypeErrors on get_row database results]
+**Learning:** When using `$wpdb->get_row()`, it may return `null` if no records are found or if the query fails. Directly accessing properties on the result via `isset($result->prop)` causes warnings/fatal errors in PHP 8+ if `$result` is not an object.
+**Action:** Always wrap `get_row()` property checks with `is_object($result) && isset($result->prop)` to prevent TypeErrors, e.g. `(is_object($result) && isset($result->total)) ? (int) $result->total : 0`.

--- a/ai-post-scheduler/CHANGELOG.md
+++ b/ai-post-scheduler/CHANGELOG.md
@@ -164,3 +164,4 @@ All notable changes to this project will be documented in this file.
 ## [sentinel-prevent-directory-listing] - 2024-05-24
 ### Security
 - [2024-05-24] Added empty `index.php` files to all plugin subdirectories to prevent directory listing and information disclosure.
+- **Fix:** Fixed PHP 8.1+ TypeErrors caused by accessing properties on `get_row()` results that could be `null`.

--- a/ai-post-scheduler/includes/class-aips-article-structure-repository.php
+++ b/ai-post-scheduler/includes/class-aips-article-structure-repository.php
@@ -268,8 +268,8 @@ class AIPS_Article_Structure_Repository {
 		");
 		
 		return array(
-			'total' => isset($results->total) ? (int) $results->total : 0,
-			'active' => isset($results->active) ? (int) $results->active : 0,
+			'total' => (is_object($results) && isset($results->total)) ? (int) $results->total : 0,
+			'active' => (is_object($results) && isset($results->active)) ? (int) $results->active : 0,
 		);
 	}
 	

--- a/ai-post-scheduler/includes/class-aips-date-time-db-repair.php
+++ b/ai-post-scheduler/includes/class-aips-date-time-db-repair.php
@@ -366,6 +366,7 @@ class AIPS_Date_Time_DB_Repair {
 			return false;
 		}
 
+		if (!is_object($col_info) || !isset($col_info->Type)) { return false; }
 		$type_lower = strtolower( $col_info->Type );
 
 		if ( false !== strpos( $type_lower, 'bigint' ) ) {

--- a/ai-post-scheduler/includes/class-aips-feedback-repository.php
+++ b/ai-post-scheduler/includes/class-aips-feedback-repository.php
@@ -234,9 +234,9 @@ class AIPS_Feedback_Repository {
 		));
 		
 		return array(
-			'total' => isset($results->total) ? (int) $results->total : 0,
-			'approved' => isset($results->approved) ? (int) $results->approved : 0,
-			'rejected' => isset($results->rejected) ? (int) $results->rejected : 0
+			'total' => (is_object($results) && isset($results->total)) ? (int) $results->total : 0,
+			'approved' => (is_object($results) && isset($results->approved)) ? (int) $results->approved : 0,
+			'rejected' => (is_object($results) && isset($results->rejected)) ? (int) $results->rejected : 0
 		);
 	}
 	

--- a/ai-post-scheduler/includes/class-aips-history-repository.php
+++ b/ai-post-scheduler/includes/class-aips-history-repository.php
@@ -584,11 +584,11 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
         ");
 
         $stats = array(
-            'total' => isset($results->total) ? (int) $results->total : 0,
-            'completed' => isset($results->completed) ? (int) $results->completed : 0,
-            'failed' => isset($results->failed) ? (int) $results->failed : 0,
-            'processing' => isset($results->processing) ? (int) $results->processing : 0,
-            'partial' => isset($results->partial) ? (int) $results->partial : 0,
+            'total' => (is_object($results) && isset($results->total)) ? (int) $results->total : 0,
+            'completed' => (is_object($results) && isset($results->completed)) ? (int) $results->completed : 0,
+            'failed' => (is_object($results) && isset($results->failed)) ? (int) $results->failed : 0,
+            'processing' => (is_object($results) && isset($results->processing)) ? (int) $results->processing : 0,
+            'partial' => (is_object($results) && isset($results->partial)) ? (int) $results->partial : 0,
         );
         
         $stats['success_rate'] = $stats['total'] > 0 

--- a/ai-post-scheduler/includes/class-aips-metrics-repository.php
+++ b/ai-post-scheduler/includes/class-aips-metrics-repository.php
@@ -454,10 +454,10 @@ class AIPS_Metrics_Repository {
 		}
 
 		return array(
-			'total'     => isset( $row->total )     ? (int) $row->total     : 0,
-			'completed' => isset( $row->completed ) ? (int) $row->completed : 0,
-			'failed'    => isset( $row->failed )    ? (int) $row->failed    : 0,
-			'partial'   => isset( $row->partial )   ? (int) $row->partial   : 0,
+			'total'     => (is_object($row) && isset($row->total))     ? (int) $row->total     : 0,
+			'completed' => (is_object($row) && isset($row->completed)) ? (int) $row->completed : 0,
+			'failed'    => (is_object($row) && isset($row->failed))    ? (int) $row->failed    : 0,
+			'partial'   => (is_object($row) && isset($row->partial))   ? (int) $row->partial   : 0,
 		);
 	}
 
@@ -568,7 +568,7 @@ class AIPS_Metrics_Repository {
 			)
 		);
 
-		if ( ! $row || ! isset( $row->avg_calls ) || $row->avg_calls === null ) {
+		if ( ! $row || ! (is_object($row) && isset($row->avg_calls)) || $row->avg_calls === null ) {
 			return 0.0;
 		}
 
@@ -660,7 +660,7 @@ class AIPS_Metrics_Repository {
 			)
 		);
 
-		if ( ! $row || ! isset( $row->total ) || (int) $row->total === 0 ) {
+		if ( ! $row || ! (is_object($row) && isset($row->total)) || (int) $row->total === 0 ) {
 			return -1.0; // No scheduled-run data available.
 		}
 

--- a/ai-post-scheduler/includes/class-aips-prompt-section-repository.php
+++ b/ai-post-scheduler/includes/class-aips-prompt-section-repository.php
@@ -296,8 +296,8 @@ class AIPS_Prompt_Section_Repository {
 		");
 		
 		return array(
-			'total' => isset($results->total) ? (int) $results->total : 0,
-			'active' => isset($results->active) ? (int) $results->active : 0,
+			'total' => (is_object($results) && isset($results->total)) ? (int) $results->total : 0,
+			'active' => (is_object($results) && isset($results->active)) ? (int) $results->active : 0,
 		);
 	}
 	

--- a/ai-post-scheduler/includes/class-aips-schedule-repository.php
+++ b/ai-post-scheduler/includes/class-aips-schedule-repository.php
@@ -746,8 +746,8 @@ class AIPS_Schedule_Repository implements AIPS_Schedule_Repository_Interface {
         ");
         
         return array(
-            'total' => isset($results->total) ? (int) $results->total : 0,
-            'active' => isset($results->active) ? (int) $results->active : 0,
+            'total' => (is_object($results) && isset($results->total)) ? (int) $results->total : 0,
+            'active' => (is_object($results) && isset($results->active)) ? (int) $results->active : 0,
         );
     }
 }

--- a/ai-post-scheduler/includes/class-aips-template-repository.php
+++ b/ai-post-scheduler/includes/class-aips-template-repository.php
@@ -346,8 +346,8 @@ class AIPS_Template_Repository {
         ");
         
         return array(
-            'total' => isset($results->total) ? (int) $results->total : 0,
-            'active' => isset($results->active) ? (int) $results->active : 0,
+            'total' => (is_object($results) && isset($results->total)) ? (int) $results->total : 0,
+            'active' => (is_object($results) && isset($results->active)) ? (int) $results->active : 0,
         );
     }
     


### PR DESCRIPTION
🐛 **Bug**: When `$wpdb->get_row()` returns `null` (e.g. no records found or query fails), directly checking properties via `isset($result->prop)` raises warnings/TypeErrors in PHP 8+.
🔎 **Root Cause**: `isset()` on a property of a non-object is no longer silently ignored in newer PHP versions and generates an "Undefined property" warning or fatal error when statically analyzed. Similarly, `class-aips-date-time-db-repair.php` lacked an `isset` check before attempting to read `$col_info->Type`, throwing a deprecation notice when passing `null` to `strtolower()`.
🛠️ **Fix**: Safely guarded all property access on `get_row()` results with an `is_object()` check (e.g. `is_object($result) && isset($result->total)`).
🧪 **Verification**: Validated code changes and ran the PHPUnit test suite. Documented learning in `.jules/hunter.md`.

---
*PR created automatically by Jules for task [4956691995289246821](https://jules.google.com/task/4956691995289246821) started by @rpnunez*