### PR TITLE
Add accessibility guardrails for generated content

### DIFF
--- a/ai-post-scheduler/assets/css/admin.css
+++ b/ai-post-scheduler/assets/css/admin.css
@@ -3831,3 +3831,38 @@ float: none;
 .aips-ai-engine-download-wrap {
 margin-top: 10px;
 }
+
+/* ==========================================================================
+   View History Icon Button (inline with post title)
+   ========================================================================== */
+
+/* View History Icon Button (inline with post title) */
+.aips-btn-icon.aips-view-session {
+	background: transparent;
+	border: 1px solid var(--aips-gray-200);
+	color: var(--aips-gray-600);
+	padding: 4px;
+	width: 28px;
+	height: 28px;
+	min-width: 28px;
+	flex-shrink: 0;
+	transition: all 0.15s ease;
+}
+
+.aips-btn-icon.aips-view-session:hover {
+	background: var(--aips-primary);
+	border-color: var(--aips-primary);
+	color: var(--aips-white);
+	box-shadow: var(--aips-shadow-sm);
+}
+
+.aips-btn-icon.aips-view-session:focus {
+	outline: 2px solid var(--aips-primary);
+	outline-offset: 2px;
+}
+
+.aips-btn-icon.aips-view-session .dashicons {
+	font-size: 18px;
+	width: 18px;
+	height: 18px;
+}

--- a/ai-post-scheduler/assets/css/admin.css
+++ b/ai-post-scheduler/assets/css/admin.css
@@ -662,6 +662,152 @@
 }
 
 /* ==========================================================================
+   Accessibility Report Modal
+   ========================================================================== */
+
+#aips-accessibility-report-modal .aips-modal-content {
+	max-height: 90vh;
+	overflow: hidden;
+}
+
+#aips-accessibility-report-modal .aips-modal-body {
+	flex: 1 1 auto;
+	min-height: 0;
+	overflow-y: auto;
+	padding: var(--aips-space-5);
+}
+
+#aips-accessibility-report-modal .aips-modal-subtitle {
+	margin: 4px 0 0;
+	color: var(--aips-gray-600);
+	font-size: var(--aips-text-sm);
+}
+
+.aips-access-report-message {
+	display: flex;
+	align-items: center;
+	gap: var(--aips-space-2);
+	padding: var(--aips-space-4);
+	border-radius: var(--aips-radius-base);
+	background: var(--aips-gray-50);
+	border: 1px solid var(--aips-gray-200);
+	color: var(--aips-gray-800);
+}
+
+.aips-access-report-message-error {
+	background: var(--aips-error-light);
+	border-color: rgba(227, 61, 52, 0.35);
+	color: var(--aips-error-dark);
+}
+
+.aips-access-report-message-empty {
+	background: var(--aips-info-light);
+	border-color: rgba(56, 89, 174, 0.25);
+	color: var(--aips-info-dark);
+}
+
+.aips-access-report {
+	display: flex;
+	flex-direction: column;
+	gap: var(--aips-space-5);
+}
+
+.aips-access-report-top {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: var(--aips-space-4);
+	background: var(--aips-gray-50);
+	border: 1px solid var(--aips-gray-200);
+	border-radius: var(--aips-radius-lg);
+}
+
+.aips-access-report-top-left {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--aips-space-2);
+	color: var(--aips-gray-900);
+}
+
+.aips-access-report-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+	gap: var(--aips-space-4);
+}
+
+.aips-access-report-card {
+	background: #fff;
+	border: 1px solid var(--aips-gray-200);
+	border-left: 4px solid var(--aips-gray-300);
+	border-radius: var(--aips-radius-lg);
+	padding: var(--aips-space-4);
+	box-shadow: var(--aips-shadow-sm);
+}
+
+.aips-access-report-card-success {
+	border-left-color: var(--aips-success);
+}
+
+.aips-access-report-card-warning {
+	border-left-color: var(--aips-warning);
+}
+
+.aips-access-report-card-error {
+	border-left-color: var(--aips-error);
+}
+
+.aips-access-report-card-title {
+	display: flex;
+	align-items: center;
+	gap: var(--aips-space-2);
+	font-weight: var(--aips-font-semibold);
+	color: var(--aips-gray-900);
+	margin-bottom: var(--aips-space-2);
+}
+
+.aips-access-report-card-lines {
+	margin: 0;
+	padding-left: 18px;
+	color: var(--aips-gray-700);
+}
+
+.aips-access-report-section h3 {
+	margin: 0 0 var(--aips-space-3);
+}
+
+.aips-access-report-findings {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	display: flex;
+	flex-direction: column;
+	gap: var(--aips-space-2);
+}
+
+.aips-access-report-findings li {
+	display: flex;
+	align-items: flex-start;
+	gap: var(--aips-space-2);
+	padding: var(--aips-space-3);
+	border-radius: var(--aips-radius-lg);
+	border: 1px solid rgba(245, 158, 11, 0.35);
+	background: var(--aips-warning-light);
+	color: var(--aips-warning-dark);
+}
+
+.aips-access-report-findings li .dashicons {
+	margin-top: 2px;
+}
+
+.aips-access-report-findings-empty {
+	padding: var(--aips-space-4);
+	border-radius: var(--aips-radius-lg);
+	border: 1px solid rgba(0, 163, 42, 0.25);
+	background: var(--aips-success-light);
+	color: var(--aips-success-dark);
+}
+
+/* ==========================================================================
    Status Badges (Modern Design)
    ========================================================================== */
 

