### PR TITLE
🐞 Hunter: Fix Interval Calculator start time string parsing

### DIFF
--- a/.jules/hunter.md
+++ b/.jules/hunter.md
@@ -1,3 +1,7 @@
 ## 2026-04-27 - Handle Template Data Object Type Error
 **Learning:** Legacy template variables might receive class instances instead of expected associative arrays, causing fatal `Cannot use object of type class as array` errors in PHP 8+.
 **Action:** Always check `is_object($data)` before accessing elements via `$data['key']` in templates. If it is an object, use getter methods (e.g. `$handler->get_data()`) to retrieve an array context.
+
+## 2026-05-09 - Interval Calculator Date String Parsing
+**Learning:** `AIPS_Interval_Calculator::calculate_next_run` strictly enforced `is_numeric` on `$start_time`, but it was often passed string dates (e.g. '2030-06-15 10:00:00') from other components or tests, causing silent fallback to the current timestamp and incorrect scheduling offsets.
+**Action:** When a method signature allows flexible date formats (`$start_time`), implement type guards that fallback gracefully (e.g., using `strtotime($start_time) !== false`). Tests evaluating timestamps should be strict about type casting instead of relying on loose equality with string dates.

--- a/ai-post-scheduler/includes/class-aips-interval-calculator.php
+++ b/ai-post-scheduler/includes/class-aips-interval-calculator.php
@@ -129,9 +129,12 @@ class AIPS_Interval_Calculator {
      * @return int UTC Unix timestamp for the next run.
      */
     public function calculate_next_run($frequency, $start_time = null) {
-        $base_time = is_numeric($start_time) && (int) $start_time > 0
-            ? (int) $start_time
-            : AIPS_DateTime::now()->timestamp();
+        $base_time = AIPS_DateTime::now()->timestamp();
+        if (is_numeric($start_time) && (int) $start_time > 0) {
+            $base_time = (int) $start_time;
+        } elseif (is_string($start_time) && strtotime($start_time) !== false) {
+            $base_time = strtotime($start_time);
+        }
         $now = AIPS_DateTime::now()->timestamp();
         
         // If start time is in the past, add intervals until future (Catch-up logic)

--- a/ai-post-scheduler/tests/Test_AIPS_Interval_Calculator.php
+++ b/ai-post-scheduler/tests/Test_AIPS_Interval_Calculator.php
@@ -66,7 +66,7 @@ class Test_AIPS_Interval_Calculator extends WP_UnitTestCase {
         $next = $this->calculator->calculate_next_run('hourly', $start);
         
         $expected = '2030-06-15 11:00:00';
-        $this->assertEquals($expected, $next);
+        $this->assertEquals(strtotime($expected), $next);
     }
 
     /**
@@ -77,7 +77,7 @@ class Test_AIPS_Interval_Calculator extends WP_UnitTestCase {
         $next = $this->calculator->calculate_next_run('daily', $start);
         
         $expected = '2030-06-16 10:00:00';
-        $this->assertEquals($expected, $next);
+        $this->assertEquals(strtotime($expected), $next);
     }
 
     /**
@@ -88,7 +88,7 @@ class Test_AIPS_Interval_Calculator extends WP_UnitTestCase {
         $next = $this->calculator->calculate_next_run('weekly', $start);
         
         $expected = '2030-06-22 10:00:00';
-        $this->assertEquals($expected, $next);
+        $this->assertEquals(strtotime($expected), $next);
     }
 
     /**
@@ -99,7 +99,7 @@ class Test_AIPS_Interval_Calculator extends WP_UnitTestCase {
         $next = $this->calculator->calculate_next_run('monthly', $start);
         
         $expected = '2030-07-15 10:00:00';
-        $this->assertEquals($expected, $next);
+        $this->assertEquals(strtotime($expected), $next);
     }
 
     /**
@@ -110,7 +110,7 @@ class Test_AIPS_Interval_Calculator extends WP_UnitTestCase {
         $next = $this->calculator->calculate_next_run('every_4_hours', $start);
         
         $expected = '2030-06-15 14:00:00';
-        $this->assertEquals($expected, $next);
+        $this->assertEquals(strtotime($expected), $next);
     }
 
     /**
@@ -121,7 +121,7 @@ class Test_AIPS_Interval_Calculator extends WP_UnitTestCase {
         $next = $this->calculator->calculate_next_run('every_6_hours', $start);
         
         $expected = '2030-06-15 16:00:00';
-        $this->assertEquals($expected, $next);
+        $this->assertEquals(strtotime($expected), $next);
     }
 
     /**
@@ -132,7 +132,7 @@ class Test_AIPS_Interval_Calculator extends WP_UnitTestCase {
         $next = $this->calculator->calculate_next_run('every_12_hours', $start);
         
         $expected = '2030-06-15 22:00:00';
-        $this->assertEquals($expected, $next);
+        $this->assertEquals(strtotime($expected), $next);
     }
 
     /**
@@ -143,7 +143,7 @@ class Test_AIPS_Interval_Calculator extends WP_UnitTestCase {
         $next = $this->calculator->calculate_next_run('bi_weekly', $start);
         
         $expected = '2030-06-29 10:00:00';
-        $this->assertEquals($expected, $next);
+        $this->assertEquals(strtotime($expected), $next);
     }
 
     /**
@@ -157,7 +157,7 @@ class Test_AIPS_Interval_Calculator extends WP_UnitTestCase {
         
         // For every_monday from a Monday start, next should be 7 days later
         $expected = '2030-06-17 10:00:00';
-        $this->assertEquals($expected, $next);
+        $this->assertEquals(strtotime($expected), $next);
     }
 
     /**
@@ -172,7 +172,7 @@ class Test_AIPS_Interval_Calculator extends WP_UnitTestCase {
         
         // Next Wednesday after Monday June 10 should be Wednesday June 12, preserving time
         $expected = '2030-06-12 14:30:00';
-        $this->assertEquals($expected, $next);
+        $this->assertEquals(strtotime($expected), $next);
     }
 
     /**
@@ -182,10 +182,11 @@ class Test_AIPS_Interval_Calculator extends WP_UnitTestCase {
         $next = $this->calculator->calculate_next_run('daily');
         
         // Should return a datetime string
-        $this->assertMatchesRegularExpression('/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/', $next);
+        $next_string = is_numeric($next) ? gmdate('Y-m-d H:i:s', $next) : $next;
+        $this->assertMatchesRegularExpression('/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/', $next_string);
         
         // Should be in the future
-        $this->assertGreaterThan(current_time('mysql'), $next);
+        $this->assertGreaterThan(current_time('timestamp'), is_numeric($next) ? $next : strtotime($next));
     }
 
     /**
@@ -196,7 +197,7 @@ class Test_AIPS_Interval_Calculator extends WP_UnitTestCase {
         $next = $this->calculator->calculate_next_run('daily', $start);
         
         // Should be in the future, not based on 2020
-        $next_timestamp = strtotime($next);
+        $next_timestamp = is_numeric($next) ? $next : strtotime($next);
         $current_timestamp = current_time('timestamp');
         
         $this->assertGreaterThan($current_timestamp, $next_timestamp);
@@ -288,6 +289,6 @@ class Test_AIPS_Interval_Calculator extends WP_UnitTestCase {
         
         // Should default to +1 day
         $expected = date('Y-m-d 10:00:00', strtotime('+1 day', strtotime($start)));
-        $this->assertEquals($expected, $next);
+        $this->assertEquals(strtotime($expected), $next);
     }
 }


### PR DESCRIPTION
**🐛 Bug:** `AIPS_Interval_Calculator::calculate_next_run` strictly enforced `is_numeric()` on the `$start_time` parameter. When passed a valid string date, it silently failed the check and fell back to generating intervals from the current timestamp instead of the intended start time, causing scheduling offsets to drift.

**🔎 Root Cause:** Type rigidity in the fallback ternary operator failed to parse valid date strings, compounding with tests that incorrectly compared the resulting timestamps directly against formatted string expectations.

**🛠️ Fix:** Modified the logic to implement a type guard: if the input is numeric, use it; if it is a valid string, parse it with `strtotime()`; otherwise, fallback to the current timestamp. Rewrote the test assertions to correctly enforce and expect numeric timestamp values, validating the returned timestamps accurately against `strtotime($expected)`.

**🧪 Verification:** Ran the full test suite. 22 tests within `Test_AIPS_Interval_Calculator` now successfully pass, verifying both the accurate phase offset calculations and the ability to process valid start time strings natively.

---
*PR created automatically by Jules for task [13401922716798632447](https://jules.google.com/task/13401922716798632447) started by @rpnunez*