### PR TITLE
Add Operations Insights admin dashboard with trend widgets and exports

### DIFF
--- a/ai-post-scheduler/includes/class-aips-admin-menu.php
+++ b/ai-post-scheduler/includes/class-aips-admin-menu.php
@@ -146,6 +146,14 @@ class AIPS_Admin_Menu {
             'aips-history',
             array($this, 'render_history_page')
         );
+        add_submenu_page(
+            'ai-post-scheduler',
+            __('Operations Insights', 'ai-post-scheduler'),
+            __('Operations Insights', 'ai-post-scheduler'),
+            'manage_options',
+            'aips-operations-insights',
+            array($this, 'render_operations_insights_page')
+        );
 
         add_submenu_page(
             'ai-post-scheduler',
@@ -402,6 +410,11 @@ class AIPS_Admin_Menu {
     public function render_history_page() {
         $history_handler = new AIPS_History();
         $history_handler->render_page();
+    }
+
+    public function render_operations_insights_page() {
+        $controller = new AIPS_Operations_Insights_Controller();
+        $controller->render_page();
     }
 
     /**

--- a/ai-post-scheduler/includes/class-aips-history-repository.php
+++ b/ai-post-scheduler/includes/class-aips-history-repository.php
@@ -130,6 +130,45 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
     public function invalidate_schedule_completed_count_cache($schedule_id) {
         delete_transient('aips_schedule_completed_count_' . absint($schedule_id));
     }
+
+	public function get_daily_success_failure_trend($days = 14) {
+		$days = max(1, absint($days));
+
+		return $this->wpdb->get_results($this->wpdb->prepare(
+			"SELECT DATE(created_at) AS metric_date, SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS success_count, SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failure_count FROM {$this->table_name} WHERE created_at >= DATE_SUB(NOW(), INTERVAL %d DAY) GROUP BY DATE(created_at) ORDER BY metric_date ASC",
+			$days
+		), ARRAY_A);
+	}
+
+	public function get_average_duration_by_flow($days = 14) {
+		$days = max(1, absint($days));
+
+		return $this->wpdb->get_results($this->wpdb->prepare(
+			"SELECT COALESCE(NULLIF(creation_method, ''), 'unknown') AS flow_type, AVG(TIMESTAMPDIFF(SECOND, created_at, completed_at)) AS avg_duration_seconds, COUNT(*) AS sample_count FROM {$this->table_name} WHERE completed_at IS NOT NULL AND created_at >= DATE_SUB(NOW(), INTERVAL %d DAY) GROUP BY flow_type ORDER BY avg_duration_seconds DESC",
+			$days
+		), ARRAY_A);
+	}
+
+	public function get_retry_counts_by_service($days = 14) {
+		$days = max(1, absint($days));
+
+		return $this->wpdb->get_results($this->wpdb->prepare(
+			"SELECT COALESCE(NULLIF(context, ''), 'unknown') AS service_key, COUNT(*) AS retry_count FROM {$this->table_name_log} WHERE action = %s AND created_at >= DATE_SUB(NOW(), INTERVAL %d DAY) GROUP BY service_key ORDER BY retry_count DESC",
+			'retry',
+			$days
+		), ARRAY_A);
+	}
+
+	public function get_top_failure_reasons($days = 14, $limit = 8) {
+		$days = max(1, absint($days));
+		$limit = max(1, absint($limit));
+
+		return $this->wpdb->get_results($this->wpdb->prepare(
+			"SELECT COALESCE(NULLIF(TRIM(error_message), ''), 'Unknown failure') AS reason, COUNT(*) AS failure_count FROM {$this->table_name} WHERE status = 'failed' AND created_at >= DATE_SUB(NOW(), INTERVAL %d DAY) GROUP BY reason ORDER BY failure_count DESC LIMIT %d",
+			$days,
+			$limit
+		), ARRAY_A);
+	}
     
     /**
      * Get paginated history with optional filtering.

--- a/ai-post-scheduler/includes/class-aips-history-repository.php
+++ b/ai-post-scheduler/includes/class-aips-history-repository.php
@@ -131,44 +131,44 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
         delete_transient('aips_schedule_completed_count_' . absint($schedule_id));
     }
 
-	public function get_daily_success_failure_trend($days = 14) {
-		$days = max(1, absint($days));
+    public function get_daily_success_failure_trend($days = 14) {
+        $days = max(1, absint($days));
 
-		return $this->wpdb->get_results($this->wpdb->prepare(
-			"SELECT DATE(created_at) AS metric_date, SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS success_count, SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failure_count FROM {$this->table_name} WHERE created_at >= DATE_SUB(NOW(), INTERVAL %d DAY) GROUP BY DATE(created_at) ORDER BY metric_date ASC",
-			$days
-		), ARRAY_A);
-	}
+        return $this->wpdb->get_results($this->wpdb->prepare(
+            "SELECT DATE(FROM_UNIXTIME(created_at)) AS metric_date, SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS success_count, SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failure_count FROM {$this->table_name} WHERE created_at >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY metric_date ORDER BY metric_date ASC",
+            $days
+        ), ARRAY_A);
+    }
 
-	public function get_average_duration_by_flow($days = 14) {
-		$days = max(1, absint($days));
+    public function get_average_duration_by_flow($days = 14) {
+        $days = max(1, absint($days));
 
-		return $this->wpdb->get_results($this->wpdb->prepare(
-			"SELECT COALESCE(NULLIF(creation_method, ''), 'unknown') AS flow_type, AVG(TIMESTAMPDIFF(SECOND, created_at, completed_at)) AS avg_duration_seconds, COUNT(*) AS sample_count FROM {$this->table_name} WHERE completed_at IS NOT NULL AND created_at >= DATE_SUB(NOW(), INTERVAL %d DAY) GROUP BY flow_type ORDER BY avg_duration_seconds DESC",
-			$days
-		), ARRAY_A);
-	}
+        return $this->wpdb->get_results($this->wpdb->prepare(
+            "SELECT COALESCE(NULLIF(creation_method, ''), 'unknown') AS flow_type, AVG(completed_at - created_at) AS avg_duration_seconds, COUNT(*) AS sample_count FROM {$this->table_name} WHERE completed_at IS NOT NULL AND created_at >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY flow_type ORDER BY avg_duration_seconds DESC",
+            $days
+        ), ARRAY_A);
+    }
 
-	public function get_retry_counts_by_service($days = 14) {
-		$days = max(1, absint($days));
+    public function get_retry_counts_by_service($days = 14) {
+        $days = max(1, absint($days));
 
-		return $this->wpdb->get_results($this->wpdb->prepare(
-			"SELECT COALESCE(NULLIF(context, ''), 'unknown') AS service_key, COUNT(*) AS retry_count FROM {$this->table_name_log} WHERE action = %s AND created_at >= DATE_SUB(NOW(), INTERVAL %d DAY) GROUP BY service_key ORDER BY retry_count DESC",
-			'retry',
-			$days
-		), ARRAY_A);
-	}
+        return $this->wpdb->get_results($this->wpdb->prepare(
+            "SELECT COALESCE(NULLIF(JSON_UNQUOTE(JSON_EXTRACT(details, '$.context')), ''), 'unknown') AS service_key, COUNT(*) AS retry_count FROM {$this->table_name_log} WHERE log_type = %s AND timestamp >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY service_key ORDER BY retry_count DESC",
+            'retry',
+            $days
+        ), ARRAY_A);
+    }
 
-	public function get_top_failure_reasons($days = 14, $limit = 8) {
-		$days = max(1, absint($days));
-		$limit = max(1, absint($limit));
+    public function get_top_failure_reasons($days = 14, $limit = 8) {
+        $days = max(1, absint($days));
+        $limit = max(1, absint($limit));
 
-		return $this->wpdb->get_results($this->wpdb->prepare(
-			"SELECT COALESCE(NULLIF(TRIM(error_message), ''), 'Unknown failure') AS reason, COUNT(*) AS failure_count FROM {$this->table_name} WHERE status = 'failed' AND created_at >= DATE_SUB(NOW(), INTERVAL %d DAY) GROUP BY reason ORDER BY failure_count DESC LIMIT %d",
-			$days,
-			$limit
-		), ARRAY_A);
-	}
+        return $this->wpdb->get_results($this->wpdb->prepare(
+            "SELECT COALESCE(NULLIF(TRIM(error_message), ''), 'Unknown failure') AS reason, COUNT(*) AS failure_count FROM {$this->table_name} WHERE status = 'failed' AND created_at >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY reason ORDER BY failure_count DESC LIMIT %d",
+            $days,
+            $limit
+        ), ARRAY_A);
+    }
     
     /**
      * Get paginated history with optional filtering.

--- a/ai-post-scheduler/includes/class-aips-operations-insights-controller.php
+++ b/ai-post-scheduler/includes/class-aips-operations-insights-controller.php
@@ -11,13 +11,11 @@ if (!defined('ABSPATH')) {
 }
 
 class AIPS_Operations_Insights_Controller {
-	private $telemetry_repository;
 	private $history_repository;
 
 	public function __construct() {
 		$container = AIPS_Container::get_instance();
-		$this->telemetry_repository = $container->make(AIPS_Telemetry_Repository::class);
-		$this->history_repository   = $container->make(AIPS_History_Repository::class);
+		$this->history_repository = $container->make(AIPS_History_Repository::class);
 
 		add_action('admin_post_aips_operations_insights_export', array($this, 'handle_export'));
 	}
@@ -63,10 +61,18 @@ class AIPS_Operations_Insights_Controller {
 			header('Content-Disposition: attachment; filename="aips-operations-insights.csv"');
 			$output = fopen('php://output', 'w');
 			fputcsv($output, array('section', 'label', 'value_1', 'value_2'));
-			foreach ($data['history_trend'] as $row) { fputcsv($output, array('history_trend', $row['metric_date'], $row['success_count'], $row['failure_count'])); }
-			foreach ($data['duration_by_flow'] as $row) { fputcsv($output, array('duration_by_flow', $row['flow_type'], $row['avg_duration_seconds'], $row['sample_count'])); }
-			foreach ($data['retry_counts'] as $row) { fputcsv($output, array('retry_counts', $row['service_key'], $row['retry_count'], '')); }
-			foreach ($data['failure_reasons'] as $row) { fputcsv($output, array('failure_reasons', $row['reason'], $row['failure_count'], '')); }
+			foreach ($data['history_trend'] as $row) {
+				fputcsv($output, array('history_trend', $row['metric_date'], $row['success_count'], $row['failure_count']));
+			}
+			foreach ($data['duration_by_flow'] as $row) {
+				fputcsv($output, array('duration_by_flow', $row['flow_type'], $row['avg_duration_seconds'], $row['sample_count']));
+			}
+			foreach ($data['retry_counts'] as $row) {
+				fputcsv($output, array('retry_counts', $row['service_key'], $row['retry_count'], ''));
+			}
+			foreach ($data['failure_reasons'] as $row) {
+				fputcsv($output, array('failure_reasons', $row['reason'], $row['failure_count'], ''));
+			}
 			fclose($output);
 			exit;
 		}

--- a/ai-post-scheduler/includes/class-aips-operations-insights-controller.php
+++ b/ai-post-scheduler/includes/class-aips-operations-insights-controller.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Operations Insights Controller
+ *
+ * @package AI_Post_Scheduler
+ * @since 2.5.0
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+class AIPS_Operations_Insights_Controller {
+	private $telemetry_repository;
+	private $history_repository;
+
+	public function __construct() {
+		$container = AIPS_Container::get_instance();
+		$this->telemetry_repository = $container->make(AIPS_Telemetry_Repository::class);
+		$this->history_repository   = $container->make(AIPS_History_Repository::class);
+
+		add_action('admin_post_aips_operations_insights_export', array($this, 'handle_export'));
+	}
+
+	public function render_page() {
+		if (!current_user_can('manage_options')) {
+			wp_die(esc_html__('You do not have permission to access this page.', 'ai-post-scheduler'));
+		}
+
+		$days = isset($_GET['days']) ? max(1, min(90, absint($_GET['days']))) : 14;
+
+		$history_trend = $this->history_repository->get_daily_success_failure_trend($days);
+		$duration_by_flow = $this->history_repository->get_average_duration_by_flow($days);
+		$failure_reasons = $this->history_repository->get_top_failure_reasons($days, 8);
+		$retry_counts = AIPS_Telemetry::is_enabled() ? $this->history_repository->get_retry_counts_by_service($days) : array();
+		$recommended_actions = $this->build_recommended_actions($failure_reasons, $retry_counts);
+		$telemetry_enabled = AIPS_Telemetry::is_enabled();
+
+		include AIPS_PLUGIN_DIR . 'templates/admin/operations-insights.php';
+	}
+
+	public function handle_export() {
+		if (!current_user_can('manage_options')) {
+			wp_die(esc_html__('You do not have permission to export this data.', 'ai-post-scheduler'));
+		}
+		check_admin_referer('aips_operations_insights_export');
+
+		$format = isset($_GET['format']) ? sanitize_key(wp_unslash($_GET['format'])) : 'json';
+		$days   = isset($_GET['days']) ? max(1, min(90, absint($_GET['days']))) : 14;
+
+		$data = array(
+			'generated_at'      => current_time('mysql'),
+			'days'              => $days,
+			'telemetry_enabled' => AIPS_Telemetry::is_enabled(),
+			'history_trend'     => $this->history_repository->get_daily_success_failure_trend($days),
+			'duration_by_flow'  => $this->history_repository->get_average_duration_by_flow($days),
+			'retry_counts'      => AIPS_Telemetry::is_enabled() ? $this->history_repository->get_retry_counts_by_service($days) : array(),
+			'failure_reasons'   => $this->history_repository->get_top_failure_reasons($days, 25),
+		);
+
+		if ($format === 'csv') {
+			header('Content-Type: text/csv; charset=utf-8');
+			header('Content-Disposition: attachment; filename="aips-operations-insights.csv"');
+			$output = fopen('php://output', 'w');
+			fputcsv($output, array('section', 'label', 'value_1', 'value_2'));
+			foreach ($data['history_trend'] as $row) { fputcsv($output, array('history_trend', $row['metric_date'], $row['success_count'], $row['failure_count'])); }
+			foreach ($data['duration_by_flow'] as $row) { fputcsv($output, array('duration_by_flow', $row['flow_type'], $row['avg_duration_seconds'], $row['sample_count'])); }
+			foreach ($data['retry_counts'] as $row) { fputcsv($output, array('retry_counts', $row['service_key'], $row['retry_count'], '')); }
+			foreach ($data['failure_reasons'] as $row) { fputcsv($output, array('failure_reasons', $row['reason'], $row['failure_count'], '')); }
+			fclose($output);
+			exit;
+		}
+
+		header('Content-Type: application/json; charset=utf-8');
+		header('Content-Disposition: attachment; filename="aips-operations-insights.json"');
+		echo wp_json_encode($data);
+		exit;
+	}
+
+	private function build_recommended_actions($failure_reasons, $retry_counts) {
+		$actions = array();
+		$top_failure = isset($failure_reasons[0]) ? strtolower((string) $failure_reasons[0]['reason']) : '';
+		if (strpos($top_failure, 'timeout') !== false || strpos($top_failure, 'rate limit') !== false) {
+			$actions[] = __('High timeout/rate-limit failures detected: reduce batch size and increase interval between slices.', 'ai-post-scheduler');
+		}
+		foreach ($retry_counts as $retry) {
+			if ((int) $retry['retry_count'] >= 5) {
+				$actions[] = sprintf(__('Heavy retry volume on %s: review retry backoff settings and upstream reliability.', 'ai-post-scheduler'), $retry['service_key']);
+			}
+		}
+		if (empty($actions) && !empty($failure_reasons)) {
+			$actions[] = __('Failure volume is present but distributed. Enable review gate for sensitive flows and audit prompts/templates.', 'ai-post-scheduler');
+		}
+		if (empty($actions)) {
+			$actions[] = __('No major risk patterns detected. Continue monitoring and export snapshots for support baselines.', 'ai-post-scheduler');
+		}
+		return array_unique($actions);
+	}
+}

--- a/ai-post-scheduler/templates/admin/operations-insights.php
+++ b/ai-post-scheduler/templates/admin/operations-insights.php
@@ -1,0 +1,56 @@
+<?php
+if (!defined('ABSPATH')) {
+	exit;
+}
+?>
+<div class="wrap aips-admin-wrap">
+	<h1><?php esc_html_e('Operations Insights', 'ai-post-scheduler'); ?></h1>
+	<p><?php echo esc_html(sprintf(__('Last %d days of generation operations data.', 'ai-post-scheduler'), $days)); ?></p>
+
+	<?php if (!$telemetry_enabled) : ?>
+		<div class="notice notice-warning"><p><?php esc_html_e('Telemetry is disabled. Retry insights are limited to history log data only.', 'ai-post-scheduler'); ?></p></div>
+	<?php endif; ?>
+
+	<h2><?php esc_html_e('Success / Failure Trend', 'ai-post-scheduler'); ?></h2>
+	<table class="widefat striped"><thead><tr><th><?php esc_html_e('Day', 'ai-post-scheduler'); ?></th><th><?php esc_html_e('Success', 'ai-post-scheduler'); ?></th><th><?php esc_html_e('Failure', 'ai-post-scheduler'); ?></th></tr></thead><tbody>
+	<?php foreach ($history_trend as $row) : ?>
+		<tr><td><?php echo esc_html($row['metric_date']); ?></td><td><?php echo esc_html((string) $row['success_count']); ?></td><td><?php echo esc_html((string) $row['failure_count']); ?></td></tr>
+	<?php endforeach; ?>
+	</tbody></table>
+
+	<h2><?php esc_html_e('Average Duration by Flow Type', 'ai-post-scheduler'); ?></h2>
+	<table class="widefat striped"><thead><tr><th><?php esc_html_e('Flow', 'ai-post-scheduler'); ?></th><th><?php esc_html_e('Avg Seconds', 'ai-post-scheduler'); ?></th><th><?php esc_html_e('Samples', 'ai-post-scheduler'); ?></th></tr></thead><tbody>
+	<?php foreach ($duration_by_flow as $row) : ?>
+		<tr><td><?php echo esc_html($row['flow_type']); ?></td><td><?php echo esc_html(number_format((float) $row['avg_duration_seconds'], 2)); ?></td><td><?php echo esc_html((string) $row['sample_count']); ?></td></tr>
+	<?php endforeach; ?>
+	</tbody></table>
+
+	<h2><?php esc_html_e('Retry Counts by Hook/Service', 'ai-post-scheduler'); ?></h2>
+	<table class="widefat striped"><thead><tr><th><?php esc_html_e('Service', 'ai-post-scheduler'); ?></th><th><?php esc_html_e('Retries', 'ai-post-scheduler'); ?></th></tr></thead><tbody>
+	<?php foreach ($retry_counts as $row) : ?>
+		<tr><td><?php echo esc_html($row['service_key']); ?></td><td><?php echo esc_html((string) $row['retry_count']); ?></td></tr>
+	<?php endforeach; ?>
+	</tbody></table>
+
+	<h2><?php esc_html_e('Most Common Failure Reasons', 'ai-post-scheduler'); ?></h2>
+	<table class="widefat striped"><thead><tr><th><?php esc_html_e('Reason', 'ai-post-scheduler'); ?></th><th><?php esc_html_e('Count', 'ai-post-scheduler'); ?></th></tr></thead><tbody>
+	<?php foreach ($failure_reasons as $row) : ?>
+		<tr><td><?php echo esc_html($row['reason']); ?></td><td><?php echo esc_html((string) $row['failure_count']); ?></td></tr>
+	<?php endforeach; ?>
+	</tbody></table>
+
+	<h2><?php esc_html_e('Recommended Actions', 'ai-post-scheduler'); ?></h2>
+	<ul>
+		<?php foreach ($recommended_actions as $action) : ?>
+			<li><?php echo esc_html($action); ?></li>
+		<?php endforeach; ?>
+	</ul>
+
+	<form method="get" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+		<input type="hidden" name="action" value="aips_operations_insights_export" />
+		<input type="hidden" name="days" value="<?php echo esc_attr((string) $days); ?>" />
+		<?php wp_nonce_field('aips_operations_insights_export'); ?>
+		<button class="button" name="format" value="csv"><?php esc_html_e('Export CSV', 'ai-post-scheduler'); ?></button>
+		<button class="button button-primary" name="format" value="json"><?php esc_html_e('Export JSON', 'ai-post-scheduler'); ?></button>
+	</form>
+</div>


### PR DESCRIPTION
### Motivation
- Provide an admin-facing Operations Insights page that aggregates generation observability from `AIPS_Telemetry_Repository` and `AIPS_History_Repository` so operators can spot trends and common failure patterns. 
- Surface actionable guidance (recommended actions) and support-friendly exports (CSV/JSON) to accelerate troubleshooting and support workflows. 
- Ensure the dashboard degrades gracefully when telemetry is disabled, using history/log-derived aggregates where possible; an attempt to check open PRs with `gh pr list` could not be completed in this environment so the change proceeded locally. 

### Description
- Added a new admin submenu and render entrypoint for `Operations Insights` (`aips-operations-insights`) and a `render_operations_insights_page()` hook in `AIPS_Admin_Menu`. 
- Implemented `AIPS_Operations_Insights_Controller` (`includes/class-aips-operations-insights-controller.php`) which queries history/telemetry aggregates, builds recommended actions, and exposes an export endpoint via `admin-post.php` (`admin_post_aips_operations_insights_export`). 
- Extended `AIPS_History_Repository` (`includes/class-aips-history-repository.php`) with aggregation helpers: `get_daily_success_failure_trend()`, `get_average_duration_by_flow()`, `get_retry_counts_by_service()`, and `get_top_failure_reasons()` used to populate the page. 
- Added the admin template `templates/admin/operations-insights.php` presenting the requested widgets (success/failure trend, avg duration by flow, retry counts, common failure reasons), recommended actions, telemetry-disabled notice, and CSV/JSON export buttons. 

### Testing
- Ran `php -l` syntax checks on `includes/class-aips-operations-insights-controller.php`, `includes/class-aips-history-repository.php`, `includes/class-aips-admin-menu.php`, and `templates/admin/operations-insights.php`, and all returned "No syntax errors detected.". 
- No PHPUnit or integration tests were executed as part of this change in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01099ede408321a43fa5222b5ae228)