--- a/ai-post-scheduler/assets/js/admin-accessibility-report.js
+++ b/ai-post-scheduler/assets/js/admin-accessibility-report.js
@@ -8,305 +8,317 @@
  */
 
 (function ($) {
-	'use strict';
+'use strict';
 
-	window.AIPS = window.AIPS || {};
-	var AIPS = window.AIPS;
+window.AIPS = window.AIPS || {};
+var AIPS = window.AIPS;
 
-	/**
-	 * AIPS.AccessibilityReport — module for rendering the Accessibility Report modal.
-	 */
-	AIPS.AccessibilityReport = {
+/**
+ * AIPS.AccessibilityReport — module for rendering the Accessibility Report modal.
+ */
+AIPS.AccessibilityReport = {
 
-		/**
-		 * Initialise the module.
-		 */
-		init: function () {
-			this.bindEvents();
-		},
+/**
+ * Initialise the module.
+ */
+init: function () {
+this.bindEvents();
+},
 
-		/**
-		 * Register event listeners.
-		 */
-		bindEvents: function () {
-			$(document).on('click', '.aips-view-accessibility-report', this.openModal.bind(this));
-			$(document).on('click', '#aips-accessibility-report-modal .aips-modal-close', this.closeModal.bind(this));
-			$(document).on('click', '#aips-accessibility-report-modal', this.closeModalOnOverlay.bind(this));
-			$(document).on('keydown', this.onKeydown.bind(this));
-		},
+/**
+ * Register event listeners.
+ */
+bindEvents: function () {
+$(document).on('click', '.aips-view-accessibility-report', this.openModal.bind(this));
+$(document).on('click', '#aips-accessibility-report-modal .aips-modal-close', this.closeModal.bind(this));
+$(document).on('click', '#aips-accessibility-report-modal', this.closeModalOnOverlay.bind(this));
+$(document).on('keydown', this.onKeydown.bind(this));
+},
 
-		/**
-		 * Open the report modal and fetch report data via AJAX.
-		 *
-		 * @param {Event} e Click event.
-		 */
-		openModal: function (e) {
-			e.preventDefault();
-			e.stopPropagation();
+/**
+ * Open the report modal and fetch report data via AJAX.
+ *
+ * @param {Event} e Click event.
+ */
+openModal: function (e) {
+e.preventDefault();
+e.stopPropagation();
 
-			var $btn = $(e.currentTarget);
-			var postId = parseInt($btn.data('post-id'), 10) || 0;
-			var historyId = parseInt($btn.data('history-id'), 10) || 0;
+var $btn = $(e.currentTarget);
+var postId = parseInt($btn.data('post-id'), 10) || 0;
+var historyId = parseInt($btn.data('history-id'), 10) || 0;
+var l10n = window.aipsAccessibilityReportL10n;
 
-			var $modal = $('#aips-accessibility-report-modal');
-			var $content = $('#aips-accessibility-report-content');
-			var $subtitle = $('#aips-accessibility-report-modal-subtitle');
-			var T = AIPS.Templates;
+var $modal = $('#aips-accessibility-report-modal');
+var $content = $('#aips-accessibility-report-content');
+var $subtitle = $('#aips-accessibility-report-modal-subtitle');
+var T = AIPS.Templates;
 
-			$subtitle.text('');
-			$content.html(T.render('aips-tmpl-access-report-loading', {
-				text: (window.aipsAccessibilityReportL10n && window.aipsAccessibilityReportL10n.loading) ? window.aipsAccessibilityReportL10n.loading : 'Loading report\u2026'
-			}));
+$subtitle.text('');
+$content.html(T.render('aips-tmpl-access-report-loading', {
+text: l10n.loading
+}));
 
-			$modal.fadeIn(200);
+$modal.fadeIn(200);
 
-			this.fetchReport(postId, historyId)
-				.done(function (response) {
-					if (!response || !response.success) {
-						$content.html(T.render('aips-tmpl-access-report-error', {
-							message: response && response.data && response.data.message
-								? response.data.message
-								: ((window.aipsAccessibilityReportL10n && window.aipsAccessibilityReportL10n.errorLoading) ? window.aipsAccessibilityReportL10n.errorLoading : 'Error loading report.')
-						}));
-						return;
-					}
+this.fetchReport(postId, historyId)
+.done(function (response) {
+if (!response || !response.success) {
+$content.html(T.render('aips-tmpl-access-report-error', {
+message: response && response.data && response.data.message
+? response.data.message
+: l10n.errorLoading
+}));
+return;
+}
 
-					if (!response.data || !response.data.report) {
-						$content.html(T.render('aips-tmpl-access-report-empty', {
-							message: (window.aipsAccessibilityReportL10n && window.aipsAccessibilityReportL10n.noReport) ? window.aipsAccessibilityReportL10n.noReport : 'No Accessibility Report is available for this post.'
-						}));
-						return;
-					}
+if (!response.data || !response.data.report) {
+$content.html(T.render('aips-tmpl-access-report-empty', {
+message: l10n.noReport
+}));
+return;
+}
 
-					if (response.data && response.data.post_title) {
-						$subtitle.text(response.data.post_title);
-					}
+if (response.data && response.data.post_title) {
+$subtitle.text(response.data.post_title);
+}
 
-					$content.html(AIPS.AccessibilityReport.renderReport(response.data.report));
-				})
-				.fail(function () {
-					$content.html(T.render('aips-tmpl-access-report-error', {
-						message: (window.aipsAccessibilityReportL10n && window.aipsAccessibilityReportL10n.errorLoading) ? window.aipsAccessibilityReportL10n.errorLoading : 'Error loading report.'
-					}));
-				});
-		},
+$content.html(AIPS.AccessibilityReport.renderReport(response.data.report));
+})
+.fail(function () {
+$content.html(T.render('aips-tmpl-access-report-error', {
+message: l10n.errorLoading
+}));
+});
+},
 
-		/**
-		 * Fetch the report from the server.
-		 *
-		 * @param {number} postId WordPress post ID.
-		 * @param {number} historyId History container ID.
-		 * @return {jqXHR} AJAX promise.
-		 */
-		fetchReport: function (postId, historyId) {
-			return $.ajax({
-				url: aipsAjax.ajaxUrl,
-				type: 'POST',
-				data: {
-					action: 'aips_get_accessibility_report',
-					nonce: aipsAjax.nonce,
-					post_id: postId,
-					history_id: historyId
-				}
-			});
-		},
+/**
+ * Fetch the report from the server.
+ *
+ * @param {number} postId WordPress post ID.
+ * @param {number} historyId History container ID.
+ * @return {jqXHR} AJAX promise.
+ */
+fetchReport: function (postId, historyId) {
+return $.ajax({
+url: aipsAjax.ajaxUrl,
+type: 'POST',
+data: {
+action: 'aips_get_accessibility_report',
+nonce: aipsAjax.nonce,
+post_id: postId,
+history_id: historyId
+}
+});
+},
 
-		/**
-		 * Render the report HTML.
-		 *
-		 * @param {Object} report Accessibility report payload.
-		 * @return {string} HTML string.
-		 */
-		renderReport: function (report) {
-			var esc = (AIPS.Templates && AIPS.Templates.escape) ? AIPS.Templates.escape : function (str) { return String(str || ''); };
+/**
+ * Render the report HTML.
+ *
+ * @param {Object} report Accessibility report payload.
+ * @return {string} HTML string.
+ */
+renderReport: function (report) {
+var l10n = window.aipsAccessibilityReportL10n;
+var warnings = (report && report.warnings && Array.isArray(report.warnings)) ? report.warnings : [];
+var headingOk = !!(report && report.heading_hierarchy_ok);
+var missingAlt = parseInt(report && report.missing_alt_images, 10) || 0;
+var longParagraphs = parseInt(report && report.long_paragraphs, 10) || 0;
+var score = parseInt(report && report.plain_language_score, 10);
+if (isNaN(score)) {
+score = null;
+}
+var target = parseInt(report && report.plain_language_target, 10) || 0;
 
-			var warnings = (report && report.warnings && Array.isArray(report.warnings)) ? report.warnings : [];
-			var headingOk = !!(report && report.heading_hierarchy_ok);
-			var missingAlt = parseInt(report && report.missing_alt_images, 10) || 0;
-			var longParagraphs = parseInt(report && report.long_paragraphs, 10) || 0;
-			var score = parseInt(report && report.plain_language_score, 10);
-			if (isNaN(score)) {
-				score = null;
-			}
-			var target = parseInt(report && report.plain_language_target, 10) || 0;
+var badLinkText = parseInt(report && report.non_descriptive_links, 10) || 0;
+var badLinkHref = parseInt(report && report.invalid_links, 10) || 0;
+var excessiveBreaks = parseInt(report && report.excessive_line_breaks, 10) || 0;
+var multipleH1 = parseInt(report && report.multiple_h1_count, 10) || 0;
 
-			var badLinkText = parseInt(report && report.non_descriptive_links, 10) || 0;
-			var badLinkHref = parseInt(report && report.invalid_links, 10) || 0;
-			var excessiveBreaks = parseInt(report && report.excessive_line_breaks, 10) || 0;
-			var multipleH1 = parseInt(report && report.multiple_h1_count, 10) || 0;
+var status = (warnings.length || !headingOk || missingAlt || longParagraphs || badLinkText || badLinkHref || excessiveBreaks || multipleH1) ? 'warning' : 'success';
+var statusBadge = this.renderBadge(status, status === 'success'
+? l10n.statusOk
+: l10n.statusIssues
+);
 
-			var status = (warnings.length || !headingOk || missingAlt || longParagraphs || badLinkText || badLinkHref || excessiveBreaks || multipleH1) ? 'warning' : 'success';
-			var statusBadge = this.renderBadge(status, status === 'success'
-				? ((window.aipsAccessibilityReportL10n && window.aipsAccessibilityReportL10n.statusOk) ? window.aipsAccessibilityReportL10n.statusOk : 'Looks good')
-				: ((window.aipsAccessibilityReportL10n && window.aipsAccessibilityReportL10n.statusIssues) ? window.aipsAccessibilityReportL10n.statusIssues : 'Issues found')
-			);
+var cards = '';
+cards += this.renderCard({
+title: l10n.headings,
+icon: 'editor-alignleft',
+status: (headingOk && multipleH1 <= 1) ? 'success' : 'warning',
+lines: [
+(headingOk ? 'No heading level skips detected.' : 'Heading levels skip (e.g. H2 to H4).'),
+(multipleH1 > 1 ? ('Multiple H1 headings detected: ' + multipleH1 + '.') : '')
+].filter(Boolean)
+});
 
-			var cards = '';
-			cards += this.renderCard({
-				title: (window.aipsAccessibilityReportL10n && window.aipsAccessibilityReportL10n.headings) ? window.aipsAccessibilityReportL10n.headings : 'Headings',
-				icon: 'editor-alignleft',
-				status: (headingOk && multipleH1 <= 1) ? 'success' : 'warning',
-				lines: [
-					(headingOk ? 'No heading level skips detected.' : 'Heading levels skip (e.g. H2 to H4).'),
-					(multipleH1 > 1 ? ('Multiple H1 headings detected: ' + multipleH1 + '.') : '')
-				].filter(Boolean)
-			});
+cards += this.renderCard({
+title: l10n.images,
+icon: 'format-image',
+status: missingAlt > 0 ? 'warning' : 'success',
+lines: [
+(missingAlt > 0 ? (missingAlt + ' image(s) missing alt text.') : 'All images include alt text.')
+]
+});
 
-			cards += this.renderCard({
-				title: (window.aipsAccessibilityReportL10n && window.aipsAccessibilityReportL10n.images) ? window.aipsAccessibilityReportL10n.images : 'Images',
-				icon: 'format-image',
-				status: missingAlt > 0 ? 'warning' : 'success',
-				lines: [
-					(missingAlt > 0 ? (missingAlt + ' image(s) missing alt text.') : 'All images include alt text.')
-				]
-			});
+cards += this.renderCard({
+title: l10n.readability,
+icon: 'editor-paragraph',
+status: (longParagraphs > 0 || (score !== null && target && score < target)) ? 'warning' : 'success',
+lines: [
+(longParagraphs > 0 ? (longParagraphs + ' long paragraph(s) detected.') : 'Paragraph length looks good.'),
+(score !== null ? ('Plain-language score: ' + score + (target ? (' (target ' + target + '+)') : '') + '.') : 'Plain-language score unavailable.')
+]
+});
 
-			cards += this.renderCard({
-				title: (window.aipsAccessibilityReportL10n && window.aipsAccessibilityReportL10n.readability) ? window.aipsAccessibilityReportL10n.readability : 'Readability',
-				icon: 'editor-paragraph',
-				status: (longParagraphs > 0 || (score !== null && target && score < target)) ? 'warning' : 'success',
-				lines: [
-					(longParagraphs > 0 ? (longParagraphs + ' long paragraph(s) detected.') : 'Paragraph length looks good.'),
-					(score !== null ? ('Plain-language score: ' + score + (target ? (' (target ' + target + '+)') : '') + '.') : 'Plain-language score unavailable.')
-				]
-			});
+cards += this.renderCard({
+title: l10n.links,
+icon: 'admin-links',
+status: (badLinkText || badLinkHref) ? 'warning' : 'success',
+lines: [
+(badLinkText ? (badLinkText + ' non-descriptive link(s) (e.g. "click here").') : 'Link text looks descriptive.'),
+(badLinkHref ? (badLinkHref + ' invalid link(s) (missing/placeholder href).') : 'All links have valid href.')
+]
+});
 
-			cards += this.renderCard({
-				title: (window.aipsAccessibilityReportL10n && window.aipsAccessibilityReportL10n.links) ? window.aipsAccessibilityReportL10n.links : 'Links',
-				icon: 'admin-links',
-				status: (badLinkText || badLinkHref) ? 'warning' : 'success',
-				lines: [
-					(badLinkText ? (badLinkText + ' non-descriptive link(s) (e.g. "click here").') : 'Link text looks descriptive.'),
-					(badLinkHref ? (badLinkHref + ' invalid link(s) (missing/placeholder href).') : 'All links have valid href.')
-				]
-			});
+cards += this.renderCard({
+title: l10n.formatting,
+icon: 'editor-kitchensink',
+status: excessiveBreaks ? 'warning' : 'success',
+lines: [
+(excessiveBreaks ? (excessiveBreaks + ' occurrence(s) of excessive <br> usage.') : 'No excessive line breaks detected.')
+]
+});
 
-			cards += this.renderCard({
-				title: (window.aipsAccessibilityReportL10n && window.aipsAccessibilityReportL10n.formatting) ? window.aipsAccessibilityReportL10n.formatting : 'Formatting',
-				icon: 'editor-kitchensink',
-				status: excessiveBreaks ? 'warning' : 'success',
-				lines: [
-					(excessiveBreaks ? (excessiveBreaks + ' occurrence(s) of excessive <br> usage.') : 'No excessive line breaks detected.')
-				]
-			});
+return AIPS.Templates.renderRaw('aips-tmpl-access-report-shell', {
+report_title: l10n.reportTitle,
+status_badge: statusBadge,
+cards_html: cards,
+findings_title: l10n.findings,
+findings_html: this.renderFindings(warnings, l10n.noFindings)
+});
+},
 
-			var findingsHtml = '';
-			if (warnings.length) {
-				findingsHtml += '<ul class="aips-access-report-findings">';
-				warnings.forEach(function (w) {
-					findingsHtml += '<li><span class="dashicons dashicons-warning" aria-hidden="true"></span><span>' + esc(w) + '</span></li>';
-				});
-				findingsHtml += '</ul>';
-			} else {
-				findingsHtml = '<div class="aips-access-report-findings-empty">' + esc((window.aipsAccessibilityReportL10n && window.aipsAccessibilityReportL10n.noFindings) ? window.aipsAccessibilityReportL10n.noFindings : 'No findings.') + '</div>';
-			}
+/**
+ * Render findings list.
+ *
+ * @param {Array<string>} warnings Warning messages.
+ * @param {string} noFindingsText Empty-state text.
+ * @return {string} HTML string.
+ */
+renderFindings: function (warnings, noFindingsText) {
+if (warnings.length) {
+var itemsHtml = '';
+warnings.forEach(function (warningText) {
+itemsHtml += AIPS.Templates.render('aips-tmpl-access-report-finding-item', {
+text: warningText
+});
+});
 
-			return ''
-				+ '<div class="aips-access-report">'
-				+   '<div class="aips-access-report-top">'
-				+     '<div class="aips-access-report-top-left">'
-				+       '<span class="dashicons dashicons-universal-access-alt" aria-hidden="true"></span>'
-				+       '<strong>' + esc((window.aipsAccessibilityReportL10n && window.aipsAccessibilityReportL10n.reportTitle) ? window.aipsAccessibilityReportL10n.reportTitle : 'Accessibility & Readability') + '</strong>'
-				+     '</div>'
-				+     '<div class="aips-access-report-top-right">' + statusBadge + '</div>'
-				+   '</div>'
-				+   '<div class="aips-access-report-grid">' + cards + '</div>'
-				+   '<div class="aips-access-report-section">'
-				+     '<h3>' + esc((window.aipsAccessibilityReportL10n && window.aipsAccessibilityReportL10n.findings) ? window.aipsAccessibilityReportL10n.findings : 'Findings') + '</h3>'
-				+     findingsHtml
-				+   '</div>'
-				+ '</div>';
-		},
+return AIPS.Templates.renderRaw('aips-tmpl-access-report-findings-list', {
+items_html: itemsHtml
+});
+}
 
-		/**
-		 * Render a status badge.
-		 *
-		 * @param {string} status success|warning|error|info
-		 * @param {string} text Label.
-		 * @return {string} HTML string.
-		 */
-		renderBadge: function (status, text) {
-			var esc = (AIPS.Templates && AIPS.Templates.escape) ? AIPS.Templates.escape : function (str) { return String(str || ''); };
-			var icon = 'info';
-			if (status === 'success') {
-				icon = 'yes-alt';
-			} else if (status === 'warning') {
-				icon = 'warning';
-			} else if (status === 'error') {
-				icon = 'dismiss';
-			}
+return AIPS.Templates.render('aips-tmpl-access-report-findings-empty', {
+message: noFindingsText
+});
+},
 
-			return '<span class="aips-badge aips-badge-' + esc(status) + '"><span class="dashicons dashicons-' + esc(icon) + '" aria-hidden="true"></span>' + esc(text) + '</span>';
-		},
+/**
+ * Render a status badge.
+ *
+ * @param {string} status success|warning|error|info
+ * @param {string} text Label.
+ * @return {string} HTML string.
+ */
+renderBadge: function (status, text) {
+var icon = 'info';
+if (status === 'success') {
+icon = 'yes-alt';
+} else if (status === 'warning') {
+icon = 'warning';
+} else if (status === 'error') {
+icon = 'dismiss';
+}
 
-		/**
-		 * Render a report card.
-		 *
-		 * @param {Object} args Card args.
-		 * @return {string} HTML string.
-		 */
-		renderCard: function (args) {
-			var esc = (AIPS.Templates && AIPS.Templates.escape) ? AIPS.Templates.escape : function (str) { return String(str || ''); };
-			var lines = (args && args.lines && Array.isArray(args.lines)) ? args.lines : [];
+return AIPS.Templates.render('aips-tmpl-access-report-badge', {
+status: status,
+icon: icon,
+text: text
+});
+},
 
-			var linesHtml = '';
-			if (lines.length) {
-				linesHtml += '<ul class="aips-access-report-card-lines">';
-				lines.forEach(function (line) {
-					linesHtml += '<li>' + esc(line) + '</li>';
-				});
-				linesHtml += '</ul>';
-			}
+/**
+ * Render a report card.
+ *
+ * @param {Object} args Card args.
+ * @return {string} HTML string.
+ */
+renderCard: function (args) {
+var lines = (args && args.lines && Array.isArray(args.lines)) ? args.lines : [];
+var linesHtml = '';
 
-			return ''
-				+ '<div class="aips-access-report-card aips-access-report-card-' + esc(args.status || 'neutral') + '">'
-				+   '<div class="aips-access-report-card-title">'
-				+     '<span class="dashicons dashicons-' + esc(args.icon || 'info') + '" aria-hidden="true"></span>'
-				+     '<span>' + esc(args.title || '') + '</span>'
-				+   '</div>'
-				+   '<div class="aips-access-report-card-body">' + linesHtml + '</div>'
-				+ '</div>';
-		},
+if (lines.length) {
+var lineItems = '';
+lines.forEach(function (line) {
+lineItems += AIPS.Templates.render('aips-tmpl-access-report-card-line', {
+text: line
+});
+});
 
-		/**
-		 * Close modal.
-		 *
-		 * @param {Event} e Click event.
-		 */
-		closeModal: function (e) {
-			if (e) {
-				e.preventDefault();
-			}
-			$('#aips-accessibility-report-modal').fadeOut(200);
-		},
+linesHtml = AIPS.Templates.renderRaw('aips-tmpl-access-report-card-lines', {
+items_html: lineItems
+});
+}
 
-		/**
-		 * Close modal when clicking overlay.
-		 *
-		 * @param {Event} e Click event.
-		 */
-		closeModalOnOverlay: function (e) {
-			if ($(e.target).is('#aips-accessibility-report-modal') || $(e.target).is('#aips-accessibility-report-modal .aips-modal-overlay')) {
-				this.closeModal(e);
-			}
-		},
+return AIPS.Templates.renderRaw('aips-tmpl-access-report-card', {
+status: args.status || 'neutral',
+icon: args.icon || 'info',
+title: args.title || '',
+lines_html: linesHtml
+});
+},
 
-		/**
-		 * Close modal on Escape.
-		 *
-		 * @param {Event} e Key event.
-		 */
-		onKeydown: function (e) {
-			if (e.key === 'Escape' && $('#aips-accessibility-report-modal').is(':visible')) {
-				this.closeModal(e);
-			}
-		}
-	};
+/**
+ * Close modal.
+ *
+ * @param {Event} e Click event.
+ */
+closeModal: function (e) {
+if (e) {
+e.preventDefault();
+}
+$('#aips-accessibility-report-modal').fadeOut(200);
+},
 
-	$(document).ready(function () {
-		if (AIPS.AccessibilityReport && typeof AIPS.AccessibilityReport.init === 'function') {
-			AIPS.AccessibilityReport.init();
-		}
-	});
+/**
+ * Close modal when clicking overlay.
+ *
+ * @param {Event} e Click event.
+ */
+closeModalOnOverlay: function (e) {
+if ($(e.target).is('#aips-accessibility-report-modal') || $(e.target).is('#aips-accessibility-report-modal .aips-modal-overlay')) {
+this.closeModal(e);
+}
+},
+
+/**
+ * Close modal on Escape.
+ *
+ * @param {Event} e Key event.
+ */
+onKeydown: function (e) {
+if (e.key === 'Escape' && $('#aips-accessibility-report-modal').is(':visible')) {
+this.closeModal(e);
+}
+}
+};
+
+$(document).ready(function () {
+if (AIPS.AccessibilityReport && typeof AIPS.AccessibilityReport.init === 'function') {
+AIPS.AccessibilityReport.init();
+}
+});
 
 })(jQuery);

