### PR TITLE
History modal: add Summary/Technical tabs with presenter-backed run summaries

### DIFF
--- a/ai-post-scheduler/assets/js/admin-history.js
+++ b/ai-post-scheduler/assets/js/admin-history.js
@@ -61,7 +61,8 @@
 			// Copy log detail to clipboard.
 			$(document).on('click', '.aips-log-copy', this.copyLogDetail.bind(this));
 
-			// Log type filter tabs inside the modal.
+			// Modal tabs and log type filter tabs.
+			$(document).on('click', '.aips-history-modal-tab', this.switchModalTab.bind(this));
 			$(document).on('click', '.aips-log-type-filter-btn', this.filterLogsByType.bind(this));
 
 			// Close modal via close button or backdrop click.
@@ -299,6 +300,18 @@
 		 *
 		 * @param {Event} e - Click event from an `.aips-log-type-filter-btn` element.
 		 */
+
+		switchModalTab: function (e) {
+			e.preventDefault();
+			var $btn = $(e.currentTarget);
+			var tab = $btn.data('tab');
+			var $modal = $('#aips-history-logs-modal');
+			$modal.find('.aips-history-modal-tab').removeClass('aips-btn-primary').addClass('aips-btn-ghost');
+			$btn.removeClass('aips-btn-ghost').addClass('aips-btn-primary');
+			$modal.find('[data-tab-panel]').hide();
+			$modal.find('[data-tab-panel="' + tab + '"]').show();
+		},
+
 		filterLogsByType: function (e) {
 			e.preventDefault();
 			var $btn    = $(e.currentTarget);
@@ -332,6 +345,9 @@
 			var self = this;
 			var T    = AIPS.Templates;
 			var html = '';
+			var technicalHtml = '';
+			var summaryData = container.summary || {};
+			html += T.render('aips-tmpl-history-modal-tabs', { summaryLabel: 'Summary', technicalLabel: 'Technical' });
 
 			// ---- Container summary ----
 			var rows = '';
@@ -415,7 +431,23 @@
 				});
 			}
 
-			html += T.renderRaw('aips-tmpl-history-modal-summary', { rows: rows });
+			var summaryHtml = T.renderRaw('aips-tmpl-history-modal-summary', { rows: rows });
+			if (summaryData.task_type) { summaryHtml += '<h4>Run synopsis</h4><p><strong>Task type:</strong> ' + T.escape(summaryData.task_type) + '</p>'; }
+			if (summaryData.timeline && summaryData.timeline.length) {
+				var tl = '<h4>What happened</h4><ul>';
+				$.each(summaryData.timeline, function(i, item){
+					var sevClass = item.severity === 'error' ? 'aips-badge-error' : (item.severity === 'warning' ? 'aips-badge-warning' : 'aips-badge-neutral');
+					tl += T.renderRaw('aips-tmpl-history-summary-timeline-item', { severityClass: T.escape(sevClass), severity: T.escape(item.severity || 'info'), label: T.escape(item.label || ''), timestamp: T.escape(item.timestamp || '') });
+				});
+				tl += '</ul>';
+				summaryHtml += tl;
+			}
+			if (summaryData.result) {
+				summaryHtml += '<h4>Result</h4><p><strong>Template:</strong> ' + T.escape(summaryData.result.template || '—') + ' | <strong>Author:</strong> ' + T.escape(summaryData.result.author || '—') + ' | <strong>Topic:</strong> ' + T.escape(summaryData.result.topic || '—') + ' | <strong>Source:</strong> ' + T.escape(summaryData.result.source || '—') + '</p>';
+			}
+			if (container.status === 'failed') {
+				summaryHtml += '<h4>If failed</h4><p><strong>Reason:</strong> ' + T.escape(summaryData.failure_reason || container.error_message || 'Unknown') + '</p><p><strong>Suggested next action:</strong> ' + T.escape(summaryData.next_action || 'Retry, edit prompt, or check source configuration.') + '</p>';
+			}
 
 			// ---- Log type filter toolbar ----
 			var typeCounts = { all: logs.length };
@@ -451,23 +483,23 @@
 					});
 				});
 
