### PR TITLE
Refactor history logging: add AIPS_History_Service helpers and normalize metadata

### DIFF
--- a/ai-post-scheduler/includes/class-aips-author-topics-controller.php
+++ b/ai-post-scheduler/includes/class-aips-author-topics-controller.php
@@ -168,20 +168,16 @@ class AIPS_Author_Topics_Controller {
 
 			// Log to activity feed using History Container
 			if ($topic) {
-				$approve_history = $this->history_service->create('topic_approval', array(
-					'topic_id' => $topic_id,
-				));
-				$approve_history->record(
-					'activity',
+				AIPS_History_Service::log_success(
+					'topic_approval',
 					sprintf(
 						__('Topic approved: "%s"', 'ai-post-scheduler'),
 						$topic->topic_title
 					),
+					'topic_approved',
 					array(
-						'event_type' => 'topic_approved',
-						'event_status' => 'success',
+						'topic_id' => $topic_id,
 					),
-					null,
 					array(
 						'topic_id' => $topic_id,
 						'topic_title' => $topic->topic_title,
@@ -238,20 +234,16 @@ class AIPS_Author_Topics_Controller {
 
 			// Log to activity feed using History Container
 			if ($topic) {
-				$reject_history = $this->history_service->create('topic_rejection', array(
-					'topic_id' => $topic_id,
-				));
-				$reject_history->record(
-					'activity',
+				AIPS_History_Service::log_failure(
+					'topic_rejection',
 					sprintf(
 						__('Topic rejected: "%s"', 'ai-post-scheduler'),
 						$topic->topic_title
 					),
+					'topic_rejected',
 					array(
-						'event_type' => 'topic_rejected',
-						'event_status' => 'failed',
+						'topic_id' => $topic_id,
 					),
-					null,
 					array(
 						'topic_id' => $topic_id,
 						'topic_title' => $topic->topic_title,
@@ -361,7 +353,7 @@ class AIPS_Author_Topics_Controller {
 		}
 
 		// Create history container for manual generation
-		$history = $this->history_service->create('manual_generation', array(
+		$history = $this->history_service->get_or_create('manual_generation', array(
 			'topic_id' => $topic_id,
 			'user_id' => get_current_user_id(),
 			'source' => 'manual_ui',
@@ -386,7 +378,7 @@ class AIPS_Author_Topics_Controller {
 			AIPS_Ajax_Response::error(array('message' => $result->get_error_message()));
 		}
 
-		$history->record('activity', __('Post generated successfully from topic', 'ai-post-scheduler'), null, null, array(
+		AIPS_History_Service::record_on_container($history, 'activity', __('Post generated successfully from topic', 'ai-post-scheduler'), null, null, array(
 			'post_id' => $result,
 			'topic_id' => $topic_id
 		));
@@ -536,7 +528,7 @@ class AIPS_Author_Topics_Controller {
 		}
 
 		// Create history container for bulk delete operation
-		$history = $this->history_service->create('bulk_delete', array(
+		$history = $this->history_service->get_or_create('bulk_delete', array(
 			'user_id' => get_current_user_id(),
 			'source' => 'manual_ui',
 			'trigger' => 'ajax_bulk_delete_topics',
@@ -558,11 +550,11 @@ class AIPS_Author_Topics_Controller {
 				$success_count++;
 			} else {
 				$failed_count++;
-				$history->record('warning', sprintf(__('Failed to delete topic ID %d', 'ai-post-scheduler'), $topic_id), null, null, array('topic_id' => $topic_id));
+				AIPS_History_Service::record_on_container($history, 'warning', sprintf(__('Failed to delete topic ID %d', 'ai-post-scheduler'), $topic_id), null, null, array('topic_id' => $topic_id, 'event_type' => 'bulk_delete_topics', 'event_status' => 'warning'));
 			}
 		}
 
-		$history->record('activity', sprintf(__('Deleted %d topics', 'ai-post-scheduler'), $success_count), null, null, array(
+		AIPS_History_Service::record_on_container($history, 'activity', sprintf(__('Deleted %d topics', 'ai-post-scheduler'), $success_count), null, null, array(
 			'deleted_count' => $success_count,
 			'requested_count' => count($topic_ids)
 		));
@@ -602,7 +594,7 @@ class AIPS_Author_Topics_Controller {
 		}
 
 		// Create history container for regeneration
-		$history = $this->history_service->create('manual_regeneration', array(
+		$history = $this->history_service->get_or_create('manual_regeneration', array(
 			'user_id' => get_current_user_id(),
 			'source' => 'manual_ui',
 			'trigger' => 'ajax_regenerate_post',
@@ -628,7 +620,7 @@ class AIPS_Author_Topics_Controller {
 			AIPS_Ajax_Response::error(array('message' => $result->get_error_message()));
 		}
 
-		$history->record('activity', __('Post regenerated successfully', 'ai-post-scheduler'), null, null, array(
+		AIPS_History_Service::record_on_container($history, 'activity', __('Post regenerated successfully', 'ai-post-scheduler'), null, null, array(
 			'post_id' => $result,
 			'original_post_id' => $post_id,
 			'topic_id' => $topic_id
@@ -1046,7 +1038,7 @@ class AIPS_Author_Topics_Controller {
 		}
 
 		// Create history container for bulk delete operation
-		$history = $this->history_service->create('bulk_delete_feedback', array(
+		$history = $this->history_service->get_or_create('bulk_delete_feedback', array(
 			'user_id' => get_current_user_id(),
 			'source' => 'manual_ui',
 			'trigger' => 'ajax_bulk_delete_feedback',
@@ -1068,11 +1060,11 @@ class AIPS_Author_Topics_Controller {
 				$success_count++;
 			} else {
 				$failed_count++;
-				$history->record('warning', sprintf(__('Failed to delete feedback ID %d', 'ai-post-scheduler'), $feedback_id), null, null, array('feedback_id' => $feedback_id));
+				AIPS_History_Service::record_on_container($history, 'warning', sprintf(__('Failed to delete feedback ID %d', 'ai-post-scheduler'), $feedback_id), null, null, array('feedback_id' => $feedback_id));
 			}
 		}
 
-		$history->record('activity', sprintf(__('Deleted %d feedback items', 'ai-post-scheduler'), $success_count), null, null, array(
+		AIPS_History_Service::record_on_container($history, 'activity', sprintf(__('Deleted %d feedback items', 'ai-post-scheduler'), $success_count), null, null, array(
 			'deleted_count' => $success_count,
 			'requested_count' => count($feedback_ids)
 		));

--- a/ai-post-scheduler/includes/class-aips-generator.php
+++ b/ai-post-scheduler/includes/class-aips-generator.php
@@ -128,18 +128,17 @@ class AIPS_Generator {
      */
     public function generate_content($prompt, $options = array(), $log_type = 'content') {
         // Log AI request before making the call
-        if ($this->current_history) {
-            $this->current_history->record(
-                'ai_request',
-                "Requesting AI generation for {$log_type}",
-                array(
-                    'prompt' => $prompt,
-                    'options' => $options,
-                ),
-                null,
-                array('component' => $log_type)
-            );
-        }
+        AIPS_History_Service::record_on_container(
+            $this->current_history,
+            'ai_request',
+            "Requesting AI generation for {$log_type}",
+            array(
+                'prompt' => $prompt,
+                'options' => $options,
+            ),
+            null,
+            array('component' => $log_type)
+        );
 
         // Forward the request type so AIPS_AI_Service can calculate maxTokens correctly.
         // Only set it when the caller has not already provided an explicit token override.
@@ -155,18 +154,17 @@ class AIPS_Generator {
 
         if (is_wp_error($result)) {
             // Log the error
-            if ($this->current_history) {
-                $this->current_history->record(
-                    'error',
-                    "AI generation failed for {$log_type}: " . $result->get_error_message(),
-                    array(
-                        'prompt' => $prompt,
-                        'options' => $options,
-                    ),
-                    null,
-                    array('component' => $log_type, 'error' => $result->get_error_message())
-                );
-            }
+            AIPS_History_Service::record_on_container(
+                $this->current_history,
+                'error',
+                "AI generation failed for {$log_type}: " . $result->get_error_message(),
+                array(
+                    'prompt' => $prompt,
+                    'options' => $options,
+                ),
+                null,
+                array('component' => $log_type, 'error' => $result->get_error_message())
+            );
 
             $this->logger->log($result->get_error_message(), 'error', array(
                 'component'      => $log_type,
@@ -174,15 +172,14 @@ class AIPS_Generator {
             ));
         } else {
             // Log successful AI response
-            if ($this->current_history) {
-                $this->current_history->record(
-                    'ai_response',
-                    "AI generation successful for {$log_type}",
-                    null,
-                    $result,
-                    array('component' => $log_type)
-                );
-            }
+            AIPS_History_Service::record_on_container(
+                $this->current_history,
+                'ai_response',
+                "AI generation successful for {$log_type}",
+                null,
+                $result,
+                array('component' => $log_type)
+            );
 
             $this->logger->log('Content generated successfully', 'info', array(
                 'component'       => $log_type,

--- a/ai-post-scheduler/includes/class-aips-history-container.php
+++ b/ai-post-scheduler/includes/class-aips-history-container.php
@@ -72,6 +72,8 @@ class AIPS_History_Container {
 		$this->repository = $repository;
 		$this->session = null;
 		
+		$this->metadata = $this->normalize_metadata($type, $metadata);
+
 		if ($existing_history_id) {
 			// Load existing history container
 			$history = $repository->get_by_id($existing_history_id);
@@ -79,8 +81,8 @@ class AIPS_History_Container {
 				$this->uuid = $history->uuid;
 				$this->correlation_id = isset($history->correlation_id) ? $history->correlation_id : null;
 				$this->history_id = $history->id;
-				$this->type = $type;
-				$this->metadata = $metadata;
+				$this->type = !empty($history->creation_method) ? $history->creation_method : $type;
+				$this->metadata = $this->normalize_metadata($this->type, $metadata);
 				$this->is_persisted = true;
 				return;
 			}
@@ -96,7 +98,7 @@ class AIPS_History_Container {
 		$this->uuid = AIPS_Utilities::generate_uuid();
 		$this->history_id = null;
 		$this->type = $type;
-		$this->metadata = $metadata;
+		$this->metadata = $this->normalize_metadata($type, $metadata);
 		$this->is_persisted = false;
 		
 		// Persist to database immediately
@@ -183,6 +185,30 @@ class AIPS_History_Container {
 		return $history_container;
 	}
 	
+
+	/**
+	 * Normalize metadata so history type is always persisted in one field.
+	 *
+	 * @param string $type Container type.
+	 * @param array  $metadata Raw metadata.
+	 * @return array
+	 */
+	private function normalize_metadata($type, $metadata) {
+		if (!is_array($metadata)) {
+			$metadata = array();
+		}
+
+		if (empty($metadata['creation_method']) && !empty($type)) {
+			$metadata['creation_method'] = $type;
+		}
+
+		if (!empty($type)) {
+			$metadata['history_type'] = $type;
+		}
+
+		return $metadata;
+	}
+
 	/**
 	 * Persist this history container to the database
 	 *

--- a/ai-post-scheduler/includes/class-aips-history-service.php
+++ b/ai-post-scheduler/includes/class-aips-history-service.php
@@ -20,6 +20,9 @@ if (!defined('ABSPATH')) {
  * managing sessions, and updating history records.
  */
 class AIPS_History_Service implements AIPS_History_Service_Interface {
+	const EVENT_TYPE_KEY   = 'event_type';
+	const EVENT_STATUS_KEY = 'event_status';
+	const EVENT_SOURCE_KEY = 'source';
 
 	/**
 	 * @var self|null Singleton instance.
@@ -71,7 +74,262 @@ class AIPS_History_Service implements AIPS_History_Service_Interface {
 	 * @return AIPS_History_Container History container object
 	 */
 	public function create($type, $metadata = array()) {
-		return new AIPS_History_Container($this->repository, $type, $metadata);
+		return new AIPS_History_Container($this->repository, $type, self::build_metadata($type, $metadata));
+	}
+
+	/**
+	 * Build normalized metadata for history containers.
+	 *
+	 * @param string $history_type Container type.
+	 * @param array  $metadata Optional metadata overrides.
+	 * @return array
+	 */
+	public static function build_metadata($history_type, $metadata = array()) {
+		if (!is_array($metadata)) {
+			$metadata = array();
+		}
+
+		$normalized = $metadata;
+
+		if (empty($normalized['creation_method']) && !empty($history_type)) {
+			$normalized['creation_method'] = $history_type;
+		}
+
+		if (empty($normalized['history_type']) && !empty($history_type)) {
+			$normalized['history_type'] = $history_type;
+		}
+
+		if (!isset($normalized['user_id']) && function_exists('get_current_user_id')) {
+			$user_id = get_current_user_id();
+			if ($user_id > 0) {
+				$normalized['user_id'] = $user_id;
+			}
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Get an existing history container when possible, or create one.
+	 *
+	 * @param string $history_type Container type.
+	 * @param array  $metadata Metadata for creation/lookup.
+	 * @param int    $history_id Optional existing history ID.
+	 * @param int    $post_id Optional post ID context for resolve fallback.
+	 * @return AIPS_History_Container
+	 */
+	public function get_or_create($history_type, $metadata = array(), $history_id = 0, $post_id = 0) {
+		$history_id = absint($history_id);
+		$post_id    = absint($post_id);
+
+		if ($history_id > 0) {
+			$existing = AIPS_History_Container::load_existing($this->repository, $history_id);
+			if ($existing) {
+				return $existing;
+			}
+		}
+
+		if ($post_id > 0) {
+			$resolved = AIPS_History_Container::resolve_existing($this->repository, $post_id, $history_id);
+			if (!is_wp_error($resolved)) {
+				return $resolved;
+			}
+		}
+
+		return $this->create($history_type, $metadata);
+	}
+
+	/**
+	 * Create a history container and record a single log entry.
+	 *
+	 * @param string $history_type Container type.
+	 * @param array  $metadata Container metadata.
+	 * @param string $log_type Log type.
+	 * @param string $message Human readable message.
+	 * @param mixed  $input Optional input payload.
+	 * @param mixed  $output Optional output payload.
+	 * @param array  $context Optional context payload.
+	 * @return AIPS_History_Container
+	 */
+	public function create_and_record($history_type, $metadata, $log_type, $message, $input = null, $output = null, $context = array()) {
+		$history = $this->create($history_type, $metadata);
+		$history->record($log_type, $message, $input, $output, $context);
+
+		return $history;
+	}
+
+	/**
+	 * Create a history container, record a single entry, and complete success.
+	 *
+	 * @param string $history_type Container type.
+	 * @param array  $metadata Container metadata.
+	 * @param string $log_type Log type.
+	 * @param string $message Human readable message.
+	 * @param mixed  $input Optional input payload.
+	 * @param mixed  $output Optional output payload.
+	 * @param array  $context Optional context payload.
+	 * @param array  $result_data Optional completion payload.
+	 * @return AIPS_History_Container
+	 */
+	public function create_record_and_complete_success($history_type, $metadata, $log_type, $message, $input = null, $output = null, $context = array(), $result_data = array()) {
+		$history = $this->create_and_record($history_type, $metadata, $log_type, $message, $input, $output, $context);
+		$history->complete_success($result_data);
+
+		return $history;
+	}
+
+	/**
+	 * Static convenience wrapper for activity-style logs.
+	 *
+	 * @param string $history_type History container type.
+	 * @param string $message Human-readable message.
+	 * @param string $event_type Event type key.
+	 * @param string $event_status Event status key.
+	 * @param array  $metadata Optional container metadata.
+	 * @param array  $context Optional log context.
+	 * @return AIPS_History_Container
+	 */
+	public static function log_activity($history_type, $message, $event_type = '', $event_status = '', $metadata = array(), $context = array()) {
+		return self::log_event(
+			array(
+				'history_type' => $history_type,
+				'message' => $message,
+				'log_type' => 'activity',
+				'event_type' => $event_type,
+				'event_status' => $event_status,
+				'metadata' => $metadata,
+				'context' => $context,
+			)
+		);
+	}
+
+	/**
+	 * Named-argument event logger to avoid positional arg overload.
+	 *
+	 * @param array $args Event logging args.
+	 * @return AIPS_History_Container
+	 */
+	public static function log_event($args = array()) {
+		$args = wp_parse_args(
+			$args,
+			array(
+				'history_type' => '',
+				'message' => '',
+				'log_type' => 'activity',
+				'event_type' => '',
+				'event_status' => '',
+				'metadata' => array(),
+				'context' => array(),
+				'input' => null,
+				'output' => null,
+				'complete' => '',
+				'result_data' => array(),
+				'history_id' => 0,
+				'post_id' => 0,
+			)
+		);
+
+		$service = self::instance();
+		$event = self::normalize_event_context($args['event_type'], $args['event_status'], $args['context']);
+		$metadata = self::build_metadata($args['history_type'], $args['metadata']);
+		$history = $service->get_or_create($args['history_type'], $metadata, $args['history_id'], $args['post_id']);
+
+		$history->record(
+			$args['log_type'],
+			$args['message'],
+			$args['input'] !== null ? $args['input'] : array(
+				self::EVENT_TYPE_KEY => $event['event_type'],
+				self::EVENT_STATUS_KEY => $event['event_status'],
+			),
+			$args['output'],
+			$event['context']
+		);
+
+		if ($args['complete'] === 'success') {
+			$history->complete_success($args['result_data']);
+		} elseif ($args['complete'] === 'failed') {
+			$history->complete_failure(
+				isset($args['result_data']['error_message']) ? $args['result_data']['error_message'] : '',
+				$args['result_data']
+			);
+		}
+
+		return $history;
+	}
+
+	/**
+	 * Normalize event type/status and fold into context.
+	 *
+	 * @param string $event_type Event type.
+	 * @param string $event_status Event status.
+	 * @param array  $context Optional context.
+	 * @return array{event_type:string,event_status:string,context:array}
+	 */
+	public static function normalize_event_context($event_type = '', $event_status = '', $context = array()) {
+		if (!is_array($context)) {
+			$context = array();
+		}
+
+		$normalized_event_type = !empty($event_type) ? (string) $event_type : (isset($context['event_type']) ? (string) $context['event_type'] : 'activity');
+		$normalized_status = !empty($event_status) ? (string) $event_status : (isset($context['event_status']) ? (string) $context['event_status'] : 'success');
+
+		$context[self::EVENT_TYPE_KEY] = $normalized_event_type;
+		$context[self::EVENT_STATUS_KEY] = $normalized_status;
+
+		return array(
+			'event_type' => $normalized_event_type,
+			'event_status' => $normalized_status,
+			'context' => $context,
+		);
+	}
+
+	public static function log_success($history_type, $message, $event_type = '', $metadata = array(), $context = array()) {
+		return self::log_activity($history_type, $message, $event_type, 'success', $metadata, $context);
+	}
+
+	public static function log_failure($history_type, $message, $event_type = '', $metadata = array(), $context = array()) {
+		return self::log_activity($history_type, $message, $event_type, 'failed', $metadata, $context);
+	}
+
+	public static function log_warning($history_type, $message, $event_type = 'warning', $metadata = array(), $context = array()) {
+		return self::log_event(
+			array(
+				'history_type' => $history_type,
+				'message' => $message,
+				'log_type' => 'warning',
+				'event_type' => $event_type,
+				'event_status' => 'warning',
+				'metadata' => $metadata,
+				'context' => $context,
+			)
+		);
+	}
+
+	public static function log_user_action($history_type, $action, $message, $metadata = array(), $action_data = array()) {
+		$service = self::instance();
+		$history = $service->create($history_type, $metadata);
+		$history->record_user_action($action, $message, $action_data);
+
+		return $history;
+	}
+
+	/**
+	 * Record on an existing container only when available.
+	 *
+	 * @param AIPS_History_Container|null $history History container.
+	 * @param string $log_type Log type.
+	 * @param string $message Message.
+	 * @param mixed $input Optional input.
+	 * @param mixed $output Optional output.
+	 * @param array $context Optional context.
+	 * @return int|false
+	 */
+	public static function record_on_container($history, $log_type, $message, $input = null, $output = null, $context = array()) {
+		if (!$history) {
+			return false;
+		}
+
+		return $history->record($log_type, $message, $input, $output, $context);
 	}
 	
 	/**
@@ -145,7 +403,9 @@ class AIPS_History_Service implements AIPS_History_Service_Interface {
 		}
 
 		foreach ($history['items'] as $item) {
-			if (!empty($type) && isset($item->creation_method) && !empty($item->creation_method) && $item->creation_method !== $type) {
+			$item_type = isset($item->creation_method) ? (string) $item->creation_method : '';
+
+			if (!empty($type) && !empty($item_type) && $item_type !== $type) {
 				continue;
 			}
 

--- a/ai-post-scheduler/includes/class-aips-notifications.php
+++ b/ai-post-scheduler/includes/class-aips-notifications.php
@@ -471,16 +471,12 @@ class AIPS_Notifications {
 		$sent = wp_mail($to_email, $subject, $body, $headers);
 
 		if ($sent) {
-			$history = $this->history_service->create('notification_sent', array());
-			$history->record(
-				'activity',
+			AIPS_History_Service::log_success(
+				'notification_sent',
 				/* translators: %s: recipient email address */
 				sprintf(__('Notification email sent to %s', 'ai-post-scheduler'), $to_email),
-				array(
-					'event_type'   => 'notification_email_sent',
-					'event_status' => 'success',
-				),
-				null,
+				'notification_email_sent',
+				array(),
 				array(
 					'notification_type' => $template->get_type(),
 					'to_email'          => $to_email,
@@ -490,16 +486,12 @@ class AIPS_Notifications {
 			return true;
 		}
 
-		$history = $this->history_service->create('notification_sent', array());
-		$history->record(
-			'activity',
+		AIPS_History_Service::log_failure(
+			'notification_sent',
 			/* translators: %s: recipient email address */
 			sprintf(__('Notification email failed for %s', 'ai-post-scheduler'), $to_email),
-			array(
-				'event_type'   => 'notification_email_sent',
-				'event_status' => 'failed',
-			),
-			null,
+			'notification_email_sent',
+			array(),
 			array(
 				'notification_type' => $template->get_type(),
 				'to_email'          => $to_email,

--- a/ai-post-scheduler/includes/class-aips-post-review.php
+++ b/ai-post-scheduler/includes/class-aips-post-review.php
@@ -151,6 +151,7 @@ class AIPS_Post_Review {
 		AIPS_Ajax_Response::success($draft_posts);
 	}
 	
+
 	/**
 	 * AJAX handler to publish a single post.
 	 */
@@ -160,68 +161,33 @@ class AIPS_Post_Review {
 		}
 		
 		if (!current_user_can('manage_options')) {
-			$history = $this->history_service->create('post_review_action', array());
-			$history->record(
-				'activity',
-				__('Post publish failed: Permission denied', 'ai-post-scheduler'),
-				array('event_type' => 'post_published', 'event_status' => 'failed'),
-				null,
-				array()
-			);
+			AIPS_History_Service::log_activity('post_review_action', __('Post publish failed: Permission denied', 'ai-post-scheduler'), 'post_published', 'failed');
 			AIPS_Ajax_Response::permission_denied();
 		}
 		
 		$post_id = isset($_POST['post_id']) ? absint($_POST['post_id']) : 0;
 		
 		if (!$post_id) {
-			$history = $this->history_service->create('post_review_action', array());
-			$history->record(
-				'activity',
-				__('Post publish failed: Invalid post ID', 'ai-post-scheduler'),
-				array('event_type' => 'post_published', 'event_status' => 'failed'),
-				null,
-				array()
-			);
+			AIPS_History_Service::log_activity('post_review_action', __('Post publish failed: Invalid post ID', 'ai-post-scheduler'), 'post_published', 'failed');
 			AIPS_Ajax_Response::error(__('Invalid post ID.', 'ai-post-scheduler'));
 		}
 		
 		// Verify the post exists and is a draft managed by this plugin
 		$post = get_post($post_id);
 		if (!$post || $post->post_status !== 'draft') {
-			$history = $this->history_service->create('post_review_action', array('post_id' => $post_id));
-			$history->record(
-				'activity',
-				__('Post publish failed: Post not found or not a draft', 'ai-post-scheduler'),
-				array('event_type' => 'post_published', 'event_status' => 'failed'),
-				null,
-				array('post_id' => $post_id)
-			);
+			AIPS_History_Service::log_activity('post_review_action', __('Post publish failed: Post not found or not a draft', 'ai-post-scheduler'), 'post_published', 'failed', array('post_id' => $post_id), array('post_id' => $post_id));
 			AIPS_Ajax_Response::error(__('Post not found or not a draft.', 'ai-post-scheduler'));
 		}
 		
 		// Verify the post is in the review queue (has a history record)
 		if (!$this->history_service->post_has_history_and_completed($post_id)) {
-			$history = $this->history_service->create('post_review_action', array('post_id' => $post_id));
-			$history->record(
-				'activity',
-				__('Post publish failed: Post not found in review queue', 'ai-post-scheduler'),
-				array('event_type' => 'post_published', 'event_status' => 'failed'),
-				null,
-				array('post_id' => $post_id)
-			);
+			AIPS_History_Service::log_activity('post_review_action', __('Post publish failed: Post not found in review queue', 'ai-post-scheduler'), 'post_published', 'failed', array('post_id' => $post_id), array('post_id' => $post_id));
 			AIPS_Ajax_Response::error(__('Post not found in review queue.', 'ai-post-scheduler'));
 		}
 		
 		// Check per-post capability
 		if (!current_user_can('publish_post', $post_id)) {
-			$history = $this->history_service->create('post_review_action', array('post_id' => $post_id));
-			$history->record(
-				'activity',
-				__('Post publish failed: Insufficient permissions', 'ai-post-scheduler'),
-				array('event_type' => 'post_published', 'event_status' => 'failed'),
-				null,
-				array('post_id' => $post_id)
-			);
+			AIPS_History_Service::log_activity('post_review_action', __('Post publish failed: Insufficient permissions', 'ai-post-scheduler'), 'post_published', 'failed', array('post_id' => $post_id), array('post_id' => $post_id));
 			AIPS_Ajax_Response::error(__('You do not have permission to publish this post.', 'ai-post-scheduler'));
 		}
 		
@@ -231,26 +197,12 @@ class AIPS_Post_Review {
 		));
 		
 		if (is_wp_error($result)) {
-			$history = $this->history_service->create('post_review_action', array('post_id' => $post_id));
-			$history->record(
-				'activity',
-				sprintf(__('Post publish failed: %s', 'ai-post-scheduler'), $result->get_error_message()),
-				array('event_type' => 'post_published', 'event_status' => 'failed'),
-				null,
-				array('post_id' => $post_id, 'error' => $result->get_error_message())
-			);
+			AIPS_History_Service::log_activity('post_review_action', sprintf(__('Post publish failed: %s', 'ai-post-scheduler'), $result->get_error_message()), 'post_published', 'failed', array('post_id' => $post_id), array('post_id' => $post_id, 'error' => $result->get_error_message()));
 			AIPS_Ajax_Response::error(array('message' => $result->get_error_message()));
 		}
 		
 		// Log the publish activity
-		$history = $this->history_service->create('post_review_action', array('post_id' => $post_id));
-		$history->record(
-			'activity',
-			__('Post published from review queue', 'ai-post-scheduler'),
-			array('event_type' => 'post_published', 'event_status' => 'success'),
-			null,
-			array('post_id' => $post_id)
-		);
+		AIPS_History_Service::log_activity('post_review_action', __('Post published from review queue', 'ai-post-scheduler'), 'post_published', 'success', array('post_id' => $post_id), array('post_id' => $post_id));
 		
 		/**
 		 * Fires after a post is published from the review queue.
@@ -274,14 +226,7 @@ class AIPS_Post_Review {
 		}
 		
 		if (!current_user_can('manage_options')) {
-			$history = $this->history_service->create('post_review_action', array());
-			$history->record(
-				'activity',
-				__('Bulk publish failed: Permission denied', 'ai-post-scheduler'),
-				array('event_type' => 'post_published', 'event_status' => 'failed'),
-				null,
-				array()
-			);
+			AIPS_History_Service::log_failure('post_review_action', __('Bulk publish failed: Permission denied', 'ai-post-scheduler'), 'post_published');
 			AIPS_Ajax_Response::permission_denied();
 		}
 		
@@ -297,14 +242,7 @@ class AIPS_Post_Review {
 		}
 		
 		if (empty($post_ids)) {
-			$history = $this->history_service->create('post_review_action', array());
-			$history->record(
-				'activity',
-				__('Bulk publish failed: No posts selected', 'ai-post-scheduler'),
-				array('event_type' => 'post_published', 'event_status' => 'failed'),
-				null,
-				array()
-			);
+			AIPS_History_Service::log_failure('post_review_action', __('Bulk publish failed: No posts selected', 'ai-post-scheduler'), 'post_published');
 			AIPS_Ajax_Response::error(__('No posts selected.', 'ai-post-scheduler'));
 		}
 		
@@ -316,42 +254,21 @@ class AIPS_Post_Review {
 			$post = get_post($post_id);
 			if (!$post || $post->post_status !== 'draft') {
 				$failed_count++;
-				$history = $this->history_service->create('post_review_action', array('post_id' => $post_id));
-				$history->record(
-					'activity',
-					__('Bulk publish failed: Post not found or not a draft', 'ai-post-scheduler'),
-					array('event_type' => 'post_published', 'event_status' => 'failed'),
-					null,
-					array('post_id' => $post_id)
-				);
+				AIPS_History_Service::log_failure('post_review_action', __('Bulk publish failed: Post not found or not a draft', 'ai-post-scheduler'), 'post_published', array('post_id' => $post_id), array('post_id' => $post_id));
 				continue;
 			}
 			
 			// Verify the post is in the review queue
 			if (!$this->history_service->post_has_history_and_completed($post_id)) {
 				$failed_count++;
-				$history = $this->history_service->create('post_review_action', array('post_id' => $post_id));
-				$history->record(
-					'activity',
-					__('Bulk publish failed: Post not in review queue', 'ai-post-scheduler'),
-					array('event_type' => 'post_published', 'event_status' => 'failed'),
-					null,
-					array('post_id' => $post_id)
-				);
+				AIPS_History_Service::log_failure('post_review_action', __('Bulk publish failed: Post not in review queue', 'ai-post-scheduler'), 'post_published', array('post_id' => $post_id), array('post_id' => $post_id));
 				continue;
 			}
 			
 			// Check per-post capability
 			if (!current_user_can('publish_post', $post_id)) {
 				$failed_count++;
-				$history = $this->history_service->create('post_review_action', array('post_id' => $post_id));
-				$history->record(
-					'activity',
-					__('Bulk publish failed: Insufficient permissions', 'ai-post-scheduler'),
-					array('event_type' => 'post_published', 'event_status' => 'failed'),
-					null,
-					array('post_id' => $post_id)
-				);
+				AIPS_History_Service::log_failure('post_review_action', __('Bulk publish failed: Insufficient permissions', 'ai-post-scheduler'), 'post_published', array('post_id' => $post_id), array('post_id' => $post_id));
 				continue;
 			}
 			
@@ -364,14 +281,7 @@ class AIPS_Post_Review {
 				$success_count++;
 				
 				// Log the publish activity
-				$history = $this->history_service->create('post_review_action', array('post_id' => $post_id));
-				$history->record(
-					'activity',
-					__('Post published from review queue (bulk)', 'ai-post-scheduler'),
-					array('event_type' => 'post_published', 'event_status' => 'success'),
-					null,
-					array('post_id' => $post_id)
-				);
+				AIPS_History_Service::log_success('post_review_action', __('Post published from review queue (bulk)', 'ai-post-scheduler'), 'post_published', array('post_id' => $post_id), array('post_id' => $post_id));
 				
 				/**
 				 * Fires after a post is published from the review queue.
@@ -381,14 +291,7 @@ class AIPS_Post_Review {
 				do_action('aips_post_review_published', $post_id);
 			} else {
 				$failed_count++;
-				$history = $this->history_service->create('post_review_action', array('post_id' => $post_id));
-				$history->record(
-					'activity',
-					sprintf(__('Bulk publish failed: %s', 'ai-post-scheduler'), $result->get_error_message()),
-					array('event_type' => 'post_published', 'event_status' => 'failed'),
-					null,
-					array('post_id' => $post_id, 'error' => $result->get_error_message())
-				);
+				AIPS_History_Service::log_failure('post_review_action', sprintf(__('Bulk publish failed: %s', 'ai-post-scheduler'), $result->get_error_message()), 'post_published', array('post_id' => $post_id), array('post_id' => $post_id, 'error' => $result->get_error_message()));
 			}
 		}
 		
@@ -453,29 +356,13 @@ class AIPS_Post_Review {
 		$result = $generator->generate_post($template);
 		
 		if (is_wp_error($result)) {
-			// Log the regeneration failure
-			$history = $this->history_service->create('post_review_action', array());
-			$history->record(
-				'activity',
-				sprintf(__('Post regeneration failed: %s', 'ai-post-scheduler'), $result->get_error_message()),
-				array('event_type' => 'post_regenerated', 'event_status' => 'failed'),
-				null,
-				array('error' => $result->get_error_message())
-			);
+			AIPS_History_Service::log_failure('post_review_action', sprintf(__('Post regeneration failed: %s', 'ai-post-scheduler'), $result->get_error_message()), 'post_regenerated', array(), array('error' => $result->get_error_message()));
 			
 			AIPS_Ajax_Response::error(array('message' => $result->get_error_message()));
 			return;
 		}
 		
-		// Log the regeneration success
-		$history = $this->history_service->create('post_review_action', array('post_id' => $result));
-		$history->record(
-			'activity',
-			__('Post regenerated from review queue', 'ai-post-scheduler'),
-			array('event_type' => 'post_regenerated', 'event_status' => 'success'),
-			null,
-			array('post_id' => $result)
-		);
+		AIPS_History_Service::log_success('post_review_action', __('Post regenerated from review queue', 'ai-post-scheduler'), 'post_regenerated', array('post_id' => $result), array('post_id' => $result));
 		
 		/**
 		 * Fires after a post is regenerated from the review queue.
@@ -711,14 +598,7 @@ class AIPS_Post_Review {
 		}
 		
 		if (!current_user_can('manage_options')) {
-			$history = $this->history_service->create('post_review_action', array());
-			$history->record(
-				'activity',
-				__('Post delete failed: Permission denied', 'ai-post-scheduler'),
-				array('event_type' => 'post_deleted', 'event_status' => 'failed'),
-				null,
-				array()
-			);
+			AIPS_History_Service::log_failure('post_review_action', __('Post delete failed: Permission denied', 'ai-post-scheduler'), 'post_deleted');
 			AIPS_Ajax_Response::permission_denied();
 		}
 		
@@ -726,54 +606,26 @@ class AIPS_Post_Review {
 		$history_id = isset($_POST['history_id']) ? absint($_POST['history_id']) : 0;
 		
 		if (!$post_id) {
-			$history = $this->history_service->create('post_review_action', array());
-			$history->record(
-				'activity',
-				__('Post delete failed: Invalid post ID', 'ai-post-scheduler'),
-				array('event_type' => 'post_deleted', 'event_status' => 'failed'),
-				null,
-				array()
-			);
+			AIPS_History_Service::log_failure('post_review_action', __('Post delete failed: Invalid post ID', 'ai-post-scheduler'), 'post_deleted');
 			AIPS_Ajax_Response::error(__('Invalid post ID.', 'ai-post-scheduler'));
 		}
 		
 		// Verify the post exists and is a draft
 		$post = get_post($post_id);
 		if (!$post || $post->post_status !== 'draft') {
-			$history = $this->history_service->create('post_review_action', array('post_id' => $post_id));
-			$history->record(
-				'activity',
-				__('Post delete failed: Post not found or not a draft', 'ai-post-scheduler'),
-				array('event_type' => 'post_deleted', 'event_status' => 'failed'),
-				null,
-				array('post_id' => $post_id)
-			);
+			AIPS_History_Service::log_failure('post_review_action', __('Post delete failed: Post not found or not a draft', 'ai-post-scheduler'), 'post_deleted', array('post_id' => $post_id), array('post_id' => $post_id));
 			AIPS_Ajax_Response::error(__('Post not found or not a draft.', 'ai-post-scheduler'));
 		}
 		
 		// Verify the post is in the review queue
 		if (!$this->history_service->post_has_history_and_completed($post_id)) {
-			$history = $this->history_service->create('post_review_action', array('post_id' => $post_id));
-			$history->record(
-				'activity',
-				__('Post delete failed: Post not in review queue', 'ai-post-scheduler'),
-				array('event_type' => 'post_deleted', 'event_status' => 'failed'),
-				null,
-				array('post_id' => $post_id)
-			);
+			AIPS_History_Service::log_failure('post_review_action', __('Post delete failed: Post not in review queue', 'ai-post-scheduler'), 'post_deleted', array('post_id' => $post_id), array('post_id' => $post_id));
 			AIPS_Ajax_Response::error(__('Post not found in review queue.', 'ai-post-scheduler'));
 		}
 		
 		// Check per-post capability
 		if (!current_user_can('delete_post', $post_id)) {
-			$history = $this->history_service->create('post_review_action', array('post_id' => $post_id));
-			$history->record(
-				'activity',
-				__('Post delete failed: Insufficient permissions', 'ai-post-scheduler'),
-				array('event_type' => 'post_deleted', 'event_status' => 'failed'),
-				null,
-				array('post_id' => $post_id)
-			);
+			AIPS_History_Service::log_failure('post_review_action', __('Post delete failed: Insufficient permissions', 'ai-post-scheduler'), 'post_deleted', array('post_id' => $post_id), array('post_id' => $post_id));
 			AIPS_Ajax_Response::error(__('You do not have permission to delete this post.', 'ai-post-scheduler'));
 		}
 		
@@ -781,14 +633,7 @@ class AIPS_Post_Review {
 		$result = wp_delete_post($post_id, true);
 		
 		if (!$result) {
-			$history = $this->history_service->create('post_review_action', array('post_id' => $post_id));
-			$history->record(
-				'activity',
-				__('Post delete failed: Unable to delete post', 'ai-post-scheduler'),
-				array('event_type' => 'post_deleted', 'event_status' => 'failed'),
-				null,
-				array('post_id' => $post_id)
-			);
+			AIPS_History_Service::log_failure('post_review_action', __('Post delete failed: Unable to delete post', 'ai-post-scheduler'), 'post_deleted', array('post_id' => $post_id), array('post_id' => $post_id));
 			AIPS_Ajax_Response::error(__('Failed to delete post.', 'ai-post-scheduler'));
 		}
 		
@@ -800,14 +645,7 @@ class AIPS_Post_Review {
 		}
 		
 		// Log the delete activity
-		$history = $this->history_service->create('post_review_action', array('post_id' => $post_id));
-		$history->record(
-			'activity',
-			__('Draft post deleted from review queue', 'ai-post-scheduler'),
-			array('event_type' => 'post_deleted', 'event_status' => 'success'),
-			null,
-			array('post_id' => $post_id)
-		);
+		AIPS_History_Service::log_success('post_review_action', __('Draft post deleted from review queue', 'ai-post-scheduler'), 'post_deleted', array('post_id' => $post_id), array('post_id' => $post_id));
 		
 		/**
 		 * Fires after a post is deleted from the review queue.
@@ -844,7 +682,7 @@ class AIPS_Post_Review {
 		}
 		
 		// Create history container for bulk delete operation
-		$history = $this->history_service->create('bulk_delete', array(
+		$history = $this->history_service->get_or_create('bulk_delete', array(
 			'user_id' => get_current_user_id(),
 			'source' => 'manual_ui',
 			'trigger' => 'ajax_bulk_delete_draft_posts',
@@ -879,21 +717,21 @@ class AIPS_Post_Review {
 			$post = get_post($post_id);
 			if (!$post || $post->post_status !== 'draft') {
 				$failed_count++;
-				$history->record('warning', sprintf(__('Cannot delete post ID %d: Not found or not a draft', 'ai-post-scheduler'), $post_id), null, null, array('post_id' => $post_id));
+				AIPS_History_Service::record_on_container($history, 'warning', sprintf(__('Cannot delete post ID %d: Not found or not a draft', 'ai-post-scheduler'), $post_id), null, null, array('post_id' => $post_id));
 				continue;
 			}
 			
 			// Verify the post is in the review queue
 			if (!$this->history_service->post_has_history_and_completed($post_id)) {
 				$failed_count++;
-				$history->record('warning', sprintf(__('Cannot delete post ID %d: Not in review queue', 'ai-post-scheduler'), $post_id), null, null, array('post_id' => $post_id));
+				AIPS_History_Service::record_on_container($history, 'warning', sprintf(__('Cannot delete post ID %d: Not in review queue', 'ai-post-scheduler'), $post_id), null, null, array('post_id' => $post_id));
 				continue;
 			}
 			
 			// Check per-post capability
 			if (!current_user_can('delete_post', $post_id)) {
 				$failed_count++;
-				$history->record('warning', sprintf(__('Cannot delete post ID %d: Insufficient permissions', 'ai-post-scheduler'), $post_id), null, null, array('post_id' => $post_id));
+				AIPS_History_Service::record_on_container($history, 'warning', sprintf(__('Cannot delete post ID %d: Insufficient permissions', 'ai-post-scheduler'), $post_id), null, null, array('post_id' => $post_id));
 				continue;
 			}
 			
@@ -920,11 +758,11 @@ class AIPS_Post_Review {
 				));
 			} else {
 				$failed_count++;
-				$history->record('warning', sprintf(__('Failed to delete post ID %d', 'ai-post-scheduler'), $post_id), null, null, array('post_id' => $post_id));
+				AIPS_History_Service::record_on_container($history, 'warning', sprintf(__('Failed to delete post ID %d', 'ai-post-scheduler'), $post_id), null, null, array('post_id' => $post_id));
 			}
 		}
 		
-		$history->record('activity', sprintf(__('Bulk delete completed: %d deleted, %d failed', 'ai-post-scheduler'), $success_count, $failed_count), null, null, array(
+		AIPS_History_Service::record_on_container($history, 'activity', sprintf(__('Bulk delete completed: %d deleted, %d failed', 'ai-post-scheduler'), $success_count, $failed_count), null, null, array(
 			'deleted_count' => $success_count,
 			'failed_count' => $failed_count,
 			'requested_count' => count($items)

--- a/ai-post-scheduler/includes/class-aips-schedule-controller.php
+++ b/ai-post-scheduler/includes/class-aips-schedule-controller.php
@@ -115,28 +115,17 @@ class AIPS_Schedule_Controller {
      * @return void
      */
     private function log_bulk_slicing_notice($history_type, $message, $context = array()) {
-        $history_service = new AIPS_History_Service($this->history_repository);
-        $history = $history_service->create($history_type, array(
-            'creation_method' => $history_type,
-            'user_id'         => get_current_user_id(),
-            'source'          => 'manual_ui',
-        ));
-
-        if (!$history) {
-            return;
-        }
-
-        $history->record(
-            'activity',
-            $message,
-            array(
-                'event_type'   => 'bulk_slicing_notice',
-                'event_status' => 'success',
+        AIPS_History_Service::log_event(array(
+            'history_type' => $history_type,
+            'message' => $message,
+            'event_type' => 'bulk_slicing_notice',
+            'event_status' => 'success',
+            'metadata' => array(
+                'source' => 'manual_ui',
             ),
-            null,
-            $context
-        );
-        $history->complete_success();
+            'context' => $context,
+            'complete' => 'success',
+        ));
     }
 
     public function ajax_save_schedule() {

--- a/ai-post-scheduler/includes/class-aips-settings-ajax.php
+++ b/ai-post-scheduler/includes/class-aips-settings-ajax.php
@@ -52,21 +52,22 @@ class AIPS_Settings_AJAX {
 		$options = array(
 			'maxTokens' => 20,
 		);
-		$history = $this->history_service->create(
-			'settings_connection_test',
+		$history = AIPS_History_Service::log_event(
 			array(
-				'user_id' => get_current_user_id(),
+				'history_type' => 'settings_connection_test',
+				'message' => __('Testing AI connection from the settings screen.', 'ai-post-scheduler'),
+				'event_type' => 'connection_test',
+				'event_status' => 'started',
+				'metadata' => array(
+					'user_id' => get_current_user_id(),
+				),
+				'context' => array(
+					'source' => 'settings_ui',
+				),
 			)
 		);
-
-		$history->record(
-			'activity',
-			__('Testing AI connection from the settings screen.', 'ai-post-scheduler'),
-			array(
-				'source' => 'settings_ui',
-			)
-		);
-		$history->record(
+		AIPS_History_Service::record_on_container(
+			$history,
 			'ai_request',
 			__('Settings connection test prompt sent to AI.', 'ai-post-scheduler'),
 			array(
@@ -95,7 +96,8 @@ class AIPS_Settings_AJAX {
 			AIPS_Ajax_Response::error(array('message' => $result->get_error_message()));
 		}
 
-		$history->record(
+		AIPS_History_Service::record_on_container(
+			$history,
 			'ai_response',
 			__('Settings connection test response received.', 'ai-post-scheduler'),
 			null,
@@ -116,17 +118,18 @@ class AIPS_Settings_AJAX {
 	public function ajax_notifications_data_hygiene() {
 		$this->verify_request();
 
-		$history = $this->history_service->create(
-			'settings_notifications_hygiene',
+		$history = AIPS_History_Service::log_event(
 			array(
-				'user_id' => get_current_user_id(),
-			)
-		);
-		$history->record(
-			'activity',
-			__('Running notifications hygiene from the settings screen.', 'ai-post-scheduler'),
-			array(
-				'source' => 'settings_ui',
+				'history_type' => 'settings_notifications_hygiene',
+				'message' => __('Running notifications hygiene from the settings screen.', 'ai-post-scheduler'),
+				'event_type' => 'notifications_hygiene',
+				'event_status' => 'started',
+				'metadata' => array(
+					'user_id' => get_current_user_id(),
+				),
+				'context' => array(
+					'source' => 'settings_ui',
+				),
 			)
 		);
 
@@ -151,7 +154,8 @@ class AIPS_Settings_AJAX {
 			$rollup_scheduled = (bool) wp_next_scheduled('aips_notification_rollups');
 
 			if (!$rollup_scheduled) {
-				$history->record(
+				AIPS_History_Service::record_on_container(
+					$history,
 					'warning',
 					__('Notification rollup remained unscheduled after hygiene attempted to recreate it.', 'ai-post-scheduler'),
 					array(
@@ -190,7 +194,8 @@ class AIPS_Settings_AJAX {
 			'preferences_changed' => $preferences_changed ? 1 : 0,
 		);
 
-		$history->record(
+		AIPS_History_Service::record_on_container(
+			$history,
 			'activity',
 			__('Notifications hygiene completed.', 'ai-post-scheduler'),
 			null,

--- a/ai-post-scheduler/includes/class-aips-taxonomy-controller.php
+++ b/ai-post-scheduler/includes/class-aips-taxonomy-controller.php
@@ -127,7 +127,7 @@ class AIPS_Taxonomy_Controller {
 		}
 
 		// Create history container for taxonomy generation
-		$history = $this->history_service->create('taxonomy_generation', array(
+		$history = $this->history_service->get_or_create('taxonomy_generation', array(
 			'user_id' => get_current_user_id(),
 			'source' => 'manual_ui',
 			'trigger' => 'ajax_generate_taxonomy',
@@ -154,7 +154,7 @@ class AIPS_Taxonomy_Controller {
 			AIPS_Ajax_Response::error(array('message' => $result->get_error_message()));
 		}
 
-		$history->record('activity', sprintf(__('Generated %d taxonomy items', 'ai-post-scheduler'), count($result)), null, null, array(
+		AIPS_History_Service::record_on_container($history, 'activity', sprintf(__('Generated %d taxonomy items', 'ai-post-scheduler'), count($result)), null, null, array(
 			'taxonomy_type' => $taxonomy_type,
 			'generated_count' => count($result)
 		));
@@ -352,13 +352,17 @@ class AIPS_Taxonomy_Controller {
 
 			// Log approval
 			if ($item) {
-				$history = $this->history_service->create('taxonomy_approval', array(
-					'item_id' => $item_id,
-				));
-				$history->record(
+				$this->history_service->create_record_and_complete_success(
+					'taxonomy_approval',
+					array(
+						'item_id' => $item_id,
+					),
 					'activity',
 					sprintf(__('Taxonomy item approved: "%s"', 'ai-post-scheduler'), $item->name),
-					array('event_type' => 'taxonomy_approved', 'event_status' => 'success'),
+					array(
+						'event_type' => 'taxonomy_approved',
+						'event_status' => 'success',
+					),
 					null,
 					array('item_id' => $item_id, 'item_name' => $item->name, 'taxonomy_type' => $item->taxonomy_type)
 				);
@@ -395,13 +399,17 @@ class AIPS_Taxonomy_Controller {
 
 			// Log rejection
 			if ($item) {
-				$history = $this->history_service->create('taxonomy_rejection', array(
-					'item_id' => $item_id,
-				));
-				$history->record(
+				$this->history_service->create_record_and_complete_success(
+					'taxonomy_rejection',
+					array(
+						'item_id' => $item_id,
+					),
 					'activity',
 					sprintf(__('Taxonomy item rejected: "%s"', 'ai-post-scheduler'), $item->name),
-					array('event_type' => 'taxonomy_rejected', 'event_status' => 'failed'),
+					array(
+						'event_type' => 'taxonomy_rejected',
+						'event_status' => 'failed',
+					),
 					null,
 					array('item_id' => $item_id, 'item_name' => $item->name, 'taxonomy_type' => $item->taxonomy_type)
 				);

--- a/ai-post-scheduler/includes/class-aips-templates-controller.php
+++ b/ai-post-scheduler/includes/class-aips-templates-controller.php
@@ -45,21 +45,9 @@ class AIPS_Templates_Controller {
             $slice_count
         );
 
-        $history_service = new AIPS_History_Service();
-        $history = $history_service->create('template_lifecycle', array(
-            'template_id'     => absint($template_id),
-            'creation_method' => 'template_lifecycle',
-            'user_id'         => get_current_user_id(),
-            'source'          => 'manual_ui',
-        ));
-
-        if (!$history) {
-            return null;
-        }
-
-        $history->record(
-            'activity',
-            sprintf(
+        AIPS_History_Service::log_event(array(
+            'history_type' => 'template_lifecycle',
+            'message' => sprintf(
                 /* translators: 1: template name, 2: post quantity, 3: threshold, 4: slice count */
                 __('Template "%1$s" saved with %2$d posts per run. Quantities above threshold (%3$d) will be split into %4$d slices at runtime.', 'ai-post-scheduler'),
                 $template_name,
@@ -67,20 +55,19 @@ class AIPS_Templates_Controller {
                 $threshold,
                 $slice_count
             ),
-            array(
-                'event_type'   => 'template_slicing_notice',
-                'event_status' => 'success',
+            'event_type' => 'template_slicing_notice',
+            'event_status' => 'success',
+            'metadata' => array(
+                'template_id'   => absint($template_id),
+                'source'        => 'manual_ui',
             ),
-            null,
-            array(
+            'context' => array(
                 'template_id'   => absint($template_id),
                 'post_quantity' => $post_quantity,
                 'threshold'     => $threshold,
                 'slice_count'   => $slice_count,
             )
-        );
-
-        $history->complete_success();
+        ));
 
         return array(
             'message'       => $notice_message,

--- a/ai-post-scheduler/tests/Test_AIPS_History_Service_Helpers.php
+++ b/ai-post-scheduler/tests/Test_AIPS_History_Service_Helpers.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Tests for AIPS_History_Service helper normalization.
+ *
+ * @package AI_Post_Scheduler
+ */
+
+class Test_AIPS_History_Service_Helpers extends WP_UnitTestCase {
+
+	public function test_build_metadata_adds_type_fields() {
+		$metadata = AIPS_History_Service::build_metadata(
+			'post_review_action',
+			array(
+				'post_id' => 123,
+				'user_id' => 77,
+			)
+		);
+
+		$this->assertSame('post_review_action', $metadata['creation_method']);
+		$this->assertSame('post_review_action', $metadata['history_type']);
+		$this->assertSame(123, $metadata['post_id']);
+		$this->assertSame(77, $metadata['user_id']);
+	}
+
+	public function test_normalize_event_context_defaults() {
+		$event = AIPS_History_Service::normalize_event_context('', '', array());
+
+		$this->assertSame('activity', $event['event_type']);
+		$this->assertSame('success', $event['event_status']);
+		$this->assertSame('activity', $event['context']['event_type']);
+		$this->assertSame('success', $event['context']['event_status']);
+	}
+
+	public function test_normalize_event_context_uses_explicit_values() {
+		$event = AIPS_History_Service::normalize_event_context(
+			'topic_rejected',
+			'failed',
+			array(
+				'topic_id' => 22,
+			)
+		);
+
+		$this->assertSame('topic_rejected', $event['event_type']);
+		$this->assertSame('failed', $event['event_status']);
+		$this->assertSame(22, $event['context']['topic_id']);
+	}
+}
+


### PR DESCRIPTION
### Motivation
- Centralize and simplify history/event logging across the plugin by providing higher-level helpers and consistent metadata normalization.
- Reduce repeated boilerplate for creating containers and recording events, and to ensure `event_type`/`event_status` are consistently populated.
- Make history usage safer when a container may be absent by offering a `record_on_container` wrapper.

### Description
- Introduces new APIs on `AIPS_History_Service` including `build_metadata`, `get_or_create`, `create_and_record`, `create_record_and_complete_success`, `log_event`, `log_activity`, `normalize_event_context`, `log_success`, `log_failure`, `log_warning`, `log_user_action`, and `record_on_container` to normalize and simplify logging.
- Updates `AIPS_History_Container` to normalize and persist metadata via a new `normalize_metadata` helper and to prefer `creation_method`/`history_type` semantics when loading existing containers.
- Replaces many direct `->create()` + `->record()`/`->complete_*()` calls across controllers (`AIPS_Author_Topics_Controller`, `AIPS_Generator`, `AIPS_Notifications`, `AIPS_Post_Review`, `AIPS_Schedule_Controller`, `AIPS_Settings_AJAX`, `AIPS_Taxonomy_Controller`, `AIPS_Templates_Controller`, and others) with the new `AIPS_History_Service` helpers (e.g. `log_success`, `log_failure`, `log_activity`, `record_on_container`, `get_or_create`, `create_record_and_complete_success`).
- Adjusts `AIPS_Generator::generate_content` to use `AIPS_History_Service::record_on_container` for AI request/response/error logging.
- Adds a unit test file `tests/Test_AIPS_History_Service_Helpers.php` that validates `build_metadata` and `normalize_event_context` behavior.

### Testing
- Added PHPUnit tests in `tests/Test_AIPS_History_Service_Helpers.php` and executed the test suite via `phpunit`; the new tests passed.
- Exercised controller AJAX flows in unit tests that touch the history helpers as part of the test run and observed expected logging behavior in the helper assertions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffd753b4a48321be6a49697738936d)