### PR TITLE
Refactor generated/pending-review row actions into shared partial

### DIFF
--- a/ai-post-scheduler/templates/admin/tab-generated-posts.php
+++ b/ai-post-scheduler/templates/admin/tab-generated-posts.php
@@ -111,33 +111,33 @@ if (!defined('ABSPATH')) {
 									</div>
 								</td>
 								<td>
-									<div class="cell-actions">
-										<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-edit-post"
-										        data-edit-url="<?php echo esc_url($post_data['edit_link']); ?>"
-										        title="<?php esc_attr_e('Edit this post', 'ai-post-scheduler'); ?>">
-											<span class="dashicons dashicons-edit"></span>
-											<?php esc_html_e('Edit', 'ai-post-scheduler'); ?>
-										</button>
-										<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-preview-post"
-										        data-post-id="<?php echo esc_attr($post_data['post_id']); ?>"
-										        title="<?php esc_attr_e('Preview this post', 'ai-post-scheduler'); ?>">
-											<span class="dashicons dashicons-visibility"></span>
-											<?php esc_html_e('Preview', 'ai-post-scheduler'); ?>
-										</button>
-										<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-ai-edit-btn" 
-										        data-post-id="<?php echo esc_attr($post_data['post_id']); ?>"
-										        data-history-id="<?php echo esc_attr($post_data['history_id']); ?>"
-										        title="<?php esc_attr_e('AI Edit', 'ai-post-scheduler'); ?>">
-											<span class="dashicons dashicons-admin-customizer"></span>
-											<?php esc_html_e('AI Edit', 'ai-post-scheduler'); ?>
-										</button>
-										<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-view-session" 
-								        data-history-id="<?php echo esc_attr($post_data['history_id']); ?>"
-								        title="<?php esc_attr_e('View Session', 'ai-post-scheduler'); ?>">
-											<span class="dashicons dashicons-visibility"></span>
-											<?php esc_html_e('View Session', 'ai-post-scheduler'); ?>
-										</button>
-									</div>
+									<?php
+									// UX hierarchy: Keep "Edit" as the primary action because it is the most common follow-up task on published content.
+									// Overflow keeps less-frequent tools grouped while preserving exact classes/data attributes required by JS handlers.
+									$aips_action_config = array(
+										'container_classes' => 'cell-actions',
+										'row_identifiers' => array(
+											'post_id' => $post_data['post_id'],
+											'history_id' => $post_data['history_id'],
+											'edit_url' => $post_data['edit_link'],
+										),
+										'primary_action' => array(
+											'label' => __('Edit', 'ai-post-scheduler'),
+											'classes' => 'aips-btn aips-btn-sm aips-btn-secondary aips-edit-post',
+											'icon' => 'dashicons-edit',
+											'title' => __('Edit this post', 'ai-post-scheduler'),
+											'data' => array(
+												'edit-url' => 'edit_url',
+											),
+										),
+										'overflow_actions' => array(
+											array('label' => __('Preview', 'ai-post-scheduler'), 'classes' => 'aips-btn aips-btn-sm aips-btn-secondary aips-preview-post', 'icon' => 'dashicons-visibility', 'title' => __('Preview this post', 'ai-post-scheduler'), 'data' => array('post-id' => 'post_id')),
+											array('label' => __('AI Edit', 'ai-post-scheduler'), 'classes' => 'aips-btn aips-btn-sm aips-btn-secondary aips-ai-edit-btn', 'icon' => 'dashicons-admin-customizer', 'title' => __('AI Edit', 'ai-post-scheduler'), 'data' => array('post-id' => 'post_id', 'history-id' => 'history_id')),
+											array('label' => __('View Session', 'ai-post-scheduler'), 'classes' => 'aips-btn aips-btn-sm aips-btn-secondary aips-view-session', 'icon' => 'dashicons-visibility', 'title' => __('View Session', 'ai-post-scheduler'), 'data' => array('history-id' => 'history_id')),
+										),
+									);
+									include AIPS_PLUGIN_DIR . 'templates/partials/post-row-actions.php';
+									?>
 								</td>
 							</tr>
 							<?php endforeach; ?>
@@ -240,4 +240,3 @@ if (!defined('ABSPATH')) {
 					</div>
 					<?php endif; ?>
 				</div>
-

--- a/ai-post-scheduler/templates/admin/tab-pending-review.php
+++ b/ai-post-scheduler/templates/admin/tab-pending-review.php
@@ -113,51 +113,34 @@ if (!defined('ABSPATH')) {
 										</div>
 									</td>
 									<td>
-										<div class="cell-actions aips-actions-grid-3">
-											<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-edit-post"
-												data-edit-url="<?php echo esc_url(get_edit_post_link($item->post_id)); ?>"
-												title="<?php esc_attr_e('Edit this post', 'ai-post-scheduler'); ?>">
-												<span class="dashicons dashicons-edit"></span>
-												<?php esc_html_e('Edit', 'ai-post-scheduler'); ?>
-											</button>
-											<button type="button"
-												class="aips-btn aips-btn-sm aips-btn-secondary aips-preview-post"
-												data-post-id="<?php echo esc_attr($item->post_id); ?>"
-												title="<?php esc_attr_e('Preview this post', 'ai-post-scheduler'); ?>">
-												<span class="dashicons dashicons-visibility"></span>
-												<?php esc_html_e('Preview', 'ai-post-scheduler'); ?>
-											</button>
-											<button type="button"
-												class="aips-btn aips-btn-sm aips-btn-secondary aips-ai-edit-btn"
-												data-post-id="<?php echo esc_attr($item->post_id); ?>"
-												data-history-id="<?php echo esc_attr($item->id); ?>"
-												title="<?php esc_attr_e('AI Edit - Regenerate components', 'ai-post-scheduler'); ?>">
-												<span class="dashicons dashicons-admin-customizer"></span>
-												<?php esc_html_e('AI Edit', 'ai-post-scheduler'); ?>
-											</button>
-											<button type="button"
-												class="aips-btn aips-btn-sm aips-btn-secondary aips-view-session"
-												data-history-id="<?php echo esc_attr($item->id); ?>"
-												title="<?php esc_attr_e('View generation session', 'ai-post-scheduler'); ?>">
-												<span class="dashicons dashicons-visibility"></span>
-												<?php esc_html_e('View Session', 'ai-post-scheduler'); ?>
-											</button>
-											<button type="button"
-												class="aips-btn aips-btn-sm aips-btn-primary aips-publish-post"
-												data-post-id="<?php echo esc_attr($item->post_id); ?>"
-												title="<?php esc_attr_e('Publish this post', 'ai-post-scheduler'); ?>">
-												<span class="dashicons dashicons-upload"></span>
-												<?php esc_html_e('Publish', 'ai-post-scheduler'); ?>
-											</button>
-											<button type="button"
-												class="aips-btn aips-btn-sm aips-btn-secondary aips-regenerate-post"
-												data-history-id="<?php echo esc_attr($item->id); ?>"
-												data-post-id="<?php echo esc_attr($item->post_id); ?>"
-												title="<?php esc_attr_e('Regenerate this post', 'ai-post-scheduler'); ?>">
-												<span class="dashicons dashicons-update"></span>
-												<?php esc_html_e('Re-generate', 'ai-post-scheduler'); ?>
-											</button>
-										</div>
+										<?php
+										// UX hierarchy: "Publish" is primary in review mode because approvers are completing workflow decisions.
+										// Overflow keeps supporting tools (edit, preview, AI utilities) available without changing JS hooks.
+										$aips_action_config = array(
+											'container_classes' => 'cell-actions aips-actions-grid-3',
+											'row_identifiers' => array(
+												'post_id' => $item->post_id,
+												'history_id' => $item->id,
+												'edit_url' => get_edit_post_link($item->post_id),
+											),
+											'state_flags' => array('pending_review' => true),
+											'primary_action' => array(
+												'label' => __('Publish', 'ai-post-scheduler'),
+												'classes' => 'aips-btn aips-btn-sm aips-btn-primary aips-publish-post',
+												'icon' => 'dashicons-upload',
+												'title' => __('Publish this post', 'ai-post-scheduler'),
+												'data' => array('post-id' => 'post_id'),
+											),
+											'overflow_actions' => array(
+												array('label' => __('Edit', 'ai-post-scheduler'), 'classes' => 'aips-btn aips-btn-sm aips-btn-secondary aips-edit-post', 'icon' => 'dashicons-edit', 'title' => __('Edit this post', 'ai-post-scheduler'), 'data' => array('edit-url' => 'edit_url')),
+												array('label' => __('Preview', 'ai-post-scheduler'), 'classes' => 'aips-btn aips-btn-sm aips-btn-secondary aips-preview-post', 'icon' => 'dashicons-visibility', 'title' => __('Preview this post', 'ai-post-scheduler'), 'data' => array('post-id' => 'post_id')),
+												array('label' => __('AI Edit', 'ai-post-scheduler'), 'classes' => 'aips-btn aips-btn-sm aips-btn-secondary aips-ai-edit-btn', 'icon' => 'dashicons-admin-customizer', 'title' => __('AI Edit - Regenerate components', 'ai-post-scheduler'), 'data' => array('post-id' => 'post_id', 'history-id' => 'history_id')),
+												array('label' => __('View Session', 'ai-post-scheduler'), 'classes' => 'aips-btn aips-btn-sm aips-btn-secondary aips-view-session', 'icon' => 'dashicons-visibility', 'title' => __('View generation session', 'ai-post-scheduler'), 'data' => array('history-id' => 'history_id')),
+												array('label' => __('Re-generate', 'ai-post-scheduler'), 'classes' => 'aips-btn aips-btn-sm aips-btn-secondary aips-regenerate-post', 'icon' => 'dashicons-update', 'title' => __('Regenerate this post', 'ai-post-scheduler'), 'data' => array('history-id' => 'history_id', 'post-id' => 'post_id')),
+											),
+										);
+										include AIPS_PLUGIN_DIR . 'templates/partials/post-row-actions.php';
+										?>
 									</td>
 								</tr>
 								<?php endforeach; ?>

--- a/ai-post-scheduler/templates/partials/post-row-actions.php
+++ b/ai-post-scheduler/templates/partials/post-row-actions.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Reusable post row actions partial.
+ *
+ * @var array $aips_action_config
+ *
+ * @package AI_Post_Scheduler
+ * @since 2.5.0
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+$defaults = array(
+	'container_classes' => 'cell-actions',
+	'primary_action' => array(),
+	'overflow_actions' => array(),
+	'row_identifiers' => array(),
+	'state_flags' => array(),
+);
+
+$config = wp_parse_args(is_array($aips_action_config) ? $aips_action_config : array(), $defaults);
+$row_identifiers = is_array($config['row_identifiers']) ? $config['row_identifiers'] : array();
+$state_flags = is_array($config['state_flags']) ? $config['state_flags'] : array();
+
+$render_action = static function($action, $row_identifiers, $is_primary) {
+	if (empty($action) || !is_array($action) || empty($action['label'])) {
+		return;
+	}
+
+	$button_type = !empty($action['button_type']) ? $action['button_type'] : 'button';
+	$classes = !empty($action['classes']) ? $action['classes'] : 'aips-btn aips-btn-sm aips-btn-secondary';
+	$icon = !empty($action['icon']) ? $action['icon'] : '';
+	$title = !empty($action['title']) ? $action['title'] : '';
+	$data = !empty($action['data']) && is_array($action['data']) ? $action['data'] : array();
+	$extra_attributes = !empty($action['attributes']) && is_array($action['attributes']) ? $action['attributes'] : array();
+
+	echo '<button type="' . esc_attr($button_type) . '" class="' . esc_attr($classes) . '"';
+
+	foreach ($data as $key => $value) {
+		$resolved_value = (is_string($value) && isset($row_identifiers[$value])) ? $row_identifiers[$value] : $value;
+		if ('' === $resolved_value || null === $resolved_value) {
+			continue;
+		}
+		echo ' data-' . esc_attr($key) . '="' . esc_attr($resolved_value) . '"';
+	}
+
+	foreach ($extra_attributes as $key => $value) {
+		if ('' === $value || null === $value) {
+			continue;
+		}
+		echo ' ' . esc_attr($key) . '="' . esc_attr($value) . '"';
+	}
+
+	if (!empty($title)) {
+		echo ' title="' . esc_attr($title) . '"';
+	}
+
+	echo ' data-action-tier="' . esc_attr($is_primary ? 'primary' : 'overflow') . '">';
+
+	if (!empty($icon)) {
+		echo '<span class="dashicons ' . esc_attr($icon) . '"></span>';
+	}
+
+	echo esc_html($action['label']);
+	echo '</button>';
+};
+?>
+<div class="<?php echo esc_attr($config['container_classes']); ?>"<?php echo !empty($state_flags['pending_review']) ? ' data-pending-review="1"' : ''; ?>>
+	<?php $render_action($config['primary_action'], $row_identifiers, true); ?>
+	<?php foreach ($config['overflow_actions'] as $overflow_action): ?>
+		<?php $render_action($overflow_action, $row_identifiers, false); ?>
+	<?php endforeach; ?>
+</div>


### PR DESCRIPTION
### Motivation

- Reduce duplication and centralize rendering of per-row action buttons used across Generated Posts and Pending Review tables by introducing a single reusable partial. 
- Preserve existing client-side behavior by keeping CSS class names and `data-*` attributes exactly compatible with the existing admin JS handlers. 

### Description

- Add a new partial `templates/partials/post-row-actions.php` that accepts a configuration array supporting `primary_action`, `overflow_actions`, `row_identifiers`, and `state_flags` and renders buttons with the same classes and `data-*` attributes used by JS. 
- Replace the inline action button markup in `templates/admin/tab-generated-posts.php` with a per-row `$aips_action_config` and an `include` of the new partial, and add inline comments explaining the UX hierarchy (primary = Edit). 
- Replace the inline action button markup in `templates/admin/tab-pending-review.php` with a per-row `$aips_action_config` (including `pending_review` state flag) and an `include` of the same partial, and add inline comments explaining the UX hierarchy (primary = Publish). 

### Testing

- Ran PHP syntax checks with `php -l` for `templates/partials/post-row-actions.php`, `templates/admin/tab-generated-posts.php`, and `templates/admin/tab-pending-review.php`, and all reported "No syntax errors detected". 
- Verified that the partial renders identical button classes and `data-*` attributes required by the existing scripts (`assets/js/admin-generated-posts.js`, `assets/js/admin-post-review.js`, `assets/js/admin-view-session.js`, `assets/js/admin-ai-edit.js`). 
- Attempted to check open PRs via `gh pr list` to satisfy de-duplication rules but the `gh` CLI is not available in this environment (`command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a029793a3788321a7747be2e9feb815)