-				html += T.renderRaw('aips-tmpl-history-log-type-filter', {
+				technicalHtml += T.renderRaw('aips-tmpl-history-log-type-filter', {
 					filterLabel: T.escape(aipsHistoryL10n.filterByType || 'Filter:'),
 					buttons:     filterButtons
 				});
 			}
 
 			// ---- Log entries heading ----
-			html += T.renderRaw('aips-tmpl-history-logs-heading', {
+			technicalHtml += T.renderRaw('aips-tmpl-history-logs-heading', {
 				heading: T.escape(aipsHistoryL10n.logsHeading || 'Log Entries'),
 				count:   logs.length
 			});
 
 			if (logs.length === 0) {
-				html += T.render('aips-tmpl-history-no-logs', {
+				technicalHtml += T.render('aips-tmpl-history-no-logs', {
 					message: aipsHistoryL10n.noLogsFound || 'No log entries found for this container.'
 				});
-				return html;
+				return T.renderRaw('aips-tmpl-history-summary-section', { content: summaryHtml, technical: technicalHtml });
 			}
 
 			var rowsHtml = '';
@@ -507,7 +539,7 @@
 				});
 			});
 
-			html += T.renderRaw('aips-tmpl-history-logs-table', {
+			technicalHtml += T.renderRaw('aips-tmpl-history-logs-table', {
 				colTimestamp: T.escape(aipsHistoryL10n.colTimestamp || 'Timestamp'),
 				colType:      T.escape(aipsHistoryL10n.colType || 'Type'),
 				colLogType:   T.escape(aipsHistoryL10n.colLogType || 'Log Type'),
@@ -515,7 +547,7 @@
 				rows:         rowsHtml
 			});
 
-			return html;
+			return T.renderRaw('aips-tmpl-history-summary-section', { content: summaryHtml, technical: technicalHtml });
 		},
 
 		/**

--- a/ai-post-scheduler/includes/class-aips-history-run-presenter.php
+++ b/ai-post-scheduler/includes/class-aips-history-run-presenter.php
@@ -1,0 +1,115 @@
+<?php
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+class AIPS_History_Run_Presenter {
+	public function present_container($container, $logs) {
+		$task_type = !empty($container->creation_method) ? str_replace('_', ' ', (string) $container->creation_method) : __('Generation run', 'ai-post-scheduler');
+		$task_type = ucwords($task_type);
+
+		$timeline = array();
+		$result = array(
+			'template' => isset($container->template_name) ? $container->template_name : '',
+			'author' => '',
+			'topic' => '',
+			'source' => '',
+		);
+		$failure_reason = isset($container->error_message) ? (string) $container->error_message : '';
+
+		foreach ($logs as $log) {
+			$details = array();
+			if (!empty($log->details)) {
+				$decoded = json_decode($log->details, true);
+				if (is_array($decoded)) {
+					$details = $decoded;
+				}
+			}
+
+			if (empty($failure_reason) && !empty($details['error'])) {
+				$failure_reason = (string) $details['error'];
+			}
+
+			foreach (array('author_name' => 'author', 'topic' => 'topic', 'source' => 'source', 'source_name' => 'source') as $key => $slot) {
+				if (empty($result[$slot]) && !empty($details[$key])) {
+					$result[$slot] = is_scalar($details[$key]) ? (string) $details[$key] : '';
+				}
+			}
+
+			$severity = $this->map_severity((int) $log->history_type_id);
+			$friendly = $this->friendly_event_label((string) $log->log_type, (int) $log->history_type_id);
+			$timeline[] = array(
+				'timestamp' => isset($log->timestamp) ? $log->timestamp : '',
+				'label' => $friendly,
+				'severity' => $severity,
+			);
+		}
+
+		return array(
+			'task_type' => $task_type,
+			'timeline' => $timeline,
+			'result' => $result,
+			'failure_reason' => $failure_reason,
+			'next_action' => $this->suggest_next_action($container, $failure_reason),
+		);
+	}
+
+	public function present_log($log) {
+		$history_type_id = (int) $log->history_type_id;
+		return array(
+			'id' => (int) $log->id,
+			'log_type' => $log->log_type,
+			'history_type_id' => $history_type_id,
+			'type_label' => AIPS_History_Type::get_label($history_type_id),
+			'friendly_label' => $this->friendly_event_label((string) $log->log_type, $history_type_id),
+			'severity' => $this->map_severity($history_type_id),
+			'timestamp' => $log->timestamp,
+		);
+	}
+
+	private function map_severity($history_type_id) {
+		if ($history_type_id === AIPS_History_Type::ERROR) {
+			return 'error';
+		}
+		if ($history_type_id === AIPS_History_Type::WARNING) {
+			return 'warning';
+		}
+		if ($history_type_id === AIPS_History_Type::ACTIVITY || $history_type_id === AIPS_History_Type::INFO) {
+			return 'success';
+		}
+		return 'neutral';
+	}
+
+	private function friendly_event_label($log_type, $history_type_id) {
+		$map = array(
+			'generation_started' => __('Generation started', 'ai-post-scheduler'),
+			'post_created' => __('Post created', 'ai-post-scheduler'),
+			'post_published' => __('Post published', 'ai-post-scheduler'),
+			'ai_request' => __('AI request sent', 'ai-post-scheduler'),
+			'ai_response' => __('AI response received', 'ai-post-scheduler'),
+			'generation_completed' => __('Generation completed', 'ai-post-scheduler'),
+			'generation_failed' => __('Generation failed', 'ai-post-scheduler'),
+		);
+		if (isset($map[$log_type])) {
+			return $map[$log_type];
+		}
+		if ($history_type_id === AIPS_History_Type::ERROR) {
+			return __('Error event', 'ai-post-scheduler');
+		}
+		return ucwords(str_replace('_', ' ', $log_type));
+	}
+
+	private function suggest_next_action($container, $failure_reason) {
+		if (!isset($container->status) || $container->status !== 'failed') {
+			return '';
+		}
+		$reason = strtolower((string) $failure_reason);
+		if (false !== strpos($reason, 'source')) {
+			return __('Check source availability/settings, then retry.', 'ai-post-scheduler');
+		}
+		if (false !== strpos($reason, 'prompt') || false !== strpos($reason, 'token')) {
+			return __('Review and adjust the prompt/template, then retry.', 'ai-post-scheduler');
+		}
+		return __('Retry the run. If it fails again, review template inputs and AI settings.', 'ai-post-scheduler');
+	}
+}

--- a/ai-post-scheduler/includes/class-aips-history.php
+++ b/ai-post-scheduler/includes/class-aips-history.php
@@ -238,6 +238,7 @@ class AIPS_History {
         // avoid a second trip to aips_history_log.
         $raw_logs = isset($history_item->log) ? $history_item->log : array();
 
+        $presenter = new AIPS_History_Run_Presenter();
         $logs = array();
         foreach ($raw_logs as $log) {
             $details = array();
@@ -248,14 +249,9 @@ class AIPS_History {
                 }
             }
 
-            $logs[] = array(
-                'id'               => (int) $log->id,
-                'log_type'         => $log->log_type,
-                'history_type_id'  => (int) $log->history_type_id,
-                'type_label'       => AIPS_History_Type::get_label((int) $log->history_type_id),
-                'timestamp'        => $log->timestamp,
-                'details'          => $details,
-            );
+            $presented_log = $presenter->present_log($log);
+            $presented_log['details'] = $details;
+            $logs[] = $presented_log;
         }
 
         // Calculate duration between created_at and completed_at.
@@ -285,6 +281,8 @@ class AIPS_History {
             }
         }
 
+        $summary = $presenter->present_container($history_item, $raw_logs);
+
         AIPS_Ajax_Response::success(array(
             'container' => array(
                 'id'               => (int) $history_item->id,
@@ -300,6 +298,7 @@ class AIPS_History {
                 'creation_method'  => isset( $history_item->creation_method ) ? $history_item->creation_method : null,
                 'duration_seconds' => $duration_seconds,
             ),
+            'summary'   => $summary,
             'logs'      => $logs,
         ));
     }

--- a/ai-post-scheduler/templates/admin/history.php
+++ b/ai-post-scheduler/templates/admin/history.php
@@ -316,3 +316,19 @@ if (is_object($history)) {
 <script type="text/html" id="aips-tmpl-history-summary-duration-row">
 	<tr><th>{{label}}</th><td>{{value}}</td></tr>
 </script>
+<script type="text/html" id="aips-tmpl-history-modal-tabs">
+	<div class="aips-log-type-filter" style="margin-bottom:12px;display:flex;gap:8px;">
+		<button type="button" class="aips-btn aips-btn-sm aips-btn-primary aips-history-modal-tab" data-tab="summary">{{summaryLabel}}</button>
+		<button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-history-modal-tab" data-tab="technical">{{technicalLabel}}</button>
+	</div>
+</script>
+
+<script type="text/html" id="aips-tmpl-history-summary-timeline-item">
+	<li><span class="aips-badge {{severityClass}}">{{severity}}</span> <strong>{{label}}</strong> <span style="color:#666;">{{timestamp}}</span></li>
+</script>
+
+<script type="text/html" id="aips-tmpl-history-summary-section">
+	<div data-tab-panel="summary">{{content}}</div>
+	<div data-tab-panel="technical" style="display:none;">{{technical}}</div>
+</script>
+


### PR DESCRIPTION
### Motivation
- Make history details accessible to non-technical admins by providing a human-friendly run synopsis and timeline while preserving full raw logs for advanced debugging. 
- Keep raw repository data unchanged and perform UI-focused transformation in a lightweight presenter so the database/log schema is not modified.

### Description
- Add `AIPS_History_Run_Presenter` (`includes/class-aips-history-run-presenter.php`) that maps history/log records into a UI `summary` (task type, timeline with friendly labels/severities, result metadata, failure reason, and suggested next action) and provides a per-log presentation method. 
- Update `AIPS_History::ajax_get_history_logs()` (`includes/class-aips-history.php`) to use the presenter, return a `summary` object alongside the existing `logs` array, and keep raw `details` intact for the Technical view. 
- Extend the history modal templates (`templates/admin/history.php`) with tab controls and summary/technical container templates, and add timeline item and summary-section templates. 
- Extend `assets/js/admin-history.js` to render a two-tab modal (default `Summary` and `Technical` for the existing raw log table), add tab switching logic, and build the summary HTML from the presenter payload; existing log filtering/detail/copy behavior is retained.
- Attempted to follow the repository preflight instruction to run `gh pr list`, but `gh` was not available in the execution environment so that check could not be completed.

### Testing
- Ran PHP lint on the new presenter with `php -l includes/class-aips-history-run-presenter.php` which succeeded. 
- Ran PHP lint on the modified history handler with `php -l includes/class-aips-history.php` which succeeded. 
- Performed a JS syntax sanity check with `node -e "new Function(require('fs').readFileSync('assets/js/admin-history.js','utf8')); console.log('ok')"` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a029d6d91cc8321a04efbf0762696b8)