### PR TITLE
Wizard: Standardize Empty States and Search Filters

### DIFF
--- a/.build/wizard.md
+++ b/.build/wizard.md
@@ -77,3 +77,6 @@
 ## 2026-04-18 - Post Preview Added to Generated Posts and Partial Generations Tabs
 **Learning:** The AJAX-based post preview functionality was already implemented for Pending Review but omitted from the Generated Posts and Partial Generations lists, causing users to have to fully open the WordPress editor to see the generated content.
 **Action:** Reuse the `.aips-preview-post` class and `aips_get_post_preview` AJAX action from `admin-post-review.js` by simply adding the preview button to the other tabs in the Content view.
+## 2026-05-06 - Standardize Search Clear Buttons Classes
+**Learning:** Found inconsistency in "Clear Search/Filters" buttons across the admin UI using the standard solid secondary button style (`.aips-btn-secondary`), causing visual clutter alongside main action buttons. The journal noted this in the past, but some template forms hadn't been updated yet.
+**Action:** Standardized "Clear" buttons inside `.aips-filter-right` and empty states to use the ghost button style (`.aips-btn-ghost`) and primary buttons (`.aips-btn-primary`) inside `.aips-empty-state-actions` for a cleaner, consistent UI.

--- a/ai-post-scheduler/templates/admin/authors.php
+++ b/ai-post-scheduler/templates/admin/authors.php
@@ -325,7 +325,7 @@ $site_ctx = AIPS_Site_Context::get();
                     <div class="aips-filter-right">
                         <label class="screen-reader-text" for="aips-queue-search"><?php esc_html_e('Search Queue Topics:', 'ai-post-scheduler'); ?></label>
                         <input type="search" id="aips-queue-search" class="aips-form-input" placeholder="<?php esc_attr_e('Search queue topics...', 'ai-post-scheduler'); ?>">
-                        <button type="button" id="aips-queue-search-clear" class="aips-btn aips-btn-sm aips-btn-secondary" style="display: none;">
+                        <button type="button" id="aips-queue-search-clear" class="aips-btn aips-btn-sm aips-btn-ghost" style="display: none;">
                             <?php esc_html_e('Clear', 'ai-post-scheduler'); ?>
                         </button>
                     </div>

--- a/ai-post-scheduler/templates/admin/history.php
+++ b/ai-post-scheduler/templates/admin/history.php
@@ -135,7 +135,7 @@ if (is_object($history)) {
                                     <?php esc_html_e('No history containers match your current filters.', 'ai-post-scheduler'); ?>
                                     <?php if ($has_active_filter): ?>
                                         <br><br>
-                                        <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-clear-history-search-btn">
+                                        <button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-clear-history-search-btn">
                                             <span class="dashicons dashicons-dismiss"></span>
                                             <?php esc_html_e('Clear Filters', 'ai-post-scheduler'); ?>
                                         </button>

--- a/ai-post-scheduler/templates/admin/internal-links.php
+++ b/ai-post-scheduler/templates/admin/internal-links.php
@@ -111,7 +111,7 @@ $count_inserted = isset($link_counts['inserted']) ? (int) $link_counts['inserted
 					<div class="aips-filter-right">
 						<label class="screen-reader-text" for="aips-il-search"><?php esc_html_e('Search posts:', 'ai-post-scheduler'); ?></label>
 						<input type="search" id="aips-il-search" class="aips-form-input" placeholder="<?php esc_attr_e('Search by post title…', 'ai-post-scheduler'); ?>">
-						<button type="button" id="aips-il-search-clear" class="aips-btn aips-btn-sm aips-btn-secondary" style="display:none;"><?php esc_html_e('Clear', 'ai-post-scheduler'); ?></button>
+						<button type="button" id="aips-il-search-clear" class="aips-btn aips-btn-sm aips-btn-ghost" style="display:none;"><?php esc_html_e('Clear', 'ai-post-scheduler'); ?></button>
 					</div>
 				</div>
 

--- a/ai-post-scheduler/templates/admin/research.php
+++ b/ai-post-scheduler/templates/admin/research.php
@@ -552,7 +552,9 @@ if (!in_array($active_tab, $valid_tabs, true)) {
             <div class="dashicons dashicons-search aips-empty-state-icon" aria-hidden="true"></div>
             <h3 class="aips-empty-state-title">{{title}}</h3>
             <p class="aips-empty-state-description">{{description}}</p>
-            <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary" id="clear-topics-search">{{clear_label}}</button>
+            <div class="aips-empty-state-actions">
+                <button type="button" class="aips-btn aips-btn-primary" id="clear-topics-search">{{clear_label}}</button>
+            </div>
         </div>
     </script>
 


### PR DESCRIPTION
**What**:
Standardized the styling of the "Clear Search/Filters" buttons across the admin interface.

**Why**:
There was an inconsistency in button styles, with some clear buttons using the standard solid secondary style (`.aips-btn-secondary`), which caused visual clutter alongside the primary action buttons in search bars or empty states. 

**Value**:
A cleaner and more consistent UI that draws the user's focus appropriately, creating a predictable visual hierarchy.

**Testing**:
Ran unit tests which passed (no regressions). Visually verified via codebase review that target templates now use `aips-btn-ghost`.

**Visuals**:
Clear buttons now uniformly display as ghost buttons inside filter bars, and standard primary buttons inside empty states.

---
*PR created automatically by Jules for task [13864615826908107630](https://jules.google.com/task/13864615826908107630) started by @rpnunez*