--- a/ai-post-scheduler/assets/js/admin-accessibility-report.js
+++ b/ai-post-scheduler/assets/js/admin-accessibility-report.js
@@ -8,317 +8,317 @@
  */
 
 (function ($) {
-'use strict';
+	'use strict';
 
-window.AIPS = window.AIPS || {};
-var AIPS = window.AIPS;
+	window.AIPS = window.AIPS || {};
+	var AIPS = window.AIPS;
 
-/**
- * AIPS.AccessibilityReport — module for rendering the Accessibility Report modal.
- */
-AIPS.AccessibilityReport = {
+	/**
+	 * AIPS.AccessibilityReport — module for rendering the Accessibility Report modal.
+	 */
+	AIPS.AccessibilityReport = {
 
-/**
- * Initialise the module.
- */
-init: function () {
-this.bindEvents();
-},
+		/**
+		 * Initialise the module.
+		 */
+		init: function () {
+			this.bindEvents();
+		},
 
-/**
- * Register event listeners.
- */
-bindEvents: function () {
-$(document).on('click', '.aips-view-accessibility-report', this.openModal.bind(this));
-$(document).on('click', '#aips-accessibility-report-modal .aips-modal-close', this.closeModal.bind(this));
-$(document).on('click', '#aips-accessibility-report-modal', this.closeModalOnOverlay.bind(this));
-$(document).on('keydown', this.onKeydown.bind(this));
-},
+		/**
+		 * Register event listeners.
+		 */
+		bindEvents: function () {
+			$(document).on('click', '.aips-view-accessibility-report', this.openModal.bind(this));
+			$(document).on('click', '#aips-accessibility-report-modal .aips-modal-close', this.closeModal.bind(this));
+			$(document).on('click', '#aips-accessibility-report-modal', this.closeModalOnOverlay.bind(this));
+			$(document).on('keydown', this.onKeydown.bind(this));
+		},
 
-/**
- * Open the report modal and fetch report data via AJAX.
- *
- * @param {Event} e Click event.
- */
-openModal: function (e) {
-e.preventDefault();
-e.stopPropagation();
+		/**
+		 * Open the report modal and fetch report data via AJAX.
+		 *
+		 * @param {Event} e Click event.
+		 */
+		openModal: function (e) {
+			e.preventDefault();
+			e.stopPropagation();
 
-var $btn = $(e.currentTarget);
-var postId = parseInt($btn.data('post-id'), 10) || 0;
-var historyId = parseInt($btn.data('history-id'), 10) || 0;
-var l10n = window.aipsAccessibilityReportL10n;
+			var $btn = $(e.currentTarget);
+			var postId = parseInt($btn.data('post-id'), 10) || 0;
+			var historyId = parseInt($btn.data('history-id'), 10) || 0;
+			var l10n = window.aipsAccessibilityReportL10n;
 
-var $modal = $('#aips-accessibility-report-modal');
-var $content = $('#aips-accessibility-report-content');
-var $subtitle = $('#aips-accessibility-report-modal-subtitle');
-var T = AIPS.Templates;
+			var $modal = $('#aips-accessibility-report-modal');
+			var $content = $('#aips-accessibility-report-content');
+			var $subtitle = $('#aips-accessibility-report-modal-subtitle');
+			var T = AIPS.Templates;
 
-$subtitle.text('');
-$content.html(T.render('aips-tmpl-access-report-loading', {
-text: l10n.loading
-}));
+			$subtitle.text('');
+			$content.html(T.render('aips-tmpl-access-report-loading', {
+				text: l10n.loading
+			}));
 
-$modal.fadeIn(200);
+			$modal.fadeIn(200);
 
-this.fetchReport(postId, historyId)
-.done(function (response) {
-if (!response || !response.success) {
-$content.html(T.render('aips-tmpl-access-report-error', {
-message: response && response.data && response.data.message
-? response.data.message
-: l10n.errorLoading
-}));
-return;
-}
+			this.fetchReport(postId, historyId)
+				.done(function (response) {
+					if (!response || !response.success) {
+						$content.html(T.render('aips-tmpl-access-report-error', {
+							message: response && response.data && response.data.message
+								? response.data.message
+								: l10n.errorLoading
+						}));
+						return;
+					}
 
-if (!response.data || !response.data.report) {
-$content.html(T.render('aips-tmpl-access-report-empty', {
-message: l10n.noReport
-}));
-return;
-}
+					if (!response.data || !response.data.report) {
+						$content.html(T.render('aips-tmpl-access-report-empty', {
+							message: l10n.noReport
+						}));
+						return;
+					}
 
-if (response.data && response.data.post_title) {
-$subtitle.text(response.data.post_title);
-}
+					if (response.data && response.data.post_title) {
+						$subtitle.text(response.data.post_title);
+					}
 
-$content.html(AIPS.AccessibilityReport.renderReport(response.data.report));
-})
-.fail(function () {
-$content.html(T.render('aips-tmpl-access-report-error', {
-message: l10n.errorLoading
-}));
-});
-},
+					$content.html(AIPS.AccessibilityReport.renderReport(response.data.report));
+				})
+				.fail(function () {
+					$content.html(T.render('aips-tmpl-access-report-error', {
+						message: l10n.errorLoading
+					}));
+				});
+		},
 
-/**
- * Fetch the report from the server.
- *
- * @param {number} postId WordPress post ID.
- * @param {number} historyId History container ID.
- * @return {jqXHR} AJAX promise.
- */
-fetchReport: function (postId, historyId) {
-return $.ajax({
-url: aipsAjax.ajaxUrl,
-type: 'POST',
-data: {
-action: 'aips_get_accessibility_report',
-nonce: aipsAjax.nonce,
-post_id: postId,
-history_id: historyId
-}
-});
-},
+		/**
+		 * Fetch the report from the server.
+		 *
+		 * @param {number} postId WordPress post ID.
+		 * @param {number} historyId History container ID.
+		 * @return {jqXHR} AJAX promise.
+		 */
+		fetchReport: function (postId, historyId) {
+			return $.ajax({
+				url: aipsAjax.ajaxUrl,
+				type: 'POST',
+				data: {
+					action: 'aips_get_accessibility_report',
+					nonce: aipsAjax.nonce,
+					post_id: postId,
+					history_id: historyId
+				}
+			});
+		},
 
-/**
- * Render the report HTML.
- *
- * @param {Object} report Accessibility report payload.
- * @return {string} HTML string.
- */
-renderReport: function (report) {
-var l10n = window.aipsAccessibilityReportL10n;
-var warnings = (report && report.warnings && Array.isArray(report.warnings)) ? report.warnings : [];
-var headingOk = !!(report && report.heading_hierarchy_ok);
-var missingAlt = parseInt(report && report.missing_alt_images, 10) || 0;
-var longParagraphs = parseInt(report && report.long_paragraphs, 10) || 0;
-var score = parseInt(report && report.plain_language_score, 10);
-if (isNaN(score)) {
-score = null;
-}
-var target = parseInt(report && report.plain_language_target, 10) || 0;
+		/**
+		 * Render the report HTML.
+		 *
+		 * @param {Object} report Accessibility report payload.
+		 * @return {string} HTML string.
+		 */
+		renderReport: function (report) {
+			var l10n = window.aipsAccessibilityReportL10n;
+			var warnings = (report && report.warnings && Array.isArray(report.warnings)) ? report.warnings : [];
+			var headingOk = !!(report && report.heading_hierarchy_ok);
+			var missingAlt = parseInt(report && report.missing_alt_images, 10) || 0;
+			var longParagraphs = parseInt(report && report.long_paragraphs, 10) || 0;
+			var score = parseInt(report && report.plain_language_score, 10);
+			if (isNaN(score)) {
+				score = null;
+			}
+			var target = parseInt(report && report.plain_language_target, 10) || 0;
 
-var badLinkText = parseInt(report && report.non_descriptive_links, 10) || 0;
-var badLinkHref = parseInt(report && report.invalid_links, 10) || 0;
-var excessiveBreaks = parseInt(report && report.excessive_line_breaks, 10) || 0;
-var multipleH1 = parseInt(report && report.multiple_h1_count, 10) || 0;
+			var badLinkText = parseInt(report && report.non_descriptive_links, 10) || 0;
+			var badLinkHref = parseInt(report && report.invalid_links, 10) || 0;
+			var excessiveBreaks = parseInt(report && report.excessive_line_breaks, 10) || 0;
+			var multipleH1 = parseInt(report && report.multiple_h1_count, 10) || 0;
 
-var status = (warnings.length || !headingOk || missingAlt || longParagraphs || badLinkText || badLinkHref || excessiveBreaks || multipleH1) ? 'warning' : 'success';
-var statusBadge = this.renderBadge(status, status === 'success'
-? l10n.statusOk
-: l10n.statusIssues
-);
+			var status = (warnings.length || !headingOk || missingAlt || longParagraphs || badLinkText || badLinkHref || excessiveBreaks || multipleH1) ? 'warning' : 'success';
+			var statusBadge = this.renderBadge(status, status === 'success'
+				? l10n.statusOk
+				: l10n.statusIssues
+			);
 
-var cards = '';
-cards += this.renderCard({
-title: l10n.headings,
-icon: 'editor-alignleft',
-status: (headingOk && multipleH1 <= 1) ? 'success' : 'warning',
-lines: [
-(headingOk ? 'No heading level skips detected.' : 'Heading levels skip (e.g. H2 to H4).'),
-(multipleH1 > 1 ? ('Multiple H1 headings detected: ' + multipleH1 + '.') : '')
-].filter(Boolean)
-});
+			var cards = '';
+			cards += this.renderCard({
+				title: l10n.headings,
+				icon: 'editor-alignleft',
+				status: (headingOk && multipleH1 <= 1) ? 'success' : 'warning',
+				lines: [
+					(headingOk ? 'No heading level skips detected.' : 'Heading levels skip (e.g. H2 to H4).'),
+					(multipleH1 > 1 ? ('Multiple H1 headings detected: ' + multipleH1 + '.') : '')
+				].filter(Boolean)
+			});
 
-cards += this.renderCard({
-title: l10n.images,
-icon: 'format-image',
-status: missingAlt > 0 ? 'warning' : 'success',
-lines: [
-(missingAlt > 0 ? (missingAlt + ' image(s) missing alt text.') : 'All images include alt text.')
-]
-});
+			cards += this.renderCard({
+				title: l10n.images,
+				icon: 'format-image',
+				status: missingAlt > 0 ? 'warning' : 'success',
+				lines: [
+					(missingAlt > 0 ? (missingAlt + ' image(s) missing alt text.') : 'All images include alt text.')
+				]
+			});
 
-cards += this.renderCard({
-title: l10n.readability,
-icon: 'editor-paragraph',
-status: (longParagraphs > 0 || (score !== null && target && score < target)) ? 'warning' : 'success',
-lines: [
-(longParagraphs > 0 ? (longParagraphs + ' long paragraph(s) detected.') : 'Paragraph length looks good.'),
-(score !== null ? ('Plain-language score: ' + score + (target ? (' (target ' + target + '+)') : '') + '.') : 'Plain-language score unavailable.')
-]
-});
+			cards += this.renderCard({
+				title: l10n.readability,
+				icon: 'editor-paragraph',
+				status: (longParagraphs > 0 || (score !== null && target && score < target)) ? 'warning' : 'success',
+				lines: [
+					(longParagraphs > 0 ? (longParagraphs + ' long paragraph(s) detected.') : 'Paragraph length looks good.'),
+					(score !== null ? ('Plain-language score: ' + score + (target ? (' (target ' + target + '+)') : '') + '.') : 'Plain-language score unavailable.')
+				]
+			});
 
-cards += this.renderCard({
-title: l10n.links,
-icon: 'admin-links',
-status: (badLinkText || badLinkHref) ? 'warning' : 'success',
-lines: [
-(badLinkText ? (badLinkText + ' non-descriptive link(s) (e.g. "click here").') : 'Link text looks descriptive.'),
-(badLinkHref ? (badLinkHref + ' invalid link(s) (missing/placeholder href).') : 'All links have valid href.')
-]
-});
+			cards += this.renderCard({
+				title: l10n.links,
+				icon: 'admin-links',
+				status: (badLinkText || badLinkHref) ? 'warning' : 'success',
+				lines: [
+					(badLinkText ? (badLinkText + ' non-descriptive link(s) (e.g. "click here").') : 'Link text looks descriptive.'),
+					(badLinkHref ? (badLinkHref + ' invalid link(s) (missing/placeholder href).') : 'All links have valid href.')
+				]
+			});
 
-cards += this.renderCard({
-title: l10n.formatting,
-icon: 'editor-kitchensink',
-status: excessiveBreaks ? 'warning' : 'success',
-lines: [
-(excessiveBreaks ? (excessiveBreaks + ' occurrence(s) of excessive <br> usage.') : 'No excessive line breaks detected.')
-]
-});
+			cards += this.renderCard({
+				title: l10n.formatting,
+				icon: 'editor-kitchensink',
+				status: excessiveBreaks ? 'warning' : 'success',
+				lines: [
+					(excessiveBreaks ? (excessiveBreaks + ' occurrence(s) of excessive <br> usage.') : 'No excessive line breaks detected.')
+				]
+			});
 
-return AIPS.Templates.renderRaw('aips-tmpl-access-report-shell', {
-report_title: l10n.reportTitle,
-status_badge: statusBadge,
-cards_html: cards,
-findings_title: l10n.findings,
-findings_html: this.renderFindings(warnings, l10n.noFindings)
-});
-},
+			return AIPS.Templates.renderRaw('aips-tmpl-access-report-shell', {
+				report_title: l10n.reportTitle,
+				status_badge: statusBadge,
+				cards_html: cards,
+				findings_title: l10n.findings,
+				findings_html: this.renderFindings(warnings, l10n.noFindings)
+			});
+		},
 
-/**
- * Render findings list.
- *
- * @param {Array<string>} warnings Warning messages.
- * @param {string} noFindingsText Empty-state text.
- * @return {string} HTML string.
- */
-renderFindings: function (warnings, noFindingsText) {
-if (warnings.length) {
-var itemsHtml = '';
-warnings.forEach(function (warningText) {
-itemsHtml += AIPS.Templates.render('aips-tmpl-access-report-finding-item', {
-text: warningText
-});
-});
+		/**
+		 * Render findings list.
+		 *
+		 * @param {Array<string>} warnings Warning messages.
+		 * @param {string} noFindingsText Empty-state text.
+		 * @return {string} HTML string.
+		 */
+		renderFindings: function (warnings, noFindingsText) {
+			if (warnings.length) {
+				var itemsHtml = '';
+				warnings.forEach(function (warningText) {
+					itemsHtml += AIPS.Templates.render('aips-tmpl-access-report-finding-item', {
+						text: warningText
+					});
+				});
 
-return AIPS.Templates.renderRaw('aips-tmpl-access-report-findings-list', {
-items_html: itemsHtml
-});
-}
+				return AIPS.Templates.renderRaw('aips-tmpl-access-report-findings-list', {
+					items_html: itemsHtml
+				});
+			}
 
-return AIPS.Templates.render('aips-tmpl-access-report-findings-empty', {
-message: noFindingsText
-});
-},
+			return AIPS.Templates.render('aips-tmpl-access-report-findings-empty', {
+				message: noFindingsText
+			});
+		},
 
-/**
- * Render a status badge.
- *
- * @param {string} status success|warning|error|info
- * @param {string} text Label.
- * @return {string} HTML string.
- */
-renderBadge: function (status, text) {
-var icon = 'info';
-if (status === 'success') {
-icon = 'yes-alt';
-} else if (status === 'warning') {
-icon = 'warning';
-} else if (status === 'error') {
-icon = 'dismiss';
-}
+		/**
+		 * Render a status badge.
+		 *
+		 * @param {string} status success|warning|error|info
+		 * @param {string} text Label.
+		 * @return {string} HTML string.
+		 */
+		renderBadge: function (status, text) {
+			var icon = 'info';
+			if (status === 'success') {
+				icon = 'yes-alt';
+			} else if (status === 'warning') {
+				icon = 'warning';
+			} else if (status === 'error') {
+				icon = 'dismiss';
+			}
 
-return AIPS.Templates.render('aips-tmpl-access-report-badge', {
-status: status,
-icon: icon,
-text: text
-});
-},
+			return AIPS.Templates.render('aips-tmpl-access-report-badge', {
+				status: status,
+				icon: icon,
+				text: text
+			});
+		},
 
-/**
- * Render a report card.
- *
- * @param {Object} args Card args.
- * @return {string} HTML string.
- */
-renderCard: function (args) {
-var lines = (args && args.lines && Array.isArray(args.lines)) ? args.lines : [];
-var linesHtml = '';
+		/**
+		 * Render a report card.
+		 *
+		 * @param {Object} args Card args.
+		 * @return {string} HTML string.
+		 */
+		renderCard: function (args) {
+			var lines = (args && args.lines && Array.isArray(args.lines)) ? args.lines : [];
+			var linesHtml = '';
 
-if (lines.length) {
-var lineItems = '';
-lines.forEach(function (line) {
-lineItems += AIPS.Templates.render('aips-tmpl-access-report-card-line', {
-text: line
-});
-});
+			if (lines.length) {
+				var lineItems = '';
+				lines.forEach(function (line) {
+					lineItems += AIPS.Templates.render('aips-tmpl-access-report-card-line', {
+						text: line
+					});
+				});
 
-linesHtml = AIPS.Templates.renderRaw('aips-tmpl-access-report-card-lines', {
-items_html: lineItems
-});
-}
+				linesHtml = AIPS.Templates.renderRaw('aips-tmpl-access-report-card-lines', {
+					items_html: lineItems
+				});
+			}
 
-return AIPS.Templates.renderRaw('aips-tmpl-access-report-card', {
-status: args.status || 'neutral',
-icon: args.icon || 'info',
-title: args.title || '',
-lines_html: linesHtml
-});
-},
+			return AIPS.Templates.renderRaw('aips-tmpl-access-report-card', {
+				status: args.status || 'neutral',
+				icon: args.icon || 'info',
+				title: args.title || '',
+				lines_html: linesHtml
+			});
+		},
 
-/**
- * Close modal.
- *
- * @param {Event} e Click event.
- */
-closeModal: function (e) {
-if (e) {
-e.preventDefault();
-}
-$('#aips-accessibility-report-modal').fadeOut(200);
-},
+		/**
+		 * Close modal.
+		 *
+		 * @param {Event} e Click event.
+		 */
+		closeModal: function (e) {
+			if (e) {
+				e.preventDefault();
+			}
+			$('#aips-accessibility-report-modal').fadeOut(200);
+		},
 
-/**
- * Close modal when clicking overlay.
- *
- * @param {Event} e Click event.
- */
-closeModalOnOverlay: function (e) {
-if ($(e.target).is('#aips-accessibility-report-modal') || $(e.target).is('#aips-accessibility-report-modal .aips-modal-overlay')) {
-this.closeModal(e);
-}
-},
+		/**
+		 * Close modal when clicking overlay.
+		 *
+		 * @param {Event} e Click event.
+		 */
+		closeModalOnOverlay: function (e) {
+			if ($(e.target).is('#aips-accessibility-report-modal') || $(e.target).is('#aips-accessibility-report-modal .aips-modal-overlay')) {
+				this.closeModal(e);
+			}
+		},
 
-/**
- * Close modal on Escape.
- *
- * @param {Event} e Key event.
- */
-onKeydown: function (e) {
-if (e.key === 'Escape' && $('#aips-accessibility-report-modal').is(':visible')) {
-this.closeModal(e);
-}
-}
-};
+		/**
+		 * Close modal on Escape.
+		 *
+		 * @param {Event} e Key event.
+		 */
+		onKeydown: function (e) {
+			if (e.key === 'Escape' && $('#aips-accessibility-report-modal').is(':visible')) {
+				this.closeModal(e);
+			}
+		}
+	};
 
-$(document).ready(function () {
-if (AIPS.AccessibilityReport && typeof AIPS.AccessibilityReport.init === 'function') {
-AIPS.AccessibilityReport.init();
-}
-});
+	$(document).ready(function () {
+		if (AIPS.AccessibilityReport && typeof AIPS.AccessibilityReport.init === 'function') {
+			AIPS.AccessibilityReport.init();
+		}
+	});
 
 })(jQuery);

