### PR TITLE
Add History action to post rows and auto-open History modal from links

### DIFF
--- a/ai-post-scheduler/assets/js/admin-history.js
+++ b/ai-post-scheduler/assets/js/admin-history.js
@@ -123,7 +123,7 @@
 				this.searchQuery = String(postId);
 				$('#aips-history-search-input').val(String(postId));
 				this.syncSearchClearButton();
-				this.filterRowsBySearch(postId);
+				this.reload(1);
 			}
 
 			if (historyId > 0) {

--- a/ai-post-scheduler/assets/js/admin-history.js
+++ b/ai-post-scheduler/assets/js/admin-history.js
@@ -46,6 +46,7 @@
 			this.searchQuery  = $('#aips-history-search-input').val() || '';
 			this.syncSearchClearButton();
 			this.bindEvents();
+			this.maybeOpenFromQuery();
 		},
 
 		/**
@@ -106,6 +107,42 @@
 
 			// Export CSV.
 			$(document).on('click', '#aips-export-history-btn', this.exportHistory.bind(this));
+		},
+
+
+
+		/**
+		 * Auto-open a specific history container from query args when available.
+		 */
+		maybeOpenFromQuery: function () {
+			var params = new URLSearchParams(window.location.search || '');
+			var historyId = parseInt(params.get('history_id') || 0, 10);
+			var postId = parseInt(params.get('post_id') || 0, 10);
+
+			if (postId > 0 && !this.searchQuery) {
+				this.searchQuery = String(postId);
+				$('#aips-history-search-input').val(String(postId));
+				this.syncSearchClearButton();
+				this.filterRowsBySearch(postId);
+			}
+
+			if (historyId > 0) {
+				this.openLogsModalFromId(historyId);
+			}
+		},
+
+		/**
+		 * Open history logs modal for a known history id.
+		 *
+		 * @param {number} historyId History container id.
+		 */
+		openLogsModalFromId: function (historyId) {
+			var $trigger = $('<button type="button" class="aips-view-history-logs" data-id="' + historyId + '"></button>');
+			this.openLogsModal({
+				preventDefault: function () {},
+				stopPropagation: function () {},
+				currentTarget: $trigger.get(0)
+			});
 		},
 
 		/* ------------------------------------------------------------------ */

--- a/ai-post-scheduler/templates/admin/tab-generated-posts.php
+++ b/ai-post-scheduler/templates/admin/tab-generated-posts.php
@@ -131,6 +131,20 @@ if (!defined('ABSPATH')) {
 											<span class="dashicons dashicons-admin-customizer"></span>
 											<?php esc_html_e('AI Edit', 'ai-post-scheduler'); ?>
 										</button>
+										<?php
+											$history_url = AIPS_Admin_Menu_Helper::get_page_url('history', array_filter(array(
+												'history_id' => !empty($post_data['history_id']) ? absint($post_data['history_id']) : 0,
+												'post_id'    => !empty($post_data['post_id']) ? absint($post_data['post_id']) : 0,
+											)));
+										?>
+										<a class="aips-btn aips-btn-sm aips-btn-secondary aips-open-history"
+										   href="<?php echo esc_url($history_url); ?>"
+										   data-history-id="<?php echo esc_attr($post_data['history_id']); ?>"
+										   data-post-id="<?php echo esc_attr($post_data['post_id']); ?>"
+										   title="<?php esc_attr_e('View history for this post', 'ai-post-scheduler'); ?>">
+											<span class="dashicons dashicons-backup"></span>
+											<?php esc_html_e('History', 'ai-post-scheduler'); ?>
+										</a>
 										<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-view-session" 
 								        data-history-id="<?php echo esc_attr($post_data['history_id']); ?>"
 								        title="<?php esc_attr_e('View Session', 'ai-post-scheduler'); ?>">

--- a/ai-post-scheduler/templates/admin/tab-pending-review.php
+++ b/ai-post-scheduler/templates/admin/tab-pending-review.php
@@ -135,6 +135,20 @@ if (!defined('ABSPATH')) {
 												<span class="dashicons dashicons-admin-customizer"></span>
 												<?php esc_html_e('AI Edit', 'ai-post-scheduler'); ?>
 											</button>
+											<?php
+												$history_url = AIPS_Admin_Menu_Helper::get_page_url('history', array_filter(array(
+													'history_id' => !empty($item->id) ? absint($item->id) : 0,
+													'post_id'    => !empty($item->post_id) ? absint($item->post_id) : 0,
+												)));
+											?>
+											<a class="aips-btn aips-btn-sm aips-btn-secondary aips-open-history"
+												href="<?php echo esc_url($history_url); ?>"
+												data-history-id="<?php echo esc_attr($item->id); ?>"
+												data-post-id="<?php echo esc_attr($item->post_id); ?>"
+												title="<?php esc_attr_e('View history for this post', 'ai-post-scheduler'); ?>">
+												<span class="dashicons dashicons-backup"></span>
+												<?php esc_html_e('History', 'ai-post-scheduler'); ?>
+											</a>
 											<button type="button"
 												class="aips-btn aips-btn-sm aips-btn-secondary aips-view-session"
 												data-history-id="<?php echo esc_attr($item->id); ?>"


### PR DESCRIPTION
### Motivation
- Provide a dedicated “History” action in post row actions so editors can quickly inspect generation history directly from post-centric tables using the existing `data-history-id` context. 
- Prefer opening the History logs modal directly for the selected container while falling back to a deep-linked History page filtered by `post_id`/`history_id` when needed. 
- Apply the same UX to other post-focused tables (e.g. pending review) so history access is consistent across admin modules. 
- Attempted to check for existing PRs prior to changes but the GitHub CLI was not available in this environment, so that anti-duplication step could not complete here.

### Description
- Added a History action button to generated posts rows in `ai-post-scheduler/templates/admin/tab-generated-posts.php` that builds a focused History page URL via `AIPS_Admin_Menu_Helper::get_page_url('history', ...)` and includes `data-history-id` and `data-post-id` attributes. 
- Added the same History action to pending-review rows in `ai-post-scheduler/templates/admin/tab-pending-review.php` to keep the UX consistent for rows that already expose a `history_id`. 
- Enhanced `ai-post-scheduler/assets/js/admin-history.js` with `maybeOpenFromQuery()` and `openLogsModalFromId()` so the History page will: read `history_id` and `post_id` from the query string, prefill the history search by `post_id` when available, and auto-open the History logs modal when a `history_id` is present (preferred experience). 
- Links still deep-link to the History page (fallback) so users are focused on the relevant container even if automatic modal opening cannot occur.

### Testing
- Ran PHP syntax checks with `php -l` on the modified templates and both files passed with "No syntax errors detected": `ai-post-scheduler/templates/admin/tab-generated-posts.php` and `ai-post-scheduler/templates/admin/tab-pending-review.php` (success).
- No additional automated test suites were executed in this environment (no unit test run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0348c008b083219b151ccecfc713ff)