### PR TITLE
Standardize history logging and normalize history metadata

### DIFF
--- a/ai-post-scheduler/includes/class-aips-author-topics-controller.php
+++ b/ai-post-scheduler/includes/class-aips-author-topics-controller.php
@@ -168,20 +168,17 @@ class AIPS_Author_Topics_Controller {
 
 			// Log to activity feed using History Container
 			if ($topic) {
-				$approve_history = $this->history_service->create('topic_approval', array(
-					'topic_id' => $topic_id,
-				));
-				$approve_history->record(
-					'activity',
+				AIPS_History_Service::log_activity(
+					'topic_approval',
 					sprintf(
 						__('Topic approved: "%s"', 'ai-post-scheduler'),
 						$topic->topic_title
 					),
+					'topic_approved',
+					'success',
 					array(
-						'event_type' => 'topic_approved',
-						'event_status' => 'success',
+						'topic_id' => $topic_id,
 					),
-					null,
 					array(
 						'topic_id' => $topic_id,
 						'topic_title' => $topic->topic_title,
@@ -238,20 +235,17 @@ class AIPS_Author_Topics_Controller {
 
 			// Log to activity feed using History Container
 			if ($topic) {
-				$reject_history = $this->history_service->create('topic_rejection', array(
-					'topic_id' => $topic_id,
-				));
-				$reject_history->record(
-					'activity',
+				AIPS_History_Service::log_activity(
+					'topic_rejection',
 					sprintf(
 						__('Topic rejected: "%s"', 'ai-post-scheduler'),
 						$topic->topic_title
 					),
+					'topic_rejected',
+					'failed',
 					array(
-						'event_type' => 'topic_rejected',
-						'event_status' => 'failed',
+						'topic_id' => $topic_id,
 					),
-					null,
 					array(
 						'topic_id' => $topic_id,
 						'topic_title' => $topic->topic_title,
@@ -558,11 +552,11 @@ class AIPS_Author_Topics_Controller {
 				$success_count++;
 			} else {
 				$failed_count++;
-				$history->record('warning', sprintf(__('Failed to delete topic ID %d', 'ai-post-scheduler'), $topic_id), null, null, array('topic_id' => $topic_id));
+				AIPS_History_Service::record_on_container($history, 'warning', sprintf(__('Failed to delete topic ID %d', 'ai-post-scheduler'), $topic_id), null, null, array('topic_id' => $topic_id));
 			}
 		}
 
-		$history->record('activity', sprintf(__('Deleted %d topics', 'ai-post-scheduler'), $success_count), null, null, array(
+		AIPS_History_Service::record_on_container($history, 'activity', sprintf(__('Deleted %d topics', 'ai-post-scheduler'), $success_count), null, null, array(
 			'deleted_count' => $success_count,
 			'requested_count' => count($topic_ids)
 		));
@@ -628,7 +622,7 @@ class AIPS_Author_Topics_Controller {
 			AIPS_Ajax_Response::error(array('message' => $result->get_error_message()));
 		}
 
-		$history->record('activity', __('Post regenerated successfully', 'ai-post-scheduler'), null, null, array(
+		AIPS_History_Service::record_on_container($history, 'activity', __('Post regenerated successfully', 'ai-post-scheduler'), null, null, array(
 			'post_id' => $result,
 			'original_post_id' => $post_id,
 			'topic_id' => $topic_id
@@ -1068,11 +1062,11 @@ class AIPS_Author_Topics_Controller {
 				$success_count++;
 			} else {
 				$failed_count++;
-				$history->record('warning', sprintf(__('Failed to delete feedback ID %d', 'ai-post-scheduler'), $feedback_id), null, null, array('feedback_id' => $feedback_id));
+				AIPS_History_Service::record_on_container($history, 'warning', sprintf(__('Failed to delete feedback ID %d', 'ai-post-scheduler'), $feedback_id), null, null, array('feedback_id' => $feedback_id));
 			}
 		}
 
-		$history->record('activity', sprintf(__('Deleted %d feedback items', 'ai-post-scheduler'), $success_count), null, null, array(
+		AIPS_History_Service::record_on_container($history, 'activity', sprintf(__('Deleted %d feedback items', 'ai-post-scheduler'), $success_count), null, null, array(
 			'deleted_count' => $success_count,
 			'requested_count' => count($feedback_ids)
 		));

--- a/ai-post-scheduler/includes/class-aips-author-topics-controller.php
+++ b/ai-post-scheduler/includes/class-aips-author-topics-controller.php
@@ -168,14 +168,13 @@ class AIPS_Author_Topics_Controller {
 
 			// Log to activity feed using History Container
 			if ($topic) {
-				AIPS_History_Service::log_activity(
+				AIPS_History_Service::log_success(
 					'topic_approval',
 					sprintf(
 						__('Topic approved: "%s"', 'ai-post-scheduler'),
 						$topic->topic_title
 					),
 					'topic_approved',
-					'success',
 					array(
 						'topic_id' => $topic_id,
 					),
@@ -235,14 +234,13 @@ class AIPS_Author_Topics_Controller {
 
 			// Log to activity feed using History Container
 			if ($topic) {
-				AIPS_History_Service::log_activity(
+				AIPS_History_Service::log_failure(
 					'topic_rejection',
 					sprintf(
 						__('Topic rejected: "%s"', 'ai-post-scheduler'),
 						$topic->topic_title
 					),
 					'topic_rejected',
-					'failed',
 					array(
 						'topic_id' => $topic_id,
 					),
@@ -355,7 +353,7 @@ class AIPS_Author_Topics_Controller {
 		}
 
 		// Create history container for manual generation
-		$history = $this->history_service->create('manual_generation', array(
+		$history = $this->history_service->get_or_create('manual_generation', array(
 			'topic_id' => $topic_id,
 			'user_id' => get_current_user_id(),
 			'source' => 'manual_ui',
@@ -380,7 +378,7 @@ class AIPS_Author_Topics_Controller {
 			AIPS_Ajax_Response::error(array('message' => $result->get_error_message()));
 		}
 
-		$history->record('activity', __('Post generated successfully from topic', 'ai-post-scheduler'), null, null, array(
+		AIPS_History_Service::record_on_container($history, 'activity', __('Post generated successfully from topic', 'ai-post-scheduler'), null, null, array(
 			'post_id' => $result,
 			'topic_id' => $topic_id
 		));
@@ -530,7 +528,7 @@ class AIPS_Author_Topics_Controller {
 		}
 
 		// Create history container for bulk delete operation
-		$history = $this->history_service->create('bulk_delete', array(
+		$history = $this->history_service->get_or_create('bulk_delete', array(
 			'user_id' => get_current_user_id(),
 			'source' => 'manual_ui',
 			'trigger' => 'ajax_bulk_delete_topics',
@@ -552,7 +550,7 @@ class AIPS_Author_Topics_Controller {
 				$success_count++;
 			} else {
 				$failed_count++;
-				AIPS_History_Service::record_on_container($history, 'warning', sprintf(__('Failed to delete topic ID %d', 'ai-post-scheduler'), $topic_id), null, null, array('topic_id' => $topic_id));
+				AIPS_History_Service::record_on_container($history, 'warning', sprintf(__('Failed to delete topic ID %d', 'ai-post-scheduler'), $topic_id), null, null, array('topic_id' => $topic_id, 'event_type' => 'bulk_delete_topics', 'event_status' => 'warning'));
 			}
 		}
 
@@ -596,7 +594,7 @@ class AIPS_Author_Topics_Controller {
 		}
 
 		// Create history container for regeneration
-		$history = $this->history_service->create('manual_regeneration', array(
+		$history = $this->history_service->get_or_create('manual_regeneration', array(
 			'user_id' => get_current_user_id(),
 			'source' => 'manual_ui',
 			'trigger' => 'ajax_regenerate_post',
@@ -1040,7 +1038,7 @@ class AIPS_Author_Topics_Controller {
 		}
 
 		// Create history container for bulk delete operation
-		$history = $this->history_service->create('bulk_delete_feedback', array(
+		$history = $this->history_service->get_or_create('bulk_delete_feedback', array(
 			'user_id' => get_current_user_id(),
 			'source' => 'manual_ui',
 			'trigger' => 'ajax_bulk_delete_feedback',

--- a/ai-post-scheduler/includes/class-aips-generator.php
+++ b/ai-post-scheduler/includes/class-aips-generator.php
@@ -128,18 +128,17 @@ class AIPS_Generator {
      */
     public function generate_content($prompt, $options = array(), $log_type = 'content') {
         // Log AI request before making the call
-        if ($this->current_history) {
-            $this->current_history->record(
-                'ai_request',
-                "Requesting AI generation for {$log_type}",
-                array(
-                    'prompt' => $prompt,
-                    'options' => $options,
-                ),
-                null,
-                array('component' => $log_type)
-            );
-        }
+        AIPS_History_Service::record_on_container(
+            $this->current_history,
+            'ai_request',
+            "Requesting AI generation for {$log_type}",
+            array(
+                'prompt' => $prompt,
+                'options' => $options,
+            ),
+            null,
+            array('component' => $log_type)
+        );
 
         // Forward the request type so AIPS_AI_Service can calculate maxTokens correctly.
         // Only set it when the caller has not already provided an explicit token override.
@@ -155,18 +154,17 @@ class AIPS_Generator {
 
         if (is_wp_error($result)) {
             // Log the error
-            if ($this->current_history) {
-                $this->current_history->record(
-                    'error',
-                    "AI generation failed for {$log_type}: " . $result->get_error_message(),
-                    array(
-                        'prompt' => $prompt,
-                        'options' => $options,
-                    ),
-                    null,
-                    array('component' => $log_type, 'error' => $result->get_error_message())
-                );
-            }
+            AIPS_History_Service::record_on_container(
+                $this->current_history,
+                'error',
+                "AI generation failed for {$log_type}: " . $result->get_error_message(),
+                array(
+                    'prompt' => $prompt,
+                    'options' => $options,
+                ),
+                null,
+                array('component' => $log_type, 'error' => $result->get_error_message())
+            );
 
             $this->logger->log($result->get_error_message(), 'error', array(
                 'component'      => $log_type,
@@ -174,15 +172,14 @@ class AIPS_Generator {
             ));
         } else {
             // Log successful AI response
-            if ($this->current_history) {
-                $this->current_history->record(
-                    'ai_response',
-                    "AI generation successful for {$log_type}",
-                    null,
-                    $result,
-                    array('component' => $log_type)
-                );
-            }
+            AIPS_History_Service::record_on_container(
+                $this->current_history,
+                'ai_response',
+                "AI generation successful for {$log_type}",
+                null,
+                $result,
+                array('component' => $log_type)
+            );
 
             $this->logger->log('Content generated successfully', 'info', array(
                 'component'       => $log_type,

--- a/ai-post-scheduler/includes/class-aips-history-container.php
+++ b/ai-post-scheduler/includes/class-aips-history-container.php
@@ -72,6 +72,8 @@ class AIPS_History_Container {
 		$this->repository = $repository;
 		$this->session = null;
 		
+		$this->metadata = $this->normalize_metadata($type, $metadata);
+
 		if ($existing_history_id) {
 			// Load existing history container
 			$history = $repository->get_by_id($existing_history_id);
@@ -79,8 +81,8 @@ class AIPS_History_Container {
 				$this->uuid = $history->uuid;
 				$this->correlation_id = isset($history->correlation_id) ? $history->correlation_id : null;
 				$this->history_id = $history->id;
-				$this->type = $type;
-				$this->metadata = $metadata;
+				$this->type = !empty($history->creation_method) ? $history->creation_method : $type;
+				$this->metadata = $this->normalize_metadata($this->type, $metadata);
 				$this->is_persisted = true;
 				return;
 			}
@@ -96,7 +98,7 @@ class AIPS_History_Container {
 		$this->uuid = AIPS_Utilities::generate_uuid();
 		$this->history_id = null;
 		$this->type = $type;
-		$this->metadata = $metadata;
+		$this->metadata = $this->normalize_metadata($type, $metadata);
 		$this->is_persisted = false;
 		
 		// Persist to database immediately
@@ -183,6 +185,30 @@ class AIPS_History_Container {
 		return $history_container;
 	}
 	
+
+	/**
+	 * Normalize metadata so history type is always persisted in one field.
+	 *
+	 * @param string $type Container type.
+	 * @param array  $metadata Raw metadata.
+	 * @return array
+	 */
+	private function normalize_metadata($type, $metadata) {
+		if (!is_array($metadata)) {
+			$metadata = array();
+		}
+
+		if (empty($metadata['creation_method']) && !empty($type)) {
+			$metadata['creation_method'] = $type;
+		}
+
+		if (!empty($type)) {
+			$metadata['history_type'] = $type;
+		}
+
+		return $metadata;
+	}
+
 	/**
 	 * Persist this history container to the database
 	 *

--- a/ai-post-scheduler/includes/class-aips-history-service.php
+++ b/ai-post-scheduler/includes/class-aips-history-service.php
@@ -186,8 +186,9 @@ class AIPS_History_Service implements AIPS_History_Service_Interface {
 	 * @param array  $context Optional log context.
 	 * @return AIPS_History_Container
 	 */
-	public static function log_activity($history_type, $message, $event_type, $event_status, $metadata = array(), $context = array()) {
+	public static function log_activity($history_type, $message, $event_type = '', $event_status = '', $metadata = array(), $context = array()) {
 		$service = self::instance();
+		$event = self::normalize_event_context($event_type, $event_status, $context);
 
 		return $service->create_and_record(
 			$history_type,
@@ -195,12 +196,72 @@ class AIPS_History_Service implements AIPS_History_Service_Interface {
 			'activity',
 			$message,
 			array(
-				'event_type' => $event_type,
-				'event_status' => $event_status,
+				'event_type' => $event['event_type'],
+				'event_status' => $event['event_status'],
 			),
 			null,
-			$context
+			$event['context']
 		);
+	}
+
+	/**
+	 * Normalize event type/status and fold into context.
+	 *
+	 * @param string $event_type Event type.
+	 * @param string $event_status Event status.
+	 * @param array  $context Optional context.
+	 * @return array{event_type:string,event_status:string,context:array}
+	 */
+	public static function normalize_event_context($event_type = '', $event_status = '', $context = array()) {
+		if (!is_array($context)) {
+			$context = array();
+		}
+
+		$normalized_event_type = !empty($event_type) ? (string) $event_type : (isset($context['event_type']) ? (string) $context['event_type'] : 'activity');
+		$normalized_status = !empty($event_status) ? (string) $event_status : (isset($context['event_status']) ? (string) $context['event_status'] : 'success');
+
+		$context['event_type'] = $normalized_event_type;
+		$context['event_status'] = $normalized_status;
+
+		return array(
+			'event_type' => $normalized_event_type,
+			'event_status' => $normalized_status,
+			'context' => $context,
+		);
+	}
+
+	public static function log_success($history_type, $message, $event_type = '', $metadata = array(), $context = array()) {
+		return self::log_activity($history_type, $message, $event_type, 'success', $metadata, $context);
+	}
+
+	public static function log_failure($history_type, $message, $event_type = '', $metadata = array(), $context = array()) {
+		return self::log_activity($history_type, $message, $event_type, 'failed', $metadata, $context);
+	}
+
+	public static function log_warning($history_type, $message, $event_type = 'warning', $metadata = array(), $context = array()) {
+		$service = self::instance();
+		$event = self::normalize_event_context($event_type, 'warning', $context);
+
+		return $service->create_and_record(
+			$history_type,
+			self::build_metadata($history_type, $metadata),
+			'warning',
+			$message,
+			array(
+				'event_type' => $event['event_type'],
+				'event_status' => $event['event_status'],
+			),
+			null,
+			$event['context']
+		);
+	}
+
+	public static function log_user_action($history_type, $action, $message, $metadata = array(), $action_data = array()) {
+		$service = self::instance();
+		$history = $service->create($history_type, $metadata);
+		$history->record_user_action($action, $message, $action_data);
+
+		return $history;
 	}
 
 	/**

--- a/ai-post-scheduler/includes/class-aips-history-service.php
+++ b/ai-post-scheduler/includes/class-aips-history-service.php
@@ -71,7 +71,69 @@ class AIPS_History_Service implements AIPS_History_Service_Interface {
 	 * @return AIPS_History_Container History container object
 	 */
 	public function create($type, $metadata = array()) {
-		return new AIPS_History_Container($this->repository, $type, $metadata);
+		return new AIPS_History_Container($this->repository, $type, self::build_metadata($type, $metadata));
+	}
+
+	/**
+	 * Build normalized metadata for history containers.
+	 *
+	 * @param string $history_type Container type.
+	 * @param array  $metadata Optional metadata overrides.
+	 * @return array
+	 */
+	public static function build_metadata($history_type, $metadata = array()) {
+		if (!is_array($metadata)) {
+			$metadata = array();
+		}
+
+		$normalized = $metadata;
+
+		if (empty($normalized['creation_method']) && !empty($history_type)) {
+			$normalized['creation_method'] = $history_type;
+		}
+
+		if (empty($normalized['history_type']) && !empty($history_type)) {
+			$normalized['history_type'] = $history_type;
+		}
+
+		if (!isset($normalized['user_id']) && function_exists('get_current_user_id')) {
+			$user_id = get_current_user_id();
+			if ($user_id > 0) {
+				$normalized['user_id'] = $user_id;
+			}
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Get an existing history container when possible, or create one.
+	 *
+	 * @param string $history_type Container type.
+	 * @param array  $metadata Metadata for creation/lookup.
+	 * @param int    $history_id Optional existing history ID.
+	 * @param int    $post_id Optional post ID context for resolve fallback.
+	 * @return AIPS_History_Container
+	 */
+	public function get_or_create($history_type, $metadata = array(), $history_id = 0, $post_id = 0) {
+		$history_id = absint($history_id);
+		$post_id    = absint($post_id);
+
+		if ($history_id > 0) {
+			$existing = AIPS_History_Container::load_existing($this->repository, $history_id);
+			if ($existing) {
+				return $existing;
+			}
+		}
+
+		if ($post_id > 0) {
+			$resolved = AIPS_History_Container::resolve_existing($this->repository, $post_id, $history_id);
+			if (!is_wp_error($resolved)) {
+				return $resolved;
+			}
+		}
+
+		return $this->create($history_type, $metadata);
 	}
 
 	/**
@@ -129,7 +191,7 @@ class AIPS_History_Service implements AIPS_History_Service_Interface {
 
 		return $service->create_and_record(
 			$history_type,
-			$metadata,
+			self::build_metadata($history_type, $metadata),
 			'activity',
 			$message,
 			array(

--- a/ai-post-scheduler/includes/class-aips-history-service.php
+++ b/ai-post-scheduler/includes/class-aips-history-service.php
@@ -73,6 +73,92 @@ class AIPS_History_Service implements AIPS_History_Service_Interface {
 	public function create($type, $metadata = array()) {
 		return new AIPS_History_Container($this->repository, $type, $metadata);
 	}
+
+	/**
+	 * Create a history container and record a single log entry.
+	 *
+	 * @param string $history_type Container type.
+	 * @param array  $metadata Container metadata.
+	 * @param string $log_type Log type.
+	 * @param string $message Human readable message.
+	 * @param mixed  $input Optional input payload.
+	 * @param mixed  $output Optional output payload.
+	 * @param array  $context Optional context payload.
+	 * @return AIPS_History_Container
+	 */
+	public function create_and_record($history_type, $metadata, $log_type, $message, $input = null, $output = null, $context = array()) {
+		$history = $this->create($history_type, $metadata);
+		$history->record($log_type, $message, $input, $output, $context);
+
+		return $history;
+	}
+
+	/**
+	 * Create a history container, record a single entry, and complete success.
+	 *
+	 * @param string $history_type Container type.
+	 * @param array  $metadata Container metadata.
+	 * @param string $log_type Log type.
+	 * @param string $message Human readable message.
+	 * @param mixed  $input Optional input payload.
+	 * @param mixed  $output Optional output payload.
+	 * @param array  $context Optional context payload.
+	 * @param array  $result_data Optional completion payload.
+	 * @return AIPS_History_Container
+	 */
+	public function create_record_and_complete_success($history_type, $metadata, $log_type, $message, $input = null, $output = null, $context = array(), $result_data = array()) {
+		$history = $this->create_and_record($history_type, $metadata, $log_type, $message, $input, $output, $context);
+		$history->complete_success($result_data);
+
+		return $history;
+	}
+
+	/**
+	 * Static convenience wrapper for activity-style logs.
+	 *
+	 * @param string $history_type History container type.
+	 * @param string $message Human-readable message.
+	 * @param string $event_type Event type key.
+	 * @param string $event_status Event status key.
+	 * @param array  $metadata Optional container metadata.
+	 * @param array  $context Optional log context.
+	 * @return AIPS_History_Container
+	 */
+	public static function log_activity($history_type, $message, $event_type, $event_status, $metadata = array(), $context = array()) {
+		$service = self::instance();
+
+		return $service->create_and_record(
+			$history_type,
+			$metadata,
+			'activity',
+			$message,
+			array(
+				'event_type' => $event_type,
+				'event_status' => $event_status,
+			),
+			null,
+			$context
+		);
+	}
+
+	/**
+	 * Record on an existing container only when available.
+	 *
+	 * @param AIPS_History_Container|null $history History container.
+	 * @param string $log_type Log type.
+	 * @param string $message Message.
+	 * @param mixed $input Optional input.
+	 * @param mixed $output Optional output.
+	 * @param array $context Optional context.
+	 * @return int|false
+	 */
+	public static function record_on_container($history, $log_type, $message, $input = null, $output = null, $context = array()) {
+		if (!$history) {
+			return false;
+		}
+
+		return $history->record($log_type, $message, $input, $output, $context);
+	}
 	
 	/**
 	 * Get activity feed (high-level events)
@@ -145,7 +231,9 @@ class AIPS_History_Service implements AIPS_History_Service_Interface {
 		}
 
 		foreach ($history['items'] as $item) {
-			if (!empty($type) && isset($item->creation_method) && !empty($item->creation_method) && $item->creation_method !== $type) {
+			$item_type = isset($item->creation_method) ? (string) $item->creation_method : '';
+
+			if (!empty($type) && !empty($item_type) && $item_type !== $type) {
 				continue;
 			}
 

--- a/ai-post-scheduler/includes/class-aips-post-review.php
+++ b/ai-post-scheduler/includes/class-aips-post-review.php
@@ -151,6 +151,7 @@ class AIPS_Post_Review {
 		AIPS_Ajax_Response::success($draft_posts);
 	}
 	
+
 	/**
 	 * AJAX handler to publish a single post.
 	 */
@@ -160,68 +161,33 @@ class AIPS_Post_Review {
 		}
 		
 		if (!current_user_can('manage_options')) {
-			$history = $this->history_service->create('post_review_action', array());
-			$history->record(
-				'activity',
-				__('Post publish failed: Permission denied', 'ai-post-scheduler'),
-				array('event_type' => 'post_published', 'event_status' => 'failed'),
-				null,
-				array()
-			);
+			AIPS_History_Service::log_activity('post_review_action', __('Post publish failed: Permission denied', 'ai-post-scheduler'), 'post_published', 'failed');
 			AIPS_Ajax_Response::permission_denied();
 		}
 		
 		$post_id = isset($_POST['post_id']) ? absint($_POST['post_id']) : 0;
 		
 		if (!$post_id) {
-			$history = $this->history_service->create('post_review_action', array());
-			$history->record(
-				'activity',
-				__('Post publish failed: Invalid post ID', 'ai-post-scheduler'),
-				array('event_type' => 'post_published', 'event_status' => 'failed'),
-				null,
-				array()
-			);
+			AIPS_History_Service::log_activity('post_review_action', __('Post publish failed: Invalid post ID', 'ai-post-scheduler'), 'post_published', 'failed');
 			AIPS_Ajax_Response::error(__('Invalid post ID.', 'ai-post-scheduler'));
 		}
 		
 		// Verify the post exists and is a draft managed by this plugin
 		$post = get_post($post_id);
 		if (!$post || $post->post_status !== 'draft') {
-			$history = $this->history_service->create('post_review_action', array('post_id' => $post_id));
-			$history->record(
-				'activity',
-				__('Post publish failed: Post not found or not a draft', 'ai-post-scheduler'),
-				array('event_type' => 'post_published', 'event_status' => 'failed'),
-				null,
-				array('post_id' => $post_id)
-			);
+			AIPS_History_Service::log_activity('post_review_action', __('Post publish failed: Post not found or not a draft', 'ai-post-scheduler'), 'post_published', 'failed', array('post_id' => $post_id), array('post_id' => $post_id));
 			AIPS_Ajax_Response::error(__('Post not found or not a draft.', 'ai-post-scheduler'));
 		}
 		
 		// Verify the post is in the review queue (has a history record)
 		if (!$this->history_service->post_has_history_and_completed($post_id)) {
-			$history = $this->history_service->create('post_review_action', array('post_id' => $post_id));
-			$history->record(
-				'activity',
-				__('Post publish failed: Post not found in review queue', 'ai-post-scheduler'),
-				array('event_type' => 'post_published', 'event_status' => 'failed'),
-				null,
-				array('post_id' => $post_id)
-			);
+			AIPS_History_Service::log_activity('post_review_action', __('Post publish failed: Post not found in review queue', 'ai-post-scheduler'), 'post_published', 'failed', array('post_id' => $post_id), array('post_id' => $post_id));
 			AIPS_Ajax_Response::error(__('Post not found in review queue.', 'ai-post-scheduler'));
 		}
 		
 		// Check per-post capability
 		if (!current_user_can('publish_post', $post_id)) {
-			$history = $this->history_service->create('post_review_action', array('post_id' => $post_id));
-			$history->record(
-				'activity',
-				__('Post publish failed: Insufficient permissions', 'ai-post-scheduler'),
-				array('event_type' => 'post_published', 'event_status' => 'failed'),
-				null,
-				array('post_id' => $post_id)
-			);
+			AIPS_History_Service::log_activity('post_review_action', __('Post publish failed: Insufficient permissions', 'ai-post-scheduler'), 'post_published', 'failed', array('post_id' => $post_id), array('post_id' => $post_id));
 			AIPS_Ajax_Response::error(__('You do not have permission to publish this post.', 'ai-post-scheduler'));
 		}
 		
@@ -231,26 +197,12 @@ class AIPS_Post_Review {
 		));
 		
 		if (is_wp_error($result)) {
-			$history = $this->history_service->create('post_review_action', array('post_id' => $post_id));
-			$history->record(
-				'activity',
-				sprintf(__('Post publish failed: %s', 'ai-post-scheduler'), $result->get_error_message()),
-				array('event_type' => 'post_published', 'event_status' => 'failed'),
-				null,
-				array('post_id' => $post_id, 'error' => $result->get_error_message())
-			);
+			AIPS_History_Service::log_activity('post_review_action', sprintf(__('Post publish failed: %s', 'ai-post-scheduler'), $result->get_error_message()), 'post_published', 'failed', array('post_id' => $post_id), array('post_id' => $post_id, 'error' => $result->get_error_message()));
 			AIPS_Ajax_Response::error(array('message' => $result->get_error_message()));
 		}
 		
 		// Log the publish activity
-		$history = $this->history_service->create('post_review_action', array('post_id' => $post_id));
-		$history->record(
-			'activity',
-			__('Post published from review queue', 'ai-post-scheduler'),
-			array('event_type' => 'post_published', 'event_status' => 'success'),
-			null,
-			array('post_id' => $post_id)
-		);
+		AIPS_History_Service::log_activity('post_review_action', __('Post published from review queue', 'ai-post-scheduler'), 'post_published', 'success', array('post_id' => $post_id), array('post_id' => $post_id));
 		
 		/**
 		 * Fires after a post is published from the review queue.

--- a/ai-post-scheduler/includes/class-aips-settings-ajax.php
+++ b/ai-post-scheduler/includes/class-aips-settings-ajax.php
@@ -52,21 +52,20 @@ class AIPS_Settings_AJAX {
 		$options = array(
 			'maxTokens' => 20,
 		);
-		$history = $this->history_service->create(
+		$history = AIPS_History_Service::log_activity(
 			'settings_connection_test',
+			__('Testing AI connection from the settings screen.', 'ai-post-scheduler'),
+			'connection_test',
+			'started',
 			array(
 				'user_id' => get_current_user_id(),
-			)
-		);
-
-		$history->record(
-			'activity',
-			__('Testing AI connection from the settings screen.', 'ai-post-scheduler'),
+			),
 			array(
 				'source' => 'settings_ui',
 			)
 		);
-		$history->record(
+		AIPS_History_Service::record_on_container(
+			$history,
 			'ai_request',
 			__('Settings connection test prompt sent to AI.', 'ai-post-scheduler'),
 			array(
@@ -95,7 +94,8 @@ class AIPS_Settings_AJAX {
 			AIPS_Ajax_Response::error(array('message' => $result->get_error_message()));
 		}
 
-		$history->record(
+		AIPS_History_Service::record_on_container(
+			$history,
 			'ai_response',
 			__('Settings connection test response received.', 'ai-post-scheduler'),
 			null,

--- a/ai-post-scheduler/includes/class-aips-taxonomy-controller.php
+++ b/ai-post-scheduler/includes/class-aips-taxonomy-controller.php
@@ -154,7 +154,7 @@ class AIPS_Taxonomy_Controller {
 			AIPS_Ajax_Response::error(array('message' => $result->get_error_message()));
 		}
 
-		$history->record('activity', sprintf(__('Generated %d taxonomy items', 'ai-post-scheduler'), count($result)), null, null, array(
+		AIPS_History_Service::record_on_container($history, 'activity', sprintf(__('Generated %d taxonomy items', 'ai-post-scheduler'), count($result)), null, null, array(
 			'taxonomy_type' => $taxonomy_type,
 			'generated_count' => count($result)
 		));
@@ -352,14 +352,14 @@ class AIPS_Taxonomy_Controller {
 
 			// Log approval
 			if ($item) {
-				$history = $this->history_service->create('taxonomy_approval', array(
-					'item_id' => $item_id,
-				));
-				$history->record(
-					'activity',
+				AIPS_History_Service::log_activity(
+					'taxonomy_approval',
 					sprintf(__('Taxonomy item approved: "%s"', 'ai-post-scheduler'), $item->name),
-					array('event_type' => 'taxonomy_approved', 'event_status' => 'success'),
-					null,
+					'taxonomy_approved',
+					'success',
+					array(
+						'item_id' => $item_id,
+					),
 					array('item_id' => $item_id, 'item_name' => $item->name, 'taxonomy_type' => $item->taxonomy_type)
 				);
 			}
@@ -395,14 +395,14 @@ class AIPS_Taxonomy_Controller {
 
 			// Log rejection
 			if ($item) {
-				$history = $this->history_service->create('taxonomy_rejection', array(
-					'item_id' => $item_id,
-				));
-				$history->record(
-					'activity',
+				AIPS_History_Service::log_activity(
+					'taxonomy_rejection',
 					sprintf(__('Taxonomy item rejected: "%s"', 'ai-post-scheduler'), $item->name),
-					array('event_type' => 'taxonomy_rejected', 'event_status' => 'failed'),
-					null,
+					'taxonomy_rejected',
+					'failed',
+					array(
+						'item_id' => $item_id,
+					),
 					array('item_id' => $item_id, 'item_name' => $item->name, 'taxonomy_type' => $item->taxonomy_type)
 				);
 			}

--- a/ai-post-scheduler/tests/Test_AIPS_History_Service_Helpers.php
+++ b/ai-post-scheduler/tests/Test_AIPS_History_Service_Helpers.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Tests for AIPS_History_Service helper normalization.
+ *
+ * @package AI_Post_Scheduler
+ */
+
+class Test_AIPS_History_Service_Helpers extends WP_UnitTestCase {
+
+	public function test_build_metadata_adds_type_fields() {
+		$metadata = AIPS_History_Service::build_metadata(
+			'post_review_action',
+			array(
+				'post_id' => 123,
+				'user_id' => 77,
+			)
+		);
+
+		$this->assertSame('post_review_action', $metadata['creation_method']);
+		$this->assertSame('post_review_action', $metadata['history_type']);
+		$this->assertSame(123, $metadata['post_id']);
+		$this->assertSame(77, $metadata['user_id']);
+	}
+
+	public function test_normalize_event_context_defaults() {
+		$event = AIPS_History_Service::normalize_event_context('', '', array());
+
+		$this->assertSame('activity', $event['event_type']);
+		$this->assertSame('success', $event['event_status']);
+		$this->assertSame('activity', $event['context']['event_type']);
+		$this->assertSame('success', $event['context']['event_status']);
+	}
+
+	public function test_normalize_event_context_uses_explicit_values() {
+		$event = AIPS_History_Service::normalize_event_context(
+			'topic_rejected',
+			'failed',
+			array(
+				'topic_id' => 22,
+			)
+		);
+
+		$this->assertSame('topic_rejected', $event['event_type']);
+		$this->assertSame('failed', $event['event_status']);
+		$this->assertSame(22, $event['context']['topic_id']);
+	}
+}
+


### PR DESCRIPTION
### Motivation
- Centralize and simplify how history events are recorded so callers can log activity without duplicating container creation or null checks.
- Ensure history container metadata and type are normalized and consistently persisted so searches and reporting behave reliably.

### Description
- Added convenience APIs to `AIPS_History_Service`: `create_and_record`, `create_record_and_complete_success`, `log_activity`, and `record_on_container` to simplify creating containers and recording entries or recording on existing containers safely.
- Updated many callers to use the new static helpers (`AIPS_History_Service::log_activity` and `::record_on_container`) across controllers and services (author topics, taxonomy, post review, settings AJAX, generator, bulk operations) to remove duplicated container logic and to avoid recording when no container exists.
- Modified `AIPS_History_Container` to normalize metadata via a new `normalize_metadata` method, persist a unified `creation_method`/`history_type` field, and resolve the metadata earlier during construction (including when loading existing histories).
- Adjusted history lookup logic in `AIPS_History_Service::find_incomplete` to use the normalized creation method field when filtering by type.
- Replaced in-place container `record` calls with `record_on_container` static wrapper where appropriate and updated log payloads to include explicit event type/status and contextual fields.

### Testing
- Ran the plugin unit test suite and integration tests for history and AJAX flows, and they completed successfully.
- Executed PHP linting and static analysis checks, which passed without new issues.
- Ran automated end-to-end AJAX endpoint tests for the modified controllers and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffd753b4a48321be6a49697738936d)