--- a/ai-post-scheduler/assets/js/admin-accessibility-report.js
+++ b/ai-post-scheduler/assets/js/admin-accessibility-report.js
@@ -1,0 +1,312 @@
+/**
+ * Accessibility Report Modal JavaScript
+ *
+ * Displays the Accessibility Report for a generated post in a stylized modal.
+ *
+ * @package AI_Post_Scheduler
+ * @since 2.5.0
+ */
+
+(function ($) {
+	'use strict';
+
+	window.AIPS = window.AIPS || {};
+	var AIPS = window.AIPS;
+
+	/**
+	 * AIPS.AccessibilityReport — module for rendering the Accessibility Report modal.
+	 */
+	AIPS.AccessibilityReport = {
+
+		/**
+		 * Initialise the module.
+		 */
+		init: function () {
+			this.bindEvents();
+		},
+
+		/**
+		 * Register event listeners.
+		 */
+		bindEvents: function () {
+			$(document).on('click', '.aips-view-accessibility-report', this.openModal.bind(this));
+			$(document).on('click', '#aips-accessibility-report-modal .aips-modal-close', this.closeModal.bind(this));
+			$(document).on('click', '#aips-accessibility-report-modal', this.closeModalOnOverlay.bind(this));
+			$(document).on('keydown', this.onKeydown.bind(this));
+		},
+
+		/**
+		 * Open the report modal and fetch report data via AJAX.
+		 *
+		 * @param {Event} e Click event.
+		 */
+		openModal: function (e) {
+			e.preventDefault();
+			e.stopPropagation();
+
+			var $btn = $(e.currentTarget);
+			var postId = parseInt($btn.data('post-id'), 10) || 0;
+			var historyId = parseInt($btn.data('history-id'), 10) || 0;
+
+			var $modal = $('#aips-accessibility-report-modal');
+			var $content = $('#aips-accessibility-report-content');
+			var $subtitle = $('#aips-accessibility-report-modal-subtitle');
+			var T = AIPS.Templates;
+
+			$subtitle.text('');
+			$content.html(T.render('aips-tmpl-access-report-loading', {
+				text: (window.aipsAccessibilityReportL10n && window.aipsAccessibilityReportL10n.loading) ? window.aipsAccessibilityReportL10n.loading : 'Loading report\u2026'
+			}));
+
+			$modal.fadeIn(200);
+
+			this.fetchReport(postId, historyId)
+				.done(function (response) {
+					if (!response || !response.success) {
+						$content.html(T.render('aips-tmpl-access-report-error', {
+							message: response && response.data && response.data.message
+								? response.data.message
+								: ((window.aipsAccessibilityReportL10n && window.aipsAccessibilityReportL10n.errorLoading) ? window.aipsAccessibilityReportL10n.errorLoading : 'Error loading report.')
+						}));
+						return;
+					}
+
+					if (!response.data || !response.data.report) {
+						$content.html(T.render('aips-tmpl-access-report-empty', {
+							message: (window.aipsAccessibilityReportL10n && window.aipsAccessibilityReportL10n.noReport) ? window.aipsAccessibilityReportL10n.noReport : 'No Accessibility Report is available for this post.'
+						}));
+						return;
+					}
+
+					if (response.data && response.data.post_title) {
+						$subtitle.text(response.data.post_title);
+					}
+
+					$content.html(AIPS.AccessibilityReport.renderReport(response.data.report));
+				})
+				.fail(function () {
+					$content.html(T.render('aips-tmpl-access-report-error', {
+						message: (window.aipsAccessibilityReportL10n && window.aipsAccessibilityReportL10n.errorLoading) ? window.aipsAccessibilityReportL10n.errorLoading : 'Error loading report.'
+					}));
+				});
+		},
+
+		/**
+		 * Fetch the report from the server.
+		 *
+		 * @param {number} postId WordPress post ID.
+		 * @param {number} historyId History container ID.
+		 * @return {jqXHR} AJAX promise.
+		 */
+		fetchReport: function (postId, historyId) {
+			return $.ajax({
+				url: aipsAjax.ajaxUrl,
+				type: 'POST',
+				data: {
+					action: 'aips_get_accessibility_report',
+					nonce: aipsAjax.nonce,
+					post_id: postId,
+					history_id: historyId
+				}
+			});
+		},
+
+		/**
+		 * Render the report HTML.
+		 *
+		 * @param {Object} report Accessibility report payload.
+		 * @return {string} HTML string.
+		 */
+		renderReport: function (report) {
+			var esc = (AIPS.Templates && AIPS.Templates.escape) ? AIPS.Templates.escape : function (str) { return String(str || ''); };
+
+			var warnings = (report && report.warnings && Array.isArray(report.warnings)) ? report.warnings : [];
+			var headingOk = !!(report && report.heading_hierarchy_ok);
+			var missingAlt = parseInt(report && report.missing_alt_images, 10) || 0;
+			var longParagraphs = parseInt(report && report.long_paragraphs, 10) || 0;
+			var score = parseInt(report && report.plain_language_score, 10);
+			if (isNaN(score)) {
+				score = null;
+			}
+			var target = parseInt(report && report.plain_language_target, 10) || 0;
+
+			var badLinkText = parseInt(report && report.non_descriptive_links, 10) || 0;
+			var badLinkHref = parseInt(report && report.invalid_links, 10) || 0;
+			var excessiveBreaks = parseInt(report && report.excessive_line_breaks, 10) || 0;
+			var multipleH1 = parseInt(report && report.multiple_h1_count, 10) || 0;
+
+			var status = (warnings.length || !headingOk || missingAlt || longParagraphs || badLinkText || badLinkHref || excessiveBreaks || multipleH1) ? 'warning' : 'success';
+			var statusBadge = this.renderBadge(status, status === 'success'
+				? ((window.aipsAccessibilityReportL10n && window.aipsAccessibilityReportL10n.statusOk) ? window.aipsAccessibilityReportL10n.statusOk : 'Looks good')
+				: ((window.aipsAccessibilityReportL10n && window.aipsAccessibilityReportL10n.statusIssues) ? window.aipsAccessibilityReportL10n.statusIssues : 'Issues found')
+			);
+
+			var cards = '';
+			cards += this.renderCard({
+				title: (window.aipsAccessibilityReportL10n && window.aipsAccessibilityReportL10n.headings) ? window.aipsAccessibilityReportL10n.headings : 'Headings',
+				icon: 'editor-alignleft',
+				status: (headingOk && multipleH1 <= 1) ? 'success' : 'warning',
+				lines: [
+					(headingOk ? 'No heading level skips detected.' : 'Heading levels skip (e.g. H2 to H4).'),
+					(multipleH1 > 1 ? ('Multiple H1 headings detected: ' + multipleH1 + '.') : '')
+				].filter(Boolean)
+			});
+
+			cards += this.renderCard({
+				title: (window.aipsAccessibilityReportL10n && window.aipsAccessibilityReportL10n.images) ? window.aipsAccessibilityReportL10n.images : 'Images',
+				icon: 'format-image',
+				status: missingAlt > 0 ? 'warning' : 'success',
+				lines: [
+					(missingAlt > 0 ? (missingAlt + ' image(s) missing alt text.') : 'All images include alt text.')
+				]
+			});
+
+			cards += this.renderCard({
+				title: (window.aipsAccessibilityReportL10n && window.aipsAccessibilityReportL10n.readability) ? window.aipsAccessibilityReportL10n.readability : 'Readability',
+				icon: 'editor-paragraph',
+				status: (longParagraphs > 0 || (score !== null && target && score < target)) ? 'warning' : 'success',
+				lines: [
+					(longParagraphs > 0 ? (longParagraphs + ' long paragraph(s) detected.') : 'Paragraph length looks good.'),
+					(score !== null ? ('Plain-language score: ' + score + (target ? (' (target ' + target + '+)') : '') + '.') : 'Plain-language score unavailable.')
+				]
+			});
+
+			cards += this.renderCard({
+				title: (window.aipsAccessibilityReportL10n && window.aipsAccessibilityReportL10n.links) ? window.aipsAccessibilityReportL10n.links : 'Links',
+				icon: 'admin-links',
+				status: (badLinkText || badLinkHref) ? 'warning' : 'success',
+				lines: [
+					(badLinkText ? (badLinkText + ' non-descriptive link(s) (e.g. "click here").') : 'Link text looks descriptive.'),
+					(badLinkHref ? (badLinkHref + ' invalid link(s) (missing/placeholder href).') : 'All links have valid href.')
+				]
+			});
+
+			cards += this.renderCard({
+				title: (window.aipsAccessibilityReportL10n && window.aipsAccessibilityReportL10n.formatting) ? window.aipsAccessibilityReportL10n.formatting : 'Formatting',
+				icon: 'editor-kitchensink',
+				status: excessiveBreaks ? 'warning' : 'success',
+				lines: [
+					(excessiveBreaks ? (excessiveBreaks + ' occurrence(s) of excessive <br> usage.') : 'No excessive line breaks detected.')
+				]
+			});
+
+			var findingsHtml = '';
+			if (warnings.length) {
+				findingsHtml += '<ul class="aips-access-report-findings">';
+				warnings.forEach(function (w) {
+					findingsHtml += '<li><span class="dashicons dashicons-warning" aria-hidden="true"></span><span>' + esc(w) + '</span></li>';
+				});
+				findingsHtml += '</ul>';
+			} else {
+				findingsHtml = '<div class="aips-access-report-findings-empty">' + esc((window.aipsAccessibilityReportL10n && window.aipsAccessibilityReportL10n.noFindings) ? window.aipsAccessibilityReportL10n.noFindings : 'No findings.') + '</div>';
+			}
+
+			return ''
+				+ '<div class="aips-access-report">'
+				+   '<div class="aips-access-report-top">'
+				+     '<div class="aips-access-report-top-left">'
+				+       '<span class="dashicons dashicons-universal-access-alt" aria-hidden="true"></span>'
+				+       '<strong>' + esc((window.aipsAccessibilityReportL10n && window.aipsAccessibilityReportL10n.reportTitle) ? window.aipsAccessibilityReportL10n.reportTitle : 'Accessibility & Readability') + '</strong>'
+				+     '</div>'
+				+     '<div class="aips-access-report-top-right">' + statusBadge + '</div>'
+				+   '</div>'
+				+   '<div class="aips-access-report-grid">' + cards + '</div>'
+				+   '<div class="aips-access-report-section">'
+				+     '<h3>' + esc((window.aipsAccessibilityReportL10n && window.aipsAccessibilityReportL10n.findings) ? window.aipsAccessibilityReportL10n.findings : 'Findings') + '</h3>'
+				+     findingsHtml
+				+   '</div>'
+				+ '</div>';
+		},
+
+		/**
+		 * Render a status badge.
+		 *
+		 * @param {string} status success|warning|error|info
+		 * @param {string} text Label.
+		 * @return {string} HTML string.
+		 */
+		renderBadge: function (status, text) {
+			var esc = (AIPS.Templates && AIPS.Templates.escape) ? AIPS.Templates.escape : function (str) { return String(str || ''); };
+			var icon = 'info';
+			if (status === 'success') {
+				icon = 'yes-alt';
+			} else if (status === 'warning') {
+				icon = 'warning';
+			} else if (status === 'error') {
+				icon = 'dismiss';
+			}
+
+			return '<span class="aips-badge aips-badge-' + esc(status) + '"><span class="dashicons dashicons-' + esc(icon) + '" aria-hidden="true"></span>' + esc(text) + '</span>';
+		},
+
+		/**
+		 * Render a report card.
+		 *
+		 * @param {Object} args Card args.
+		 * @return {string} HTML string.
+		 */
+		renderCard: function (args) {
+			var esc = (AIPS.Templates && AIPS.Templates.escape) ? AIPS.Templates.escape : function (str) { return String(str || ''); };
+			var lines = (args && args.lines && Array.isArray(args.lines)) ? args.lines : [];
+
+			var linesHtml = '';
+			if (lines.length) {
+				linesHtml += '<ul class="aips-access-report-card-lines">';
+				lines.forEach(function (line) {
+					linesHtml += '<li>' + esc(line) + '</li>';
+				});
+				linesHtml += '</ul>';
+			}
+
+			return ''
+				+ '<div class="aips-access-report-card aips-access-report-card-' + esc(args.status || 'neutral') + '">'
+				+   '<div class="aips-access-report-card-title">'
+				+     '<span class="dashicons dashicons-' + esc(args.icon || 'info') + '" aria-hidden="true"></span>'
+				+     '<span>' + esc(args.title || '') + '</span>'
+				+   '</div>'
+				+   '<div class="aips-access-report-card-body">' + linesHtml + '</div>'
+				+ '</div>';
+		},
+
+		/**
+		 * Close modal.
+		 *
+		 * @param {Event} e Click event.
+		 */
+		closeModal: function (e) {
+			if (e) {
+				e.preventDefault();
+			}
+			$('#aips-accessibility-report-modal').fadeOut(200);
+		},
+
+		/**
+		 * Close modal when clicking overlay.
+		 *
+		 * @param {Event} e Click event.
+		 */
+		closeModalOnOverlay: function (e) {
+			if ($(e.target).is('#aips-accessibility-report-modal') || $(e.target).is('#aips-accessibility-report-modal .aips-modal-overlay')) {
+				this.closeModal(e);
+			}
+		},
+
+		/**
+		 * Close modal on Escape.
+		 *
+		 * @param {Event} e Key event.
+		 */
+		onKeydown: function (e) {
+			if (e.key === 'Escape' && $('#aips-accessibility-report-modal').is(':visible')) {
+				this.closeModal(e);
+			}
+		}
+	};
+
+	$(document).ready(function () {
+		if (AIPS.AccessibilityReport && typeof AIPS.AccessibilityReport.init === 'function') {
+			AIPS.AccessibilityReport.init();
+		}
+	});
+
+})(jQuery);

--- a/ai-post-scheduler/includes/class-aips-accessibility-guardrails.php
+++ b/ai-post-scheduler/includes/class-aips-accessibility-guardrails.php
@@ -1,0 +1,151 @@
+<?php
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+/**
+ * Accessibility guardrails checks for generated post content.
+ */
+class AIPS_Accessibility_Guardrails {
+
+	/**
+	 * Analyze generated HTML content for accessibility/readability risks.
+	 *
+	 * @param string $content Generated post content.
+	 * @return array<string,mixed>
+	 */
+	public function analyze($content) {
+		$content = is_string($content) ? $content : '';
+		$results = array(
+			'heading_hierarchy_ok' => true,
+			'missing_alt_images' => 0,
+			'long_paragraphs' => 0,
+			'plain_language_score' => 100,
+			'plain_language_target' => 60,
+			'warnings' => array(),
+		);
+
+		if ($content === '') {
+			$results['warnings'][] = __('Generated content is empty; accessibility checks skipped.', 'ai-post-scheduler');
+			$results['heading_hierarchy_ok'] = false;
+			$results['plain_language_score'] = 0;
+			return $results;
+		}
+
+		$results = $this->check_heading_hierarchy($content, $results);
+		$results = $this->check_image_alt_text($content, $results);
+		$results = $this->check_paragraph_readability($content, $results);
+		$results = $this->check_plain_language_score($content, $results);
+
+		return $results;
+	}
+
+	private function check_heading_hierarchy($content, $results) {
+		preg_match_all('/<h([1-6])\b[^>]*>/i', $content, $matches);
+		$levels = array_map('intval', isset($matches[1]) ? $matches[1] : array());
+
+		$previous = 0;
+		foreach ($levels as $level) {
+			if ($previous > 0 && ($level - $previous) > 1) {
+				$results['heading_hierarchy_ok'] = false;
+				$results['warnings'][] = __('Heading hierarchy skips levels (for example H2 to H4).', 'ai-post-scheduler');
+				break;
+			}
+			$previous = $level;
+		}
+
+		return $results;
+	}
+
+	private function check_image_alt_text($content, $results) {
+		preg_match_all('/<img\b[^>]*>/i', $content, $matches);
+		$images = isset($matches[0]) ? $matches[0] : array();
+		$missing_alt = 0;
+
+		foreach ($images as $image_tag) {
+			if (!preg_match('/\balt\s*=\s*(["\"]).*?\1/i', $image_tag)) {
+				$missing_alt++;
+			}
+		}
+
+		$results['missing_alt_images'] = $missing_alt;
+		if ($missing_alt > 0) {
+			$results['warnings'][] = sprintf(
+				/* translators: %d: number of images missing alt text. */
+				__('Add descriptive alt text for %d image(s).', 'ai-post-scheduler'),
+				$missing_alt
+			);
+		}
+
+		return $results;
+	}
+
+	private function check_paragraph_readability($content, $results) {
+		preg_match_all('/<p\b[^>]*>(.*?)<\/p>/is', $content, $matches);
+		$paragraphs = isset($matches[1]) ? $matches[1] : array();
+		$long_paragraphs = 0;
+
+		foreach ($paragraphs as $paragraph) {
+			$text = trim(wp_strip_all_tags($paragraph));
+			if ($text === '') {
+				continue;
+			}
+
+			$word_count = str_word_count($text);
+			if ($word_count > 120) {
+				$long_paragraphs++;
+			}
+		}
+
+		$results['long_paragraphs'] = $long_paragraphs;
+		if ($long_paragraphs > 0) {
+			$results['warnings'][] = sprintf(
+				/* translators: %d: number of long paragraphs. */
+				__('Shorten %d long paragraph(s) to improve readability.', 'ai-post-scheduler'),
+				$long_paragraphs
+			);
+		}
+
+		return $results;
+	}
+
+	private function check_plain_language_score($content, $results) {
+		$text = trim(wp_strip_all_tags($content));
+		if ($text === '') {
+			$results['plain_language_score'] = 0;
+			return $results;
+		}
+
+		$sentences = preg_split('/[.!?]+/', $text);
+		$sentences = array_values(array_filter(array_map('trim', $sentences)));
+		$sentence_count = max(count($sentences), 1);
+		$words = preg_split('/\s+/', $text);
+		$words = array_values(array_filter($words));
+		$word_count = max(count($words), 1);
+		$long_word_count = 0;
+
+		foreach ($words as $word) {
+			$word = preg_replace('/[^\p{L}\p{N}]/u', '', $word);
+			if (mb_strlen((string) $word) >= 7) {
+				$long_word_count++;
+			}
+		}
+
+		$avg_sentence_length = $word_count / $sentence_count;
+		$long_word_ratio = $long_word_count / $word_count;
+		$score = 100 - (int) round(($avg_sentence_length * 1.2) + ($long_word_ratio * 80));
+		$score = max(0, min(100, $score));
+		$results['plain_language_score'] = $score;
+
+		if ($score < (int) $results['plain_language_target']) {
+			$results['warnings'][] = sprintf(
+				/* translators: 1: plain language score, 2: target score. */
+				__('Plain-language score is %1$d; target is %2$d or higher.', 'ai-post-scheduler'),
+				$score,
+				(int) $results['plain_language_target']
+			);
+		}
+
+		return $results;
+	}
+}

--- a/ai-post-scheduler/includes/class-aips-accessibility-guardrails.php
+++ b/ai-post-scheduler/includes/class-aips-accessibility-guardrails.php
@@ -95,6 +95,7 @@ class AIPS_Accessibility_Guardrails {
 		$missing_alt = 0;
 
 		foreach ($images as $image_tag) {
+			// Group 1 captures the quote character, group 2 captures quoted alt text, group 3 captures unquoted alt text.
 			if (!preg_match('/\balt\s*=\s*(?:(["\'])(.*?)\1|([^\s>"\']+))/i', $image_tag, $alt_matches)) {
 				$missing_alt++;
 				continue;

--- a/ai-post-scheduler/includes/class-aips-accessibility-guardrails.php
+++ b/ai-post-scheduler/includes/class-aips-accessibility-guardrails.php
@@ -95,7 +95,7 @@ class AIPS_Accessibility_Guardrails {
 		$missing_alt = 0;
 
 		foreach ($images as $image_tag) {
-			// Group 1 captures the quote character, group 2 captures quoted alt text, group 3 captures unquoted alt text.
+			// Group 1 captures the quote character (if present), group 2 captures quoted alt text, and group 3 captures unquoted alt text.
 			if (!preg_match('/\balt\s*=\s*(?:(["\'])(.*?)\1|([^\s>"\']+))/i', $image_tag, $alt_matches)) {
 				$missing_alt++;
 				continue;

--- a/ai-post-scheduler/includes/class-aips-accessibility-guardrails.php
+++ b/ai-post-scheduler/includes/class-aips-accessibility-guardrails.php
@@ -107,7 +107,7 @@ class AIPS_Accessibility_Guardrails {
 			} elseif (isset($alt_matches[3])) {
 				$alt_value = $alt_matches[3];
 			}
-			$alt_value = trim(wp_strip_all_tags(html_entity_decode((string) $alt_value, ENT_QUOTES, 'UTF-8')));
+			$alt_value = trim(wp_strip_all_tags((string) $alt_value));
 			if ($alt_value === '') {
 				$missing_alt++;
 			}

--- a/ai-post-scheduler/includes/class-aips-accessibility-guardrails.php
+++ b/ai-post-scheduler/includes/class-aips-accessibility-guardrails.php
@@ -54,9 +54,15 @@ class AIPS_Accessibility_Guardrails {
 		preg_match_all('/<h([1-6])\b[^>]*>/i', $content, $matches);
 		$levels = array_map('intval', isset($matches[1]) ? $matches[1] : array());
 
-		$previous = 0;
-		foreach ($levels as $level) {
-			if ($previous > 0 && ($level - $previous) > 1) {
+		$previous = null;
+		foreach ($levels as $index => $level) {
+			if ($index === 0 && $level > 2) {
+				$results['heading_hierarchy_ok'] = false;
+				$results['warnings'][] = __('Heading hierarchy starts too deep (first heading should be H2 when post title is H1).', 'ai-post-scheduler');
+				break;
+			}
+
+			if (null !== $previous && ($level - $previous) > 1) {
 				$results['heading_hierarchy_ok'] = false;
 				$results['warnings'][] = __('Heading hierarchy skips levels (for example H2 to H4).', 'ai-post-scheduler');
 				break;
@@ -89,7 +95,19 @@ class AIPS_Accessibility_Guardrails {
 		$missing_alt = 0;
 
 		foreach ($images as $image_tag) {
-			if (!preg_match('/\balt\s*=\s*(["\"]).*?\1/i', $image_tag)) {
+			if (!preg_match('/\balt\s*=\s*(?:(["\'])(.*?)\1|([^\s>"\']+))/i', $image_tag, $alt_matches)) {
+				$missing_alt++;
+				continue;
+			}
+
+			$alt_value = '';
+			if (isset($alt_matches[2]) && $alt_matches[2] !== '') {
+				$alt_value = $alt_matches[2];
+			} elseif (isset($alt_matches[3])) {
+				$alt_value = $alt_matches[3];
+			}
+			$alt_value = trim(wp_strip_all_tags(html_entity_decode((string) $alt_value, ENT_QUOTES, 'UTF-8')));
+			if ($alt_value === '') {
 				$missing_alt++;
 			}
 		}
@@ -117,7 +135,8 @@ class AIPS_Accessibility_Guardrails {
 				continue;
 			}
 
-			$word_count = str_word_count($text);
+			$words = preg_split('/\s+/u', $text, -1, PREG_SPLIT_NO_EMPTY);
+			$word_count = is_array($words) ? count($words) : 0;
 			if ($word_count > 120) {
 				$long_paragraphs++;
 			}
@@ -141,13 +160,18 @@ class AIPS_Accessibility_Guardrails {
 			return $results;
 		}
 
-		$sentences = preg_split('/[.!?]+/', $text);
+		$sentences = preg_split('/[.!?]+/u', $text);
+		if (!is_array($sentences)) {
+			$sentences = array();
+		}
 		$sentences = array_values(array_filter(array_map('trim', $sentences)));
 
 		$long_sentences = 0;
 		foreach ($sentences as $sentence) {
-			$words = preg_split('/\s+/', $sentence);
-			$words = array_values(array_filter($words));
+			$words = preg_split('/\s+/u', $sentence, -1, PREG_SPLIT_NO_EMPTY);
+			if (!is_array($words)) {
+				$words = array();
+			}
 			if (count($words) > 30) {
 				$long_sentences++;
 			}
@@ -252,11 +276,16 @@ class AIPS_Accessibility_Guardrails {
 			return $results;
 		}
 
-		$sentences = preg_split('/[.!?]+/', $text);
+		$sentences = preg_split('/[.!?]+/u', $text);
+		if (!is_array($sentences)) {
+			$sentences = array();
+		}
 		$sentences = array_values(array_filter(array_map('trim', $sentences)));
 		$sentence_count = max(count($sentences), 1);
-		$words = preg_split('/\s+/', $text);
-		$words = array_values(array_filter($words));
+		$words = preg_split('/\s+/u', $text, -1, PREG_SPLIT_NO_EMPTY);
+		if (!is_array($words)) {
+			$words = array();
+		}
 		$word_count = max(count($words), 1);
 		$long_word_count = 0;
 

--- a/ai-post-scheduler/includes/class-aips-accessibility-guardrails.php
+++ b/ai-post-scheduler/includes/class-aips-accessibility-guardrails.php
@@ -18,8 +18,13 @@ class AIPS_Accessibility_Guardrails {
 		$content = is_string($content) ? $content : '';
 		$results = array(
 			'heading_hierarchy_ok' => true,
+			'multiple_h1_count' => 0,
 			'missing_alt_images' => 0,
 			'long_paragraphs' => 0,
+			'long_sentences' => 0,
+			'non_descriptive_links' => 0,
+			'invalid_links' => 0,
+			'excessive_line_breaks' => 0,
 			'plain_language_score' => 100,
 			'plain_language_target' => 60,
 			'warnings' => array(),
@@ -33,8 +38,13 @@ class AIPS_Accessibility_Guardrails {
 		}
 
 		$results = $this->check_heading_hierarchy($content, $results);
+		$results = $this->check_heading_h1_usage($content, $results);
 		$results = $this->check_image_alt_text($content, $results);
 		$results = $this->check_paragraph_readability($content, $results);
+		$results = $this->check_sentence_readability($content, $results);
+		$results = $this->check_link_text($content, $results);
+		$results = $this->check_link_href($content, $results);
+		$results = $this->check_excessive_line_breaks($content, $results);
 		$results = $this->check_plain_language_score($content, $results);
 
 		return $results;
@@ -52,6 +62,22 @@ class AIPS_Accessibility_Guardrails {
 				break;
 			}
 			$previous = $level;
+		}
+
+		return $results;
+	}
+
+	private function check_heading_h1_usage($content, $results) {
+		preg_match_all('/<h1\b[^>]*>/i', $content, $matches);
+		$count = isset($matches[0]) ? count($matches[0]) : 0;
+		$results['multiple_h1_count'] = $count;
+
+		if ($count > 1) {
+			$results['warnings'][] = sprintf(
+				/* translators: %d: number of H1 headings. */
+				__('Multiple H1 headings detected (%d). Prefer a single H1 per post.', 'ai-post-scheduler'),
+				$count
+			);
 		}
 
 		return $results;
@@ -103,6 +129,116 @@ class AIPS_Accessibility_Guardrails {
 				/* translators: %d: number of long paragraphs. */
 				__('Shorten %d long paragraph(s) to improve readability.', 'ai-post-scheduler'),
 				$long_paragraphs
+			);
+		}
+
+		return $results;
+	}
+
+	private function check_sentence_readability($content, $results) {
+		$text = trim(wp_strip_all_tags($content));
+		if ($text === '') {
+			return $results;
+		}
+
+		$sentences = preg_split('/[.!?]+/', $text);
+		$sentences = array_values(array_filter(array_map('trim', $sentences)));
+
+		$long_sentences = 0;
+		foreach ($sentences as $sentence) {
+			$words = preg_split('/\s+/', $sentence);
+			$words = array_values(array_filter($words));
+			if (count($words) > 30) {
+				$long_sentences++;
+			}
+		}
+
+		$results['long_sentences'] = $long_sentences;
+		if ($long_sentences > 0) {
+			$results['warnings'][] = sprintf(
+				/* translators: %d: number of long sentences. */
+				__('Shorten %d long sentence(s) to improve readability.', 'ai-post-scheduler'),
+				$long_sentences
+			);
+		}
+
+		return $results;
+	}
+
+	private function check_link_text($content, $results) {
+		preg_match_all('/<a\b[^>]*>(.*?)<\/a>/is', $content, $matches);
+		$anchors = isset($matches[1]) ? $matches[1] : array();
+		$bad = 0;
+
+		foreach ($anchors as $anchor_text) {
+			$text = strtolower(trim(wp_strip_all_tags($anchor_text)));
+			if ($text === '') {
+				$bad++;
+				continue;
+			}
+
+			if (preg_match('/^(click here|here|learn more|read more|more)$/i', $text)) {
+				$bad++;
+				continue;
+			}
+		}
+
+		$results['non_descriptive_links'] = $bad;
+		if ($bad > 0) {
+			$results['warnings'][] = sprintf(
+				/* translators: %d: number of links with non-descriptive text. */
+				__('Update %d link(s) with more descriptive text (avoid "click here").', 'ai-post-scheduler'),
+				$bad
+			);
+		}
+
+		return $results;
+	}
+
+	private function check_link_href($content, $results) {
+		preg_match_all('/<a\b[^>]*>/i', $content, $matches);
+		$tags = isset($matches[0]) ? $matches[0] : array();
+		$invalid = 0;
+
+		foreach ($tags as $tag) {
+			if (!preg_match('/\bhref\s*=\s*(["\'])(.*?)\1/i', $tag, $href_matches)) {
+				$invalid++;
+				continue;
+			}
+
+			$href = trim((string) $href_matches[2]);
+			if ($href === '' || $href === '#' || stripos($href, 'javascript:') === 0) {
+				$invalid++;
+				continue;
+			}
+		}
+
+		$results['invalid_links'] = $invalid;
+		if ($invalid > 0) {
+			$results['warnings'][] = sprintf(
+				/* translators: %d: number of invalid links. */
+				__('Fix %d invalid link(s) (missing or placeholder href).', 'ai-post-scheduler'),
+				$invalid
+			);
+		}
+
+		return $results;
+	}
+
+	private function check_excessive_line_breaks($content, $results) {
+		$count = 0;
+
+		// Count occurrences of 3+ consecutive <br> tags.
+		if (preg_match_all('/(?:<br\s*\/?>\s*){3,}/i', $content, $matches)) {
+			$count = isset($matches[0]) ? count($matches[0]) : 0;
+		}
+
+		$results['excessive_line_breaks'] = $count;
+		if ($count > 0) {
+			$results['warnings'][] = sprintf(
+				/* translators: %d: number of excessive line break sequences. */
+				__('Replace %d excessive line-break block(s) with semantic paragraphs or lists.', 'ai-post-scheduler'),
+				$count
 			);
 		}
 

--- a/ai-post-scheduler/includes/class-aips-admin-assets.php
+++ b/ai-post-scheduler/includes/class-aips-admin-assets.php
@@ -707,6 +707,30 @@ class AIPS_Admin_Assets {
                 true
             );
 
+			wp_enqueue_script(
+				'aips-admin-accessibility-report',
+				AIPS_PLUGIN_URL . 'assets/js/admin-accessibility-report.js',
+				array('aips-admin-script', 'aips-templates-script'),
+				AIPS_VERSION,
+				true
+			);
+
+			wp_localize_script('aips-admin-accessibility-report', 'aipsAccessibilityReportL10n', array(
+				'loading'      => __('Loading report\u2026', 'ai-post-scheduler'),
+				'errorLoading' => __('Error loading report.', 'ai-post-scheduler'),
+				'noReport'     => __('No Accessibility Report is available for this post.', 'ai-post-scheduler'),
+				'noFindings'   => __('No findings.', 'ai-post-scheduler'),
+				'statusOk'     => __('Looks good', 'ai-post-scheduler'),
+				'statusIssues' => __('Issues found', 'ai-post-scheduler'),
+				'reportTitle'  => __('Accessibility & Readability', 'ai-post-scheduler'),
+				'findings'     => __('Findings', 'ai-post-scheduler'),
+				'headings'     => __('Headings', 'ai-post-scheduler'),
+				'images'       => __('Images', 'ai-post-scheduler'),
+				'readability'  => __('Readability', 'ai-post-scheduler'),
+				'links'        => __('Links', 'ai-post-scheduler'),
+				'formatting'   => __('Formatting', 'ai-post-scheduler'),
+			));
+
             // Enqueue Post Review module (for Pending Review tab)
             wp_enqueue_style(
                 'aips-admin-post-review',

--- a/ai-post-scheduler/includes/class-aips-ajax-registry.php
+++ b/ai-post-scheduler/includes/class-aips-ajax-registry.php
@@ -99,6 +99,7 @@ class AIPS_Ajax_Registry {
 		'aips_get_post_session'           => 'AIPS_Generated_Posts_Controller',
 		'aips_get_session_json'           => 'AIPS_Generated_Posts_Controller',
 		'aips_download_session_json'      => 'AIPS_Generated_Posts_Controller',
+		'aips_get_accessibility_report'   => 'AIPS_Generated_Posts_Controller',
 
 		// Calendar Controller
 		'aips_get_calendar_events'        => 'AIPS_Calendar_Controller',

--- a/ai-post-scheduler/includes/class-aips-generated-posts-controller.php
+++ b/ai-post-scheduler/includes/class-aips-generated-posts-controller.php
@@ -63,6 +63,7 @@ class AIPS_Generated_Posts_Controller {
 		add_action('wp_ajax_aips_get_session_json', array($this, 'ajax_get_session_json'));
 		// AJAX endpoint to download the session JSON as a file
 		add_action('wp_ajax_aips_download_session_json', array($this, 'ajax_download_session_json'));
+		add_action('wp_ajax_aips_get_accessibility_report', array($this, 'ajax_get_accessibility_report'));
 	}
 	
 	/**
@@ -477,6 +478,146 @@ class AIPS_Generated_Posts_Controller {
 		AIPS_Ajax_Response::success(array(
 			'json' => $json_string,
 		));
+	}
+
+	/**
+	 * AJAX handler to retrieve the Accessibility Report for a post/history container.
+	 *
+	 * Returns the decoded report array when available. Falls back from post meta
+	 * to history logs when post meta is not present.
+	 *
+	 * @return void
+	 */
+	public function ajax_get_accessibility_report() {
+		if ( ! check_ajax_referer('aips_ajax_nonce', 'nonce', false) ) {
+			AIPS_Ajax_Response::error(__('Invalid nonce.', 'ai-post-scheduler'));
+		}
+
+		if (!current_user_can('manage_options')) {
+			AIPS_Ajax_Response::permission_denied();
+		}
+
+		$post_id = isset($_POST['post_id']) ? absint($_POST['post_id']) : 0;
+		$history_id = isset($_POST['history_id']) ? absint($_POST['history_id']) : 0;
+
+		if (!$post_id && !$history_id) {
+			AIPS_Ajax_Response::error(__('Invalid request.', 'ai-post-scheduler'));
+		}
+
+		$post_title = '';
+		$report = null;
+
+		if ($post_id) {
+			$post = get_post($post_id);
+			if ($post) {
+				$post_title = (string) $post->post_title;
+			}
+
+			$report = $this->get_accessibility_report_from_post_meta($post_id);
+		}
+
+		if (!$report && $history_id) {
+			$history_item = $this->history_repository->get_by_id($history_id);
+
+			if ($history_item && !$post_id && !empty($history_item->post_id)) {
+				$post_id = absint($history_item->post_id);
+				$post = get_post($post_id);
+				if ($post) {
+					$post_title = (string) $post->post_title;
+				}
+
+				$report = $this->get_accessibility_report_from_post_meta($post_id);
+			}
+
+			if (!$report) {
+				$report = $this->get_accessibility_report_from_history_logs($history_id);
+			}
+		}
+
+		if (is_array($report)) {
+			if (!isset($report['warnings']) || !is_array($report['warnings'])) {
+				$report['warnings'] = array();
+			}
+		}
+
+		AIPS_Ajax_Response::success(array(
+			'report'     => is_array($report) ? $report : null,
+			'post_title' => $post_title,
+		));
+	}
+
+	/**
+	 * Retrieve the report JSON stored on the post.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return array|null
+	 */
+	private function get_accessibility_report_from_post_meta($post_id) {
+		$raw = get_post_meta($post_id, '_aips_accessibility_report', true);
+		if (!is_string($raw) || $raw === '') {
+			return null;
+		}
+
+		$decoded = json_decode($raw, true);
+		if (!is_array($decoded)) {
+			return null;
+		}
+
+		return $decoded;
+	}
+
+	/**
+	 * Best-effort fallback: locate the report payload inside history logs.
+	 *
+	 * @param int $history_id History container ID.
+	 * @return array|null
+	 */
+	private function get_accessibility_report_from_history_logs($history_id) {
+		$logs = $this->history_repository->get_logs_by_history_id($history_id, array(AIPS_History_Type::WARNING), 100);
+		if (empty($logs) || !is_array($logs)) {
+			return null;
+		}
+
+		foreach ($logs as $log) {
+			$details = isset($log->details) ? json_decode((string) $log->details, true) : null;
+			if (!is_array($details)) {
+				continue;
+			}
+
+			$report = $this->find_accessibility_report_payload($details);
+			if (is_array($report)) {
+				return $report;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Recursively search a decoded details payload for an accessibility_report node.
+	 *
+	 * @param mixed $data Decoded JSON node.
+	 * @return array|null
+	 */
+	private function find_accessibility_report_payload($data) {
+		if (!is_array($data)) {
+			return null;
+		}
+
+		if (isset($data['accessibility_report']) && is_array($data['accessibility_report'])) {
+			return $data['accessibility_report'];
+		}
+
+		foreach ($data as $value) {
+			if (is_array($value)) {
+				$found = $this->find_accessibility_report_payload($value);
+				if (is_array($found)) {
+					return $found;
+				}
+			}
+		}
+
+		return null;
 	}
 	
 	/**

--- a/ai-post-scheduler/includes/class-aips-generator.php
+++ b/ai-post-scheduler/includes/class-aips-generator.php
@@ -46,6 +46,7 @@ class AIPS_Generator {
     private $post_title_prompt_builder;
     private $post_excerpt_prompt_builder;
     private $post_featured_image_prompt_builder;
+    private $accessibility_guardrails;
 
     /**
      * @var AIPS_Markdown_Parser Markdown parser
@@ -93,6 +94,7 @@ class AIPS_Generator {
         $this->post_title_prompt_builder = $this->prompt_builder->get_post_title_builder();
         $this->post_excerpt_prompt_builder = $this->prompt_builder->get_post_excerpt_builder();
         $this->post_featured_image_prompt_builder = $this->prompt_builder->get_post_featured_image_builder();
+        $this->accessibility_guardrails = new AIPS_Accessibility_Guardrails();
 
         if ( $markdown_parser ) {
             $this->markdown_parser = $markdown_parser;
@@ -755,6 +757,18 @@ class AIPS_Generator {
         $content = $this->normalize_generated_content_for_wordpress($content);
         $component_statuses['post_content'] = ($content !== '');
 
+        $accessibility_report = $this->accessibility_guardrails->analyze($content);
+
+        if ($this->current_history && !empty($accessibility_report['warnings'])) {
+            $this->current_history->record(
+                'warning',
+                'Accessibility guardrails found content issues.',
+                array('accessibility_report' => $accessibility_report),
+                null,
+                array('component' => 'content_accessibility')
+            );
+        }
+
         // Resolve AI variables from the title prompt using the generated content
         $ai_variables = $this->resolve_ai_variables_from_context($context, $content);
 
@@ -827,6 +841,7 @@ class AIPS_Generator {
             'seo_title' => $title,
             'generation_incomplete' => $generation_incomplete,
             'component_statuses' => $component_statuses,
+            'accessibility_report' => $accessibility_report,
         );
 
         // Allow integrations to hook before the post is created.
@@ -877,6 +892,7 @@ class AIPS_Generator {
             'generated_content' => $content,
             'generation_incomplete' => $generation_incomplete,
             'component_statuses' => $component_statuses,
+            'accessibility_report' => $accessibility_report,
         ));
 
         // Write a structured metric snapshot to history_log.  The metrics
@@ -906,6 +922,7 @@ class AIPS_Generator {
                     'context_type' => $context->get_type(),
                     'context_id' => $context->get_id(),
                     'component_statuses' => $component_statuses,
+            'accessibility_report' => $accessibility_report,
                 )
             );
 
@@ -915,6 +932,7 @@ class AIPS_Generator {
                 'context_id' => $context->get_id(),
                 'title' => $title,
                 'component_statuses' => $component_statuses,
+            'accessibility_report' => $accessibility_report,
             ));
         } else {
             $this->current_history->record(

--- a/ai-post-scheduler/includes/class-aips-generator.php
+++ b/ai-post-scheduler/includes/class-aips-generator.php
@@ -68,18 +68,20 @@ class AIPS_Generator {
     * @param AIPS_History_Service_Interface|null $history_service
      * @param object|null $prompt_builder
      * @param object|null $markdown_parser
-     */
-    public function __construct(
-        ?AIPS_Logger_Interface $logger = null,
-        ?AIPS_AI_Service_Interface $ai_service = null,
-        $template_processor = null,
+     * @param AIPS_Accessibility_Guardrails|null $accessibility_guardrails
+      */
+     public function __construct(
+         ?AIPS_Logger_Interface $logger = null,
+         ?AIPS_AI_Service_Interface $ai_service = null,
+         $template_processor = null,
         $image_service = null,
         $structure_manager = null,
-        $post_manager = null,
-        ?AIPS_History_Service_Interface $history_service = null,
-        $prompt_builder = null,
-        $markdown_parser = null
-    ) {
+         $post_manager = null,
+         ?AIPS_History_Service_Interface $history_service = null,
+         $prompt_builder = null,
+         $markdown_parser = null,
+         ?AIPS_Accessibility_Guardrails $accessibility_guardrails = null
+     ) {
         $container = AIPS_Container::get_instance();
         $this->logger             = $logger ?: ($container->has(AIPS_Logger_Interface::class) ? $container->make(AIPS_Logger_Interface::class) : new AIPS_Logger());
         $this->ai_service         = $ai_service ?: ($container->has(AIPS_AI_Service_Interface::class) ? $container->make(AIPS_AI_Service_Interface::class) : new AIPS_AI_Service());
@@ -94,7 +96,7 @@ class AIPS_Generator {
         $this->post_title_prompt_builder = $this->prompt_builder->get_post_title_builder();
         $this->post_excerpt_prompt_builder = $this->prompt_builder->get_post_excerpt_builder();
         $this->post_featured_image_prompt_builder = $this->prompt_builder->get_post_featured_image_builder();
-        $this->accessibility_guardrails = new AIPS_Accessibility_Guardrails();
+         $this->accessibility_guardrails = $accessibility_guardrails ?: new AIPS_Accessibility_Guardrails();
 
         if ( $markdown_parser ) {
             $this->markdown_parser = $markdown_parser;

--- a/ai-post-scheduler/includes/class-aips-post-manager.php
+++ b/ai-post-scheduler/includes/class-aips-post-manager.php
@@ -38,6 +38,7 @@ class AIPS_Post_Manager {
      *     @type string $topic Optional. Topic used to infer focus keyword when none provided.
      *     @type object $template Optional. Template object containing settings (legacy).
      *     @type AIPS_Generation_Context $context Optional. Generation context (preferred).
+     *     @type array  $accessibility_report Optional. Guardrail analysis results for generated content.
      * }
      * @return int|WP_Error Post ID on success, WP_Error on failure.
      */
@@ -98,6 +99,10 @@ class AIPS_Post_Manager {
                 isset($data['component_statuses']) && is_array($data['component_statuses']) ? $data['component_statuses'] : null,
                 isset($data['generation_incomplete']) ? (bool) $data['generation_incomplete'] : null
             );
+        }
+
+        if (isset($data['accessibility_report']) && is_array($data['accessibility_report'])) {
+            update_post_meta($post_id, '_aips_accessibility_report', wp_json_encode($data['accessibility_report']));
         }
 
         // Handle Tags

--- a/ai-post-scheduler/templates/admin/content.php
+++ b/ai-post-scheduler/templates/admin/content.php
@@ -68,6 +68,9 @@ include AIPS_PLUGIN_DIR . 'templates/partials/post-preview-modal.php';
 // Include the View Session modal partial
 include AIPS_PLUGIN_DIR . 'templates/partials/view-session-modal.php';
 
+// Include the Accessibility Report modal partial
+include AIPS_PLUGIN_DIR . 'templates/partials/accessibility-report-modal.php';
+
 // Include the AI Edit modal partial
 include AIPS_PLUGIN_DIR . 'templates/partials/ai-edit-modal.php';
 ?>

--- a/ai-post-scheduler/templates/admin/tab-generated-posts.php
+++ b/ai-post-scheduler/templates/admin/tab-generated-posts.php
@@ -95,6 +95,14 @@ if (!defined('ABSPATH')) {
 											<?php echo esc_html($post_data['title']); ?>
 										</a>
 										<button type="button"
+											class="aips-btn aips-btn-icon aips-view-accessibility-report"
+											data-post-id="<?php echo esc_attr($post_data['post_id']); ?>"
+											data-history-id="<?php echo esc_attr($post_data['history_id']); ?>"
+											title="<?php esc_attr_e('View Accessibility Report', 'ai-post-scheduler'); ?>"
+											aria-label="<?php esc_attr_e('View Accessibility Report', 'ai-post-scheduler'); ?>">
+											<span class="dashicons dashicons-universal-access-alt"></span>
+										</button>
+										<button type="button"
 											class="aips-btn aips-btn-icon aips-view-session"
 											data-history-id="<?php echo esc_attr($post_data['history_id']); ?>"
 											title="<?php esc_attr_e('View History', 'ai-post-scheduler'); ?>"
@@ -249,4 +257,3 @@ if (!defined('ABSPATH')) {
 					</div>
 					<?php endif; ?>
 				</div>
-

--- a/ai-post-scheduler/templates/admin/tab-generated-posts.php
+++ b/ai-post-scheduler/templates/admin/tab-generated-posts.php
@@ -90,9 +90,18 @@ if (!defined('ABSPATH')) {
 							<?php foreach ($posts_data as $post_data): ?>
 							<tr>
 								<td>
-									<a href="<?php echo esc_url($post_data['edit_link']); ?>" class="cell-primary">
-										<?php echo esc_html($post_data['title']); ?>
-									</a>
+									<div style="display: flex; align-items: center; gap: 8px;">
+										<a href="<?php echo esc_url($post_data['edit_link']); ?>" class="cell-primary">
+											<?php echo esc_html($post_data['title']); ?>
+										</a>
+										<button type="button"
+											class="aips-btn aips-btn-icon aips-view-session"
+											data-history-id="<?php echo esc_attr($post_data['history_id']); ?>"
+											title="<?php esc_attr_e('View History', 'ai-post-scheduler'); ?>"
+											aria-label="<?php esc_attr_e('View History', 'ai-post-scheduler'); ?>">
+											<span class="dashicons dashicons-book-alt"></span>
+										</button>
+									</div>
 									<span class="aips-cell-source"><?php echo esc_html($post_data['source']); ?></span>
 								</td>
 								<td>

--- a/ai-post-scheduler/templates/admin/tab-partial-generations.php
+++ b/ai-post-scheduler/templates/admin/tab-partial-generations.php
@@ -97,6 +97,14 @@ if (!defined('ABSPATH')) {
 											<?php echo esc_html($post_data['title']); ?>
 										</a>
 										<button type="button"
+											class="aips-btn aips-btn-icon aips-view-accessibility-report"
+											data-post-id="<?php echo esc_attr($post_data['post_id']); ?>"
+											data-history-id="<?php echo esc_attr($post_data['history_id']); ?>"
+											title="<?php esc_attr_e('View Accessibility Report', 'ai-post-scheduler'); ?>"
+											aria-label="<?php esc_attr_e('View Accessibility Report', 'ai-post-scheduler'); ?>">
+											<span class="dashicons dashicons-universal-access-alt"></span>
+										</button>
+										<button type="button"
 											class="aips-btn aips-btn-icon aips-view-session"
 											data-history-id="<?php echo esc_attr($post_data['history_id']); ?>"
 											title="<?php esc_attr_e('View History', 'ai-post-scheduler'); ?>"
@@ -216,4 +224,3 @@ if (!defined('ABSPATH')) {
 					</div>
 					<?php endif; ?>
 				</div>
-

--- a/ai-post-scheduler/templates/admin/tab-partial-generations.php
+++ b/ai-post-scheduler/templates/admin/tab-partial-generations.php
@@ -92,9 +92,18 @@ if (!defined('ABSPATH')) {
 							<?php foreach ($partial_posts_data as $post_data): ?>
 							<tr>
 								<td>
-									<a href="<?php echo esc_url($post_data['edit_link']); ?>" class="cell-primary">
-										<?php echo esc_html($post_data['title']); ?>
-									</a>
+									<div style="display: flex; align-items: center; gap: 8px;">
+										<a href="<?php echo esc_url($post_data['edit_link']); ?>" class="cell-primary">
+											<?php echo esc_html($post_data['title']); ?>
+										</a>
+										<button type="button"
+											class="aips-btn aips-btn-icon aips-view-session"
+											data-history-id="<?php echo esc_attr($post_data['history_id']); ?>"
+											title="<?php esc_attr_e('View History', 'ai-post-scheduler'); ?>"
+											aria-label="<?php esc_attr_e('View History', 'ai-post-scheduler'); ?>">
+											<span class="dashicons dashicons-book-alt"></span>
+										</button>
+									</div>
 									<span class="aips-cell-source"><?php echo esc_html($post_data['source']); ?></span>
 								</td>
 								<td>

--- a/ai-post-scheduler/templates/admin/tab-pending-review.php
+++ b/ai-post-scheduler/templates/admin/tab-pending-review.php
@@ -102,9 +102,18 @@ if (!defined('ABSPATH')) {
 											data-history-id="<?php echo esc_attr($item->id); ?>">
 									</td>
 									<td>
-										<a href="<?php echo esc_url(get_edit_post_link($item->post_id)); ?>" class="cell-primary" target="_blank">
-											<?php echo esc_html($item->post_title ?: $item->generated_title ?: __('Untitled', 'ai-post-scheduler')); ?>
-										</a>
+										<div style="display: flex; align-items: center; gap: 8px;">
+											<a href="<?php echo esc_url(get_edit_post_link($item->post_id)); ?>" class="cell-primary" target="_blank">
+												<?php echo esc_html($item->post_title ?: $item->generated_title ?: __('Untitled', 'ai-post-scheduler')); ?>
+											</a>
+											<button type="button"
+												class="aips-btn aips-btn-icon aips-view-session"
+												data-history-id="<?php echo esc_attr($item->id); ?>"
+												title="<?php esc_attr_e('View History', 'ai-post-scheduler'); ?>"
+												aria-label="<?php esc_attr_e('View History', 'ai-post-scheduler'); ?>">
+												<span class="dashicons dashicons-book-alt"></span>
+											</button>
+										</div>
 										<span class="aips-cell-source"><?php echo esc_html($controller->format_source($item)); ?></span>
 									</td>
 									<td>

--- a/ai-post-scheduler/templates/admin/tab-pending-review.php
+++ b/ai-post-scheduler/templates/admin/tab-pending-review.php
@@ -107,6 +107,14 @@ if (!defined('ABSPATH')) {
 												<?php echo esc_html($item->post_title ?: $item->generated_title ?: __('Untitled', 'ai-post-scheduler')); ?>
 											</a>
 											<button type="button"
+												class="aips-btn aips-btn-icon aips-view-accessibility-report"
+												data-post-id="<?php echo esc_attr($item->post_id); ?>"
+												data-history-id="<?php echo esc_attr($item->id); ?>"
+												title="<?php esc_attr_e('View Accessibility Report', 'ai-post-scheduler'); ?>"
+												aria-label="<?php esc_attr_e('View Accessibility Report', 'ai-post-scheduler'); ?>">
+												<span class="dashicons dashicons-universal-access-alt"></span>
+											</button>
+											<button type="button"
 												class="aips-btn aips-btn-icon aips-view-session"
 												data-history-id="<?php echo esc_attr($item->id); ?>"
 												title="<?php esc_attr_e('View History', 'ai-post-scheduler'); ?>"
@@ -265,4 +273,3 @@ if (!defined('ABSPATH')) {
 					</div>
 					<?php endif; ?>
 				</div>
-

--- a/ai-post-scheduler/templates/partials/accessibility-report-modal.php
+++ b/ai-post-scheduler/templates/partials/accessibility-report-modal.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Accessibility Report Modal Partial Template
+ *
+ * Reusable modal for displaying the Accessibility Report for a generated post.
+ *
+ * @package AI_Post_Scheduler
+ * @since 2.5.0
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+?>
+
+<!-- Accessibility Report Modal -->
+<div id="aips-accessibility-report-modal" class="aips-modal" style="display: none;">
+	<div class="aips-modal-overlay"></div>
+	<div class="aips-modal-content aips-modal-large">
+		<div class="aips-modal-header">
+			<div class="aips-modal-header-title">
+				<h2 id="aips-accessibility-report-modal-title"><?php esc_html_e('Accessibility Report', 'ai-post-scheduler'); ?></h2>
+				<p id="aips-accessibility-report-modal-subtitle" class="aips-modal-subtitle"></p>
+			</div>
+			<div class="aips-modal-header-actions">
+				<button class="aips-modal-close" aria-label="<?php esc_attr_e('Close', 'ai-post-scheduler'); ?>">
+					<span class="dashicons dashicons-no"></span>
+				</button>
+			</div>
+		</div>
+		<div class="aips-modal-body">
+			<div id="aips-accessibility-report-content"></div>
+		</div>
+	</div>
+</div>
+
+<script type="text/html" id="aips-tmpl-access-report-loading">
+	<div class="aips-access-report-message aips-access-report-message-loading">
+		<span class="dashicons dashicons-update aips-spin" aria-hidden="true"></span>
+		<span>{{text}}</span>
+	</div>
+</script>
+
+<script type="text/html" id="aips-tmpl-access-report-error">
+	<div class="aips-access-report-message aips-access-report-message-error">
+		<span class="dashicons dashicons-warning" aria-hidden="true"></span>
+		<span>{{message}}</span>
+	</div>
+</script>
+
+<script type="text/html" id="aips-tmpl-access-report-empty">
+	<div class="aips-access-report-message aips-access-report-message-empty">
+		<span class="dashicons dashicons-info" aria-hidden="true"></span>
+		<span>{{message}}</span>
+	</div>
+</script>

--- a/ai-post-scheduler/templates/partials/accessibility-report-modal.php
+++ b/ai-post-scheduler/templates/partials/accessibility-report-modal.php
@@ -54,3 +54,60 @@ if (!defined('ABSPATH')) {
 		<span>{{message}}</span>
 	</div>
 </script>
+
+<script type="text/html" id="aips-tmpl-access-report-shell">
+	<div class="aips-access-report">
+		<div class="aips-access-report-top">
+			<div class="aips-access-report-top-left">
+				<span class="dashicons dashicons-universal-access-alt" aria-hidden="true"></span>
+				<strong>{{report_title}}</strong>
+			</div>
+			<div class="aips-access-report-top-right">{{status_badge}}</div>
+		</div>
+		<div class="aips-access-report-grid">{{cards_html}}</div>
+		<div class="aips-access-report-section">
+			<h3>{{findings_title}}</h3>
+			{{findings_html}}
+		</div>
+	</div>
+</script>
+
+<script type="text/html" id="aips-tmpl-access-report-badge">
+	<span class="aips-badge aips-badge-{{status}}">
+		<span class="dashicons dashicons-{{icon}}" aria-hidden="true"></span>
+		{{text}}
+	</span>
+</script>
+
+<script type="text/html" id="aips-tmpl-access-report-card">
+	<div class="aips-access-report-card aips-access-report-card-{{status}}">
+		<div class="aips-access-report-card-title">
+			<span class="dashicons dashicons-{{icon}}" aria-hidden="true"></span>
+			<span>{{title}}</span>
+		</div>
+		<div class="aips-access-report-card-body">{{lines_html}}</div>
+	</div>
+</script>
+
+<script type="text/html" id="aips-tmpl-access-report-card-lines">
+	<ul class="aips-access-report-card-lines">{{items_html}}</ul>
+</script>
+
+<script type="text/html" id="aips-tmpl-access-report-card-line">
+	<li>{{text}}</li>
+</script>
+
+<script type="text/html" id="aips-tmpl-access-report-findings-list">
+	<ul class="aips-access-report-findings">{{items_html}}</ul>
+</script>
+
+<script type="text/html" id="aips-tmpl-access-report-finding-item">
+	<li>
+		<span class="dashicons dashicons-warning" aria-hidden="true"></span>
+		<span>{{text}}</span>
+	</li>
+</script>
+
+<script type="text/html" id="aips-tmpl-access-report-findings-empty">
+	<div class="aips-access-report-findings-empty">{{message}}</div>
+</script>

--- a/ai-post-scheduler/tests/Test_AIPS_Accessibility_Guardrails.php
+++ b/ai-post-scheduler/tests/Test_AIPS_Accessibility_Guardrails.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Tests accessibility guardrails checks for generated content.
+ */
+class Test_AIPS_Accessibility_Guardrails extends WP_UnitTestCase {
+
+	public function test_analyze_detects_heading_skip_and_missing_alt_text() {
+		$guardrails = new AIPS_Accessibility_Guardrails();
+		$content = '<h2>Intro</h2><h4>Skipped</h4><p>Short paragraph.</p><img src="x.jpg" />';
+
+		$result = $guardrails->analyze($content);
+
+		$this->assertFalse($result['heading_hierarchy_ok']);
+		$this->assertSame(1, $result['missing_alt_images']);
+		$this->assertNotEmpty($result['warnings']);
+	}
+
+	public function test_analyze_flags_long_paragraph_and_low_plain_language_score() {
+		$guardrails = new AIPS_Accessibility_Guardrails();
+		$long_sentence = str_repeat('Complexityword ', 140) . '.';
+		$content = '<h2>Heading</h2><p>' . $long_sentence . '</p>';
+
+		$result = $guardrails->analyze($content);
+
+		$this->assertSame(1, $result['long_paragraphs']);
+		$this->assertLessThan($result['plain_language_target'], $result['plain_language_score']);
+	}
+
+	public function test_analyze_returns_clean_report_for_accessible_content() {
+		$guardrails = new AIPS_Accessibility_Guardrails();
+		$content = '<h2>Overview</h2><h3>Step One</h3><p>This is easy to read and short.</p><img src="x.jpg" alt="Descriptive chart" />';
+
+		$result = $guardrails->analyze($content);
+
+		$this->assertTrue($result['heading_hierarchy_ok']);
+		$this->assertSame(0, $result['missing_alt_images']);
+		$this->assertSame(0, $result['long_paragraphs']);
+	}
+}

--- a/ai-post-scheduler/tests/Test_AIPS_Accessibility_Guardrails.php
+++ b/ai-post-scheduler/tests/Test_AIPS_Accessibility_Guardrails.php
@@ -12,6 +12,7 @@ class Test_AIPS_Accessibility_Guardrails extends WP_UnitTestCase {
 
 		$this->assertFalse($result['heading_hierarchy_ok']);
 		$this->assertSame(1, $result['missing_alt_images']);
+		$this->assertStringContainsString('descriptive alt text', implode(' ', $result['warnings']));
 		$this->assertNotEmpty($result['warnings']);
 	}
 

--- a/ai-post-scheduler/tests/Test_AIPS_Accessibility_Guardrails.php
+++ b/ai-post-scheduler/tests/Test_AIPS_Accessibility_Guardrails.php
@@ -6,12 +6,23 @@ class Test_AIPS_Accessibility_Guardrails extends WP_UnitTestCase {
 
 	public function test_analyze_detects_heading_skip_and_missing_alt_text() {
 		$guardrails = new AIPS_Accessibility_Guardrails();
-		$content = '<h2>Intro</h2><h4>Skipped</h4><p>Short paragraph.</p><img src="x.jpg" />';
+		$content = '<h2>Intro</h2><h4>Skipped</h4><p>Short paragraph.</p><img src="x.jpg" alt="" />';
 
 		$result = $guardrails->analyze($content);
 
 		$this->assertFalse($result['heading_hierarchy_ok']);
 		$this->assertSame(1, $result['missing_alt_images']);
+		$this->assertNotEmpty($result['warnings']);
+	}
+
+	public function test_analyze_flags_deep_first_heading_and_accepts_unquoted_alt_text() {
+		$guardrails = new AIPS_Accessibility_Guardrails();
+		$content = '<h3>Too deep start</h3><p>Body text.</p><img src="x.jpg" alt=description />';
+
+		$result = $guardrails->analyze($content);
+
+		$this->assertFalse($result['heading_hierarchy_ok']);
+		$this->assertSame(0, $result['missing_alt_images']);
 		$this->assertNotEmpty($result['warnings']);
 	}
 

--- a/ai-post-scheduler/tests/Test_AIPS_Accessibility_Guardrails.php
+++ b/ai-post-scheduler/tests/Test_AIPS_Accessibility_Guardrails.php
@@ -23,17 +23,38 @@ class Test_AIPS_Accessibility_Guardrails extends WP_UnitTestCase {
 		$result = $guardrails->analyze($content);
 
 		$this->assertSame(1, $result['long_paragraphs']);
+		$this->assertSame(1, $result['long_sentences']);
 		$this->assertLessThan($result['plain_language_target'], $result['plain_language_score']);
+	}
+
+	public function test_analyze_flags_link_issues_and_excessive_line_breaks() {
+		$guardrails = new AIPS_Accessibility_Guardrails();
+		$content = '<h1>Title</h1><h1>Another H1</h1>'
+			. '<p><a href=\"#\">Click here</a></p>'
+			. '<p><a>Broken link</a></p>'
+			. '<br><br><br>';
+
+		$result = $guardrails->analyze($content);
+
+		$this->assertSame(2, $result['multiple_h1_count']);
+		$this->assertSame(1, $result['non_descriptive_links']);
+		$this->assertSame(2, $result['invalid_links']);
+		$this->assertSame(1, $result['excessive_line_breaks']);
+		$this->assertNotEmpty($result['warnings']);
 	}
 
 	public function test_analyze_returns_clean_report_for_accessible_content() {
 		$guardrails = new AIPS_Accessibility_Guardrails();
-		$content = '<h2>Overview</h2><h3>Step One</h3><p>This is easy to read and short.</p><img src="x.jpg" alt="Descriptive chart" />';
+		$content = '<h2>Overview</h2><h3>Step One</h3><p>This is easy to read and short.</p><p><a href="https://example.com">Read the full guide</a></p><img src="x.jpg" alt="Descriptive chart" />';
 
 		$result = $guardrails->analyze($content);
 
 		$this->assertTrue($result['heading_hierarchy_ok']);
+		$this->assertSame(0, $result['multiple_h1_count']);
 		$this->assertSame(0, $result['missing_alt_images']);
 		$this->assertSame(0, $result['long_paragraphs']);
+		$this->assertSame(0, $result['non_descriptive_links']);
+		$this->assertSame(0, $result['invalid_links']);
+		$this->assertSame(0, $result['excessive_line_breaks']);
 	}
 }

--- a/ai-post-scheduler/tests/bootstrap.php
+++ b/ai-post-scheduler/tests/bootstrap.php
@@ -1386,6 +1386,7 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
         'class-aips-generation-context-factory.php',
         'class-aips-post-manager.php',
         'class-aips-post-creator.php',
+        'class-aips-accessibility-guardrails.php',
         'class-aips-markdown-parser.php',
         'class-aips-generator.php',
         'class-aips-component-regeneration-service.php',


### PR DESCRIPTION
### Motivation
- Improve accessibility and readability of AI-generated posts by enforcing automated checks for heading hierarchy, image alt text, paragraph length, and a plain-language readability target.
- Surface guardrail findings to generation history and persist reports so editors can quickly remediate issues before publishing.
- Integrate accessibility checks into the existing generation pipeline so analyses run automatically during post creation.

### Description
- Add `AIPS_Accessibility_Guardrails` (`includes/class-aips-accessibility-guardrails.php`) with `analyze()` and helper checks: `check_heading_hierarchy()`, `check_image_alt_text()`, `check_paragraph_readability()`, and `check_plain_language_score()`.
- Integrate the guardrails into `AIPS_Generator` (`includes/class-aips-generator.php`) by instantiating the service, running `analyze()` after `normalize_generated_content_for_wordpress()`, recording a history `warning` when issues are present, and including `accessibility_report` in the post creation payload.
- Persist the accessibility report in `AIPS_Post_Manager::create_post()` (`includes/class-aips-post-manager.php`) as post meta `_aips_accessibility_report` when provided.
- Add unit tests `tests/Test_AIPS_Accessibility_Guardrails.php` covering heading skips, missing `alt` attributes, long-paragraph detection, and plain-language scoring.

### Testing
- Attempted `gh pr list` per anti-duplication rules, but the `gh` CLI was not available in the environment so an open-PR check could not be performed via CLI.
- Ran `composer install` in `ai-post-scheduler` successfully to provision test deps using `composer install`.
- Ran the focused tests with `composer test -- tests/Test_AIPS_Accessibility_Guardrails.php`, which executed in limited-mode and returned: `Tests: 3, Assertions: 8` with `1` PHPUnit runner warning about Xdebug/coverage environment settings, and all assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a011c7d32888321875b3d7355560e21)