### PR TITLE
Add timeline-oriented History mode with cross-domain filters

### DIFF
--- a/ai-post-scheduler/assets/js/admin-history.js
+++ b/ai-post-scheduler/assets/js/admin-history.js
@@ -33,6 +33,11 @@
 
 		/** @type {string} Raw search query as entered by the user */
 		searchQuery: '',
+		domainFilter: '',
+		actorFilter: '',
+		correlationId: '',
+		dateFrom: '',
+		dateTo: '',
 
 		/* ------------------------------------------------------------------ */
 		/* Init / events                                                        */
@@ -43,7 +48,17 @@
 		 */
 		init: function () {
 			this.statusFilter = $('#aips-filter-status').val() || '';
+			this.domainFilter = $('#aips-filter-domain').val() || '';
+			this.actorFilter = $('#aips-filter-actor').val() || '';
+			this.correlationId = $('#aips-filter-correlation').val() || '';
+			this.dateFrom = $('#aips-filter-date-from').val() || '';
+			this.dateTo = $('#aips-filter-date-to').val() || '';
 			this.searchQuery  = $('#aips-history-search-input').val() || '';
+			this.domainFilter = $('#aips-filter-domain').val() || '';
+			this.actorFilter = $('#aips-filter-actor').val() || '';
+			this.correlationId = $('#aips-filter-correlation').val() || '';
+			this.dateFrom = $('#aips-filter-date-from').val() || '';
+			this.dateTo = $('#aips-filter-date-to').val() || '';
 			this.syncSearchClearButton();
 			this.bindEvents();
 		},
@@ -878,6 +893,11 @@
 					nonce: aipsAjax.nonce,
 					status: self.statusFilter,
 					search: self.searchQuery,
+					domain: self.domainFilter,
+					actor: self.actorFilter,
+					correlation_id: self.correlationId,
+					date_from: self.dateFrom,
+					date_to: self.dateTo,
 					paged: paged
 				},
 				success: function (response) {
@@ -968,14 +988,21 @@
 				e.preventDefault();
 			}
 			this.statusFilter = $('#aips-filter-status').val() || '';
+			this.domainFilter = $('#aips-filter-domain').val() || '';
+			this.actorFilter = $('#aips-filter-actor').val() || '';
+			this.correlationId = $('#aips-filter-correlation').val() || '';
+			this.dateFrom = $('#aips-filter-date-from').val() || '';
+			this.dateTo = $('#aips-filter-date-to').val() || '';
 
 			// Reflect change in the URL without reloading.
 			var url = new URL(window.location.href);
-			if (this.statusFilter) {
-				url.searchParams.set('status', this.statusFilter);
-			} else {
-				url.searchParams.delete('status');
-			}
+			[['status', this.statusFilter], ['domain', this.domainFilter], ['actor', this.actorFilter], ['correlation_id', this.correlationId], ['date_from', this.dateFrom], ['date_to', this.dateTo]].forEach(function (entry) {
+				if (entry[1]) {
+					url.searchParams.set(entry[0], entry[1]);
+				} else {
+					url.searchParams.delete(entry[0]);
+				}
+			});
 			url.searchParams.delete('paged');
 			window.history.pushState({}, '', url.toString());
 
@@ -1074,6 +1101,11 @@
 			form.append($('<input type="hidden" name="nonce">').val(aipsAjax.nonce));
 			form.append($('<input type="hidden" name="status">').val(this.statusFilter));
 			form.append($('<input type="hidden" name="search">').val(this.searchQuery));
+			form.append($('<input type="hidden" name="domain">').val(this.domainFilter));
+			form.append($('<input type="hidden" name="actor">').val(this.actorFilter));
+			form.append($('<input type="hidden" name="correlation_id">').val(this.correlationId));
+			form.append($('<input type="hidden" name="date_from">').val(this.dateFrom));
+			form.append($('<input type="hidden" name="date_to">').val(this.dateTo));
 			$('body').append(form);
 			form.submit();
 			form.remove();

--- a/ai-post-scheduler/assets/js/admin-history.js
+++ b/ai-post-scheduler/assets/js/admin-history.js
@@ -54,11 +54,6 @@
 			this.dateFrom = $('#aips-filter-date-from').val() || '';
 			this.dateTo = $('#aips-filter-date-to').val() || '';
 			this.searchQuery  = $('#aips-history-search-input').val() || '';
-			this.domainFilter = $('#aips-filter-domain').val() || '';
-			this.actorFilter = $('#aips-filter-actor').val() || '';
-			this.correlationId = $('#aips-filter-correlation').val() || '';
-			this.dateFrom = $('#aips-filter-date-from').val() || '';
-			this.dateTo = $('#aips-filter-date-to').val() || '';
 			this.syncSearchClearButton();
 			this.bindEvents();
 		},

--- a/ai-post-scheduler/includes/class-aips-history-repository.php
+++ b/ai-post-scheduler/includes/class-aips-history-repository.php
@@ -213,40 +213,51 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
         
         $offset = ($args['page'] - 1) * $args['per_page'];
 
-		$event_domain_case_sql = "CASE
-				WHEN COALESCE(h.creation_method, '') LIKE 'author_topic%' THEN 'author_topics'
-				WHEN COALESCE(h.creation_method, '') LIKE '%research%' THEN 'research'
-				WHEN COALESCE(h.creation_method, '') LIKE '%source%' THEN 'sources'
-				WHEN COALESCE(h.creation_method, '') LIKE '%embedding%' THEN 'embeddings'
-				WHEN COALESCE(h.creation_method, '') LIKE '%internal_link%' THEN 'internal_links'
-				WHEN COALESCE(h.creation_method, '') LIKE '%batch%' THEN 'batch_jobs'
-				ELSE 'post_generation'
-			END";
-		$event_label_case_sql = "CASE
-				WHEN h.generated_title IS NOT NULL AND h.generated_title <> '' THEN h.generated_title
-				WHEN h.topic_id IS NOT NULL AND h.topic_id > 0 THEN CONCAT('Topic #', h.topic_id)
-				ELSE 'Generation Event'
-			END";
-		$actor_type_case_sql = "CASE
-				WHEN COALESCE(h.creation_method, '') LIKE '%manual%' OR COALESCE(h.creation_method, '') LIKE '%admin%' THEN 'admin'
-				ELSE 'system'
-			END";
+        $domain_patterns = array(
+            'author_topics' => 'author_topic%',
+            'research' => '%research%',
+            'sources' => '%source%',
+            'embeddings' => '%embedding%',
+            'internal_links' => '%internal_link%',
+            'batch_jobs' => '%batch%',
+        );
 
-		// Build select fields
-		if ($args['fields'] === 'list') {
-			$fields_sql = "h.id, h.uuid, h.correlation_id, h.post_id, h.template_id, h.topic_id, h.status, h.generated_title, h.created_at, h.error_message, h.completed_at, h.creation_method,
-				{$event_domain_case_sql} AS event_domain,
-				{$event_label_case_sql} AS event_label,
-				{$actor_type_case_sql} AS actor_type,
-				t.name as template_name";
-		} elseif ($args['fields'] === 'all') {
-			// Include longtext fields only when 'all' is explicitly requested or defaulted to, to prevent breaking changes
-			$fields_sql = "h.id, h.uuid, h.correlation_id, h.post_id, h.template_id, h.status, h.generated_title, h.error_message, h.created_at, h.completed_at, h.author_id, h.topic_id, h.creation_method, h.prompt, h.generated_content, h.generation_log,
-				{$event_domain_case_sql} AS event_domain,
-				{$event_label_case_sql} AS event_label,
-				{$actor_type_case_sql} AS actor_type,
-				t.name as template_name";
-		} else {
+        $event_domain_case_parts = array('CASE');
+        foreach ($domain_patterns as $domain_key => $domain_pattern) {
+            $event_domain_case_parts[] = sprintf(
+                "WHEN COALESCE(h.creation_method, '') LIKE '%s' THEN '%s'",
+                esc_sql($domain_pattern),
+                esc_sql($domain_key)
+            );
+        }
+        $event_domain_case_parts[] = "ELSE 'post_generation'";
+        $event_domain_case_parts[] = 'END';
+        $event_domain_case_sql = implode("\n", $event_domain_case_parts);
+        $event_label_case_sql = "CASE
+                WHEN h.generated_title IS NOT NULL AND h.generated_title <> '' THEN h.generated_title
+                WHEN h.topic_id IS NOT NULL THEN CONCAT('Topic #', h.topic_id)
+                ELSE 'Generation Event'
+            END";
+        $actor_type_case_sql = "CASE
+                WHEN COALESCE(h.creation_method, '') LIKE '%manual%' OR COALESCE(h.creation_method, '') LIKE '%admin%' THEN 'admin'
+                ELSE 'system'
+            END";
+
+        // Build select fields
+        if ($args['fields'] === 'list') {
+            $fields_sql = "h.id, h.uuid, h.correlation_id, h.post_id, h.template_id, h.topic_id, h.status, h.generated_title, h.created_at, h.error_message, h.completed_at, h.creation_method,
+                {$event_domain_case_sql} AS event_domain,
+                {$event_label_case_sql} AS event_label,
+                {$actor_type_case_sql} AS actor_type,
+                t.name as template_name";
+        } elseif ($args['fields'] === 'all') {
+            // Include longtext fields only when 'all' is explicitly requested or defaulted to, to prevent breaking changes
+            $fields_sql = "h.id, h.uuid, h.correlation_id, h.post_id, h.template_id, h.status, h.generated_title, h.error_message, h.created_at, h.completed_at, h.author_id, h.topic_id, h.creation_method, h.prompt, h.generated_content, h.generation_log,
+                {$event_domain_case_sql} AS event_domain,
+                {$event_label_case_sql} AS event_label,
+                {$actor_type_case_sql} AS actor_type,
+                t.name as template_name";
+        } else {
             // For specifically 'performance' or any other restricted fields
             $fields_sql = "h.id, h.uuid, h.correlation_id, h.post_id, h.template_id, h.status, h.generated_title, h.error_message, h.created_at, h.completed_at, h.author_id, h.topic_id, h.creation_method, h.prompt, t.name as template_name";
         }
@@ -281,76 +292,55 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
             $where_args[] = sanitize_text_field($args['correlation_id']);
         }
 
-		if (!empty($args['domain'])) {
-			$domain = sanitize_key($args['domain']);
+        if (!empty($args['domain'])) {
+            $domain = sanitize_key($args['domain']);
 
-			if ($domain === 'author_topics') {
-				$where_clauses[] = "COALESCE(h.creation_method, '') LIKE %s";
-				$where_args[] = 'author_topic%';
-			} elseif ($domain === 'research') {
-				$where_clauses[] = "COALESCE(h.creation_method, '') LIKE %s";
-				$where_args[] = '%research%';
-			} elseif ($domain === 'sources') {
-				$where_clauses[] = "COALESCE(h.creation_method, '') LIKE %s";
-				$where_args[] = '%source%';
-			} elseif ($domain === 'embeddings') {
-				$where_clauses[] = "COALESCE(h.creation_method, '') LIKE %s";
-				$where_args[] = '%embedding%';
-			} elseif ($domain === 'internal_links') {
-				$where_clauses[] = "COALESCE(h.creation_method, '') LIKE %s";
-				$where_args[] = '%internal_link%';
-			} elseif ($domain === 'batch_jobs') {
-				$where_clauses[] = "COALESCE(h.creation_method, '') LIKE %s";
-				$where_args[] = '%batch%';
-			} elseif ($domain === 'post_generation') {
-				$where_clauses[] = "COALESCE(h.creation_method, '') NOT LIKE %s";
-				$where_args[] = 'author_topic%';
-				$where_clauses[] = "COALESCE(h.creation_method, '') NOT LIKE %s";
-				$where_args[] = '%research%';
-				$where_clauses[] = "COALESCE(h.creation_method, '') NOT LIKE %s";
-				$where_args[] = '%source%';
-				$where_clauses[] = "COALESCE(h.creation_method, '') NOT LIKE %s";
-				$where_args[] = '%embedding%';
-				$where_clauses[] = "COALESCE(h.creation_method, '') NOT LIKE %s";
-				$where_args[] = '%internal_link%';
-				$where_clauses[] = "COALESCE(h.creation_method, '') NOT LIKE %s";
-				$where_args[] = '%batch%';
-			}
-		}
+            if (isset($domain_patterns[$domain])) {
+                $where_clauses[] = "COALESCE(h.creation_method, '') LIKE %s";
+                $where_args[] = $domain_patterns[$domain];
+            } elseif ($domain === 'post_generation') {
+                $post_generation_clauses = array();
+                foreach ($domain_patterns as $pattern) {
+                    $post_generation_clauses[] = "COALESCE(h.creation_method, '') LIKE %s";
+                    $where_args[] = $pattern;
+                }
+                $where_clauses[] = 'NOT (' . implode(' OR ', $post_generation_clauses) . ')';
+            }
+        }
 
-		if (!empty($args['actor'])) {
-			$actor = sanitize_key($args['actor']);
+        if (!empty($args['actor'])) {
+            $actor = sanitize_key($args['actor']);
 
-			if ($actor === 'admin') {
-				$where_clauses[] = "(COALESCE(h.creation_method, '') LIKE %s OR COALESCE(h.creation_method, '') LIKE %s)";
-				$where_args[] = '%manual%';
-				$where_args[] = '%admin%';
-			} elseif ($actor === 'system') {
-				$where_clauses[] = "(COALESCE(h.creation_method, '') NOT LIKE %s AND COALESCE(h.creation_method, '') NOT LIKE %s)";
-				$where_args[] = '%manual%';
-				$where_args[] = '%admin%';
-			}
-		}
+            if ($actor === 'admin') {
+                $where_clauses[] = "(COALESCE(h.creation_method, '') LIKE %s OR COALESCE(h.creation_method, '') LIKE %s)";
+                $where_args[] = '%manual%';
+                $where_args[] = '%admin%';
+            } elseif ($actor === 'system') {
+                $where_clauses[] = "(COALESCE(h.creation_method, '') NOT LIKE %s AND COALESCE(h.creation_method, '') NOT LIKE %s)";
+                $where_args[] = '%manual%';
+                $where_args[] = '%admin%';
+            }
+        }
 
-		if (!empty($args['date_from'])) {
-			$date_from = sanitize_text_field($args['date_from']);
-			$date_from_ts = strtotime($date_from . ' 00:00:00');
+        if (!empty($args['date_from'])) {
+            $date_from = sanitize_text_field($args['date_from']);
+            $date_from_ts = strtotime($date_from . ' 00:00:00');
 
-			if (!empty($date_from_ts)) {
-				$where_clauses[] = "h.created_at >= %d";
-				$where_args[] = $date_from_ts;
-			}
-		}
+            if ($date_from_ts !== false) {
+                $where_clauses[] = "h.created_at >= %d";
+                $where_args[] = $date_from_ts;
+            }
+        }
 
-		if (!empty($args['date_to'])) {
-			$date_to = sanitize_text_field($args['date_to']);
-			$date_to_ts = strtotime($date_to . ' 23:59:59');
+        if (!empty($args['date_to'])) {
+            $date_to = sanitize_text_field($args['date_to']);
+            $date_to_ts = strtotime($date_to . ' 23:59:59');
 
-			if (!empty($date_to_ts)) {
-				$where_clauses[] = "h.created_at <= %d";
-				$where_args[] = $date_to_ts;
-			}
-		}
+            if ($date_to_ts !== false) {
+                $where_clauses[] = "h.created_at <= %d";
+                $where_args[] = $date_to_ts;
+            }
+        }
 
         if (!empty($args['search'])) {
             $where_clauses[] = "h.generated_title LIKE %s";

--- a/ai-post-scheduler/includes/class-aips-history-repository.php
+++ b/ai-post-scheduler/includes/class-aips-history-repository.php
@@ -200,6 +200,10 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
             'template_id' => 0,
             'author_id' => 0,
             'correlation_id' => '',
+            'domain' => '',
+            'actor' => '',
+            'date_from' => '',
+            'date_to' => '',
             'orderby' => 'created_at',
             'order' => 'DESC',
             'fields' => 'all',
@@ -211,10 +215,48 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
 
         // Build select fields
         if ($args['fields'] === 'list') {
-            $fields_sql = "h.id, h.uuid, h.correlation_id, h.post_id, h.template_id, h.topic_id, h.status, h.generated_title, h.created_at, h.error_message, h.completed_at, h.creation_method, t.name as template_name";
+            $fields_sql = "h.id, h.uuid, h.correlation_id, h.post_id, h.template_id, h.topic_id, h.status, h.generated_title, h.created_at, h.error_message, h.completed_at, h.creation_method,
+                CASE
+                    WHEN COALESCE(h.creation_method, '') LIKE 'author_topic%' THEN 'author_topics'
+                    WHEN COALESCE(h.creation_method, '') LIKE '%research%' THEN 'research'
+                    WHEN COALESCE(h.creation_method, '') LIKE '%source%' THEN 'sources'
+                    WHEN COALESCE(h.creation_method, '') LIKE '%embedding%' THEN 'embeddings'
+                    WHEN COALESCE(h.creation_method, '') LIKE '%internal_link%' THEN 'internal_links'
+                    WHEN COALESCE(h.creation_method, '') LIKE '%batch%' THEN 'batch_jobs'
+                    ELSE 'post_generation'
+                END AS event_domain,
+                CASE
+                    WHEN h.generated_title IS NOT NULL AND h.generated_title <> '' THEN h.generated_title
+                    WHEN h.topic_id IS NOT NULL THEN CONCAT('Topic #', h.topic_id)
+                    ELSE 'Generation Event'
+                END AS event_label,
+                CASE
+                    WHEN COALESCE(h.creation_method, '') LIKE '%manual%' OR COALESCE(h.creation_method, '') LIKE '%admin%' THEN 'admin'
+                    ELSE 'system'
+                END AS actor_type,
+                t.name as template_name";
         } elseif ($args['fields'] === 'all') {
             // Include longtext fields only when 'all' is explicitly requested or defaulted to, to prevent breaking changes
-            $fields_sql = "h.id, h.uuid, h.correlation_id, h.post_id, h.template_id, h.status, h.generated_title, h.error_message, h.created_at, h.completed_at, h.author_id, h.topic_id, h.creation_method, h.prompt, h.generated_content, h.generation_log, t.name as template_name";
+            $fields_sql = "h.id, h.uuid, h.correlation_id, h.post_id, h.template_id, h.status, h.generated_title, h.error_message, h.created_at, h.completed_at, h.author_id, h.topic_id, h.creation_method, h.prompt, h.generated_content, h.generation_log,
+                CASE
+                    WHEN COALESCE(h.creation_method, '') LIKE 'author_topic%' THEN 'author_topics'
+                    WHEN COALESCE(h.creation_method, '') LIKE '%research%' THEN 'research'
+                    WHEN COALESCE(h.creation_method, '') LIKE '%source%' THEN 'sources'
+                    WHEN COALESCE(h.creation_method, '') LIKE '%embedding%' THEN 'embeddings'
+                    WHEN COALESCE(h.creation_method, '') LIKE '%internal_link%' THEN 'internal_links'
+                    WHEN COALESCE(h.creation_method, '') LIKE '%batch%' THEN 'batch_jobs'
+                    ELSE 'post_generation'
+                END AS event_domain,
+                CASE
+                    WHEN h.generated_title IS NOT NULL AND h.generated_title <> '' THEN h.generated_title
+                    WHEN h.topic_id IS NOT NULL THEN CONCAT('Topic #', h.topic_id)
+                    ELSE 'Generation Event'
+                END AS event_label,
+                CASE
+                    WHEN COALESCE(h.creation_method, '') LIKE '%manual%' OR COALESCE(h.creation_method, '') LIKE '%admin%' THEN 'admin'
+                    ELSE 'system'
+                END AS actor_type,
+                t.name as template_name";
         } else {
             // For specifically 'performance' or any other restricted fields
             $fields_sql = "h.id, h.uuid, h.correlation_id, h.post_id, h.template_id, h.status, h.generated_title, h.error_message, h.created_at, h.completed_at, h.author_id, h.topic_id, h.creation_method, h.prompt, t.name as template_name";
@@ -248,6 +290,34 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
         if (!empty($args['correlation_id'])) {
             $where_clauses[] = "h.correlation_id = %s";
             $where_args[] = sanitize_text_field($args['correlation_id']);
+        }
+
+        if (!empty($args['domain'])) {
+            $where_clauses[] = "CASE
+                    WHEN COALESCE(h.creation_method, '') LIKE 'author_topic%' THEN 'author_topics'
+                    WHEN COALESCE(h.creation_method, '') LIKE '%research%' THEN 'research'
+                    WHEN COALESCE(h.creation_method, '') LIKE '%source%' THEN 'sources'
+                    WHEN COALESCE(h.creation_method, '') LIKE '%embedding%' THEN 'embeddings'
+                    WHEN COALESCE(h.creation_method, '') LIKE '%internal_link%' THEN 'internal_links'
+                    WHEN COALESCE(h.creation_method, '') LIKE '%batch%' THEN 'batch_jobs'
+                    ELSE 'post_generation'
+                END = %s";
+            $where_args[] = sanitize_key($args['domain']);
+        }
+
+        if (!empty($args['actor'])) {
+            $where_clauses[] = "CASE WHEN COALESCE(h.creation_method, '') LIKE '%manual%' OR COALESCE(h.creation_method, '') LIKE '%admin%' THEN 'admin' ELSE 'system' END = %s";
+            $where_args[] = sanitize_key($args['actor']);
+        }
+
+        if (!empty($args['date_from'])) {
+            $where_clauses[] = "h.created_at >= %s";
+            $where_args[] = sanitize_text_field($args['date_from']) . ' 00:00:00';
+        }
+
+        if (!empty($args['date_to'])) {
+            $where_clauses[] = "h.created_at <= %s";
+            $where_args[] = sanitize_text_field($args['date_to']) . ' 23:59:59';
         }
 
         if (!empty($args['search'])) {

--- a/ai-post-scheduler/includes/class-aips-history-repository.php
+++ b/ai-post-scheduler/includes/class-aips-history-repository.php
@@ -213,51 +213,40 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
         
         $offset = ($args['page'] - 1) * $args['per_page'];
 
-        // Build select fields
-        if ($args['fields'] === 'list') {
-            $fields_sql = "h.id, h.uuid, h.correlation_id, h.post_id, h.template_id, h.topic_id, h.status, h.generated_title, h.created_at, h.error_message, h.completed_at, h.creation_method,
-                CASE
-                    WHEN COALESCE(h.creation_method, '') LIKE 'author_topic%' THEN 'author_topics'
-                    WHEN COALESCE(h.creation_method, '') LIKE '%research%' THEN 'research'
-                    WHEN COALESCE(h.creation_method, '') LIKE '%source%' THEN 'sources'
-                    WHEN COALESCE(h.creation_method, '') LIKE '%embedding%' THEN 'embeddings'
-                    WHEN COALESCE(h.creation_method, '') LIKE '%internal_link%' THEN 'internal_links'
-                    WHEN COALESCE(h.creation_method, '') LIKE '%batch%' THEN 'batch_jobs'
-                    ELSE 'post_generation'
-                END AS event_domain,
-                CASE
-                    WHEN h.generated_title IS NOT NULL AND h.generated_title <> '' THEN h.generated_title
-                    WHEN h.topic_id IS NOT NULL THEN CONCAT('Topic #', h.topic_id)
-                    ELSE 'Generation Event'
-                END AS event_label,
-                CASE
-                    WHEN COALESCE(h.creation_method, '') LIKE '%manual%' OR COALESCE(h.creation_method, '') LIKE '%admin%' THEN 'admin'
-                    ELSE 'system'
-                END AS actor_type,
-                t.name as template_name";
-        } elseif ($args['fields'] === 'all') {
-            // Include longtext fields only when 'all' is explicitly requested or defaulted to, to prevent breaking changes
-            $fields_sql = "h.id, h.uuid, h.correlation_id, h.post_id, h.template_id, h.status, h.generated_title, h.error_message, h.created_at, h.completed_at, h.author_id, h.topic_id, h.creation_method, h.prompt, h.generated_content, h.generation_log,
-                CASE
-                    WHEN COALESCE(h.creation_method, '') LIKE 'author_topic%' THEN 'author_topics'
-                    WHEN COALESCE(h.creation_method, '') LIKE '%research%' THEN 'research'
-                    WHEN COALESCE(h.creation_method, '') LIKE '%source%' THEN 'sources'
-                    WHEN COALESCE(h.creation_method, '') LIKE '%embedding%' THEN 'embeddings'
-                    WHEN COALESCE(h.creation_method, '') LIKE '%internal_link%' THEN 'internal_links'
-                    WHEN COALESCE(h.creation_method, '') LIKE '%batch%' THEN 'batch_jobs'
-                    ELSE 'post_generation'
-                END AS event_domain,
-                CASE
-                    WHEN h.generated_title IS NOT NULL AND h.generated_title <> '' THEN h.generated_title
-                    WHEN h.topic_id IS NOT NULL THEN CONCAT('Topic #', h.topic_id)
-                    ELSE 'Generation Event'
-                END AS event_label,
-                CASE
-                    WHEN COALESCE(h.creation_method, '') LIKE '%manual%' OR COALESCE(h.creation_method, '') LIKE '%admin%' THEN 'admin'
-                    ELSE 'system'
-                END AS actor_type,
-                t.name as template_name";
-        } else {
+		$event_domain_case_sql = "CASE
+				WHEN COALESCE(h.creation_method, '') LIKE 'author_topic%' THEN 'author_topics'
+				WHEN COALESCE(h.creation_method, '') LIKE '%research%' THEN 'research'
+				WHEN COALESCE(h.creation_method, '') LIKE '%source%' THEN 'sources'
+				WHEN COALESCE(h.creation_method, '') LIKE '%embedding%' THEN 'embeddings'
+				WHEN COALESCE(h.creation_method, '') LIKE '%internal_link%' THEN 'internal_links'
+				WHEN COALESCE(h.creation_method, '') LIKE '%batch%' THEN 'batch_jobs'
+				ELSE 'post_generation'
+			END";
+		$event_label_case_sql = "CASE
+				WHEN h.generated_title IS NOT NULL AND h.generated_title <> '' THEN h.generated_title
+				WHEN h.topic_id IS NOT NULL AND h.topic_id > 0 THEN CONCAT('Topic #', h.topic_id)
+				ELSE 'Generation Event'
+			END";
+		$actor_type_case_sql = "CASE
+				WHEN COALESCE(h.creation_method, '') LIKE '%manual%' OR COALESCE(h.creation_method, '') LIKE '%admin%' THEN 'admin'
+				ELSE 'system'
+			END";
+
+		// Build select fields
+		if ($args['fields'] === 'list') {
+			$fields_sql = "h.id, h.uuid, h.correlation_id, h.post_id, h.template_id, h.topic_id, h.status, h.generated_title, h.created_at, h.error_message, h.completed_at, h.creation_method,
+				{$event_domain_case_sql} AS event_domain,
+				{$event_label_case_sql} AS event_label,
+				{$actor_type_case_sql} AS actor_type,
+				t.name as template_name";
+		} elseif ($args['fields'] === 'all') {
+			// Include longtext fields only when 'all' is explicitly requested or defaulted to, to prevent breaking changes
+			$fields_sql = "h.id, h.uuid, h.correlation_id, h.post_id, h.template_id, h.status, h.generated_title, h.error_message, h.created_at, h.completed_at, h.author_id, h.topic_id, h.creation_method, h.prompt, h.generated_content, h.generation_log,
+				{$event_domain_case_sql} AS event_domain,
+				{$event_label_case_sql} AS event_label,
+				{$actor_type_case_sql} AS actor_type,
+				t.name as template_name";
+		} else {
             // For specifically 'performance' or any other restricted fields
             $fields_sql = "h.id, h.uuid, h.correlation_id, h.post_id, h.template_id, h.status, h.generated_title, h.error_message, h.created_at, h.completed_at, h.author_id, h.topic_id, h.creation_method, h.prompt, t.name as template_name";
         }
@@ -292,33 +281,76 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
             $where_args[] = sanitize_text_field($args['correlation_id']);
         }
 
-        if (!empty($args['domain'])) {
-            $where_clauses[] = "CASE
-                    WHEN COALESCE(h.creation_method, '') LIKE 'author_topic%' THEN 'author_topics'
-                    WHEN COALESCE(h.creation_method, '') LIKE '%research%' THEN 'research'
-                    WHEN COALESCE(h.creation_method, '') LIKE '%source%' THEN 'sources'
-                    WHEN COALESCE(h.creation_method, '') LIKE '%embedding%' THEN 'embeddings'
-                    WHEN COALESCE(h.creation_method, '') LIKE '%internal_link%' THEN 'internal_links'
-                    WHEN COALESCE(h.creation_method, '') LIKE '%batch%' THEN 'batch_jobs'
-                    ELSE 'post_generation'
-                END = %s";
-            $where_args[] = sanitize_key($args['domain']);
-        }
+		if (!empty($args['domain'])) {
+			$domain = sanitize_key($args['domain']);
 
-        if (!empty($args['actor'])) {
-            $where_clauses[] = "CASE WHEN COALESCE(h.creation_method, '') LIKE '%manual%' OR COALESCE(h.creation_method, '') LIKE '%admin%' THEN 'admin' ELSE 'system' END = %s";
-            $where_args[] = sanitize_key($args['actor']);
-        }
+			if ($domain === 'author_topics') {
+				$where_clauses[] = "COALESCE(h.creation_method, '') LIKE %s";
+				$where_args[] = 'author_topic%';
+			} elseif ($domain === 'research') {
+				$where_clauses[] = "COALESCE(h.creation_method, '') LIKE %s";
+				$where_args[] = '%research%';
+			} elseif ($domain === 'sources') {
+				$where_clauses[] = "COALESCE(h.creation_method, '') LIKE %s";
+				$where_args[] = '%source%';
+			} elseif ($domain === 'embeddings') {
+				$where_clauses[] = "COALESCE(h.creation_method, '') LIKE %s";
+				$where_args[] = '%embedding%';
+			} elseif ($domain === 'internal_links') {
+				$where_clauses[] = "COALESCE(h.creation_method, '') LIKE %s";
+				$where_args[] = '%internal_link%';
+			} elseif ($domain === 'batch_jobs') {
+				$where_clauses[] = "COALESCE(h.creation_method, '') LIKE %s";
+				$where_args[] = '%batch%';
+			} elseif ($domain === 'post_generation') {
+				$where_clauses[] = "COALESCE(h.creation_method, '') NOT LIKE %s";
+				$where_args[] = 'author_topic%';
+				$where_clauses[] = "COALESCE(h.creation_method, '') NOT LIKE %s";
+				$where_args[] = '%research%';
+				$where_clauses[] = "COALESCE(h.creation_method, '') NOT LIKE %s";
+				$where_args[] = '%source%';
+				$where_clauses[] = "COALESCE(h.creation_method, '') NOT LIKE %s";
+				$where_args[] = '%embedding%';
+				$where_clauses[] = "COALESCE(h.creation_method, '') NOT LIKE %s";
+				$where_args[] = '%internal_link%';
+				$where_clauses[] = "COALESCE(h.creation_method, '') NOT LIKE %s";
+				$where_args[] = '%batch%';
+			}
+		}
 
-        if (!empty($args['date_from'])) {
-            $where_clauses[] = "h.created_at >= %s";
-            $where_args[] = sanitize_text_field($args['date_from']) . ' 00:00:00';
-        }
+		if (!empty($args['actor'])) {
+			$actor = sanitize_key($args['actor']);
 
-        if (!empty($args['date_to'])) {
-            $where_clauses[] = "h.created_at <= %s";
-            $where_args[] = sanitize_text_field($args['date_to']) . ' 23:59:59';
-        }
+			if ($actor === 'admin') {
+				$where_clauses[] = "(COALESCE(h.creation_method, '') LIKE %s OR COALESCE(h.creation_method, '') LIKE %s)";
+				$where_args[] = '%manual%';
+				$where_args[] = '%admin%';
+			} elseif ($actor === 'system') {
+				$where_clauses[] = "(COALESCE(h.creation_method, '') NOT LIKE %s AND COALESCE(h.creation_method, '') NOT LIKE %s)";
+				$where_args[] = '%manual%';
+				$where_args[] = '%admin%';
+			}
+		}
+
+		if (!empty($args['date_from'])) {
+			$date_from = sanitize_text_field($args['date_from']);
+			$date_from_ts = strtotime($date_from . ' 00:00:00');
+
+			if (!empty($date_from_ts)) {
+				$where_clauses[] = "h.created_at >= %d";
+				$where_args[] = $date_from_ts;
+			}
+		}
+
+		if (!empty($args['date_to'])) {
+			$date_to = sanitize_text_field($args['date_to']);
+			$date_to_ts = strtotime($date_to . ' 23:59:59');
+
+			if (!empty($date_to_ts)) {
+				$where_clauses[] = "h.created_at <= %d";
+				$where_args[] = $date_to_ts;
+			}
+		}
 
         if (!empty($args['search'])) {
             $where_clauses[] = "h.generated_title LIKE %s";

--- a/ai-post-scheduler/includes/class-aips-history.php
+++ b/ai-post-scheduler/includes/class-aips-history.php
@@ -99,6 +99,11 @@ class AIPS_History {
 
         $status_filter = isset($_POST['status']) ? sanitize_text_field(wp_unslash($_POST['status'])) : '';
         $search_query = isset($_POST['search']) ? sanitize_text_field(wp_unslash($_POST['search'])) : '';
+        $domain_filter = isset($_POST['domain']) ? sanitize_key(wp_unslash($_POST['domain'])) : '';
+        $actor_filter = isset($_POST['actor']) ? sanitize_key(wp_unslash($_POST['actor'])) : '';
+        $correlation_id = isset($_POST['correlation_id']) ? sanitize_text_field(wp_unslash($_POST['correlation_id'])) : '';
+        $date_from = isset($_POST['date_from']) ? sanitize_text_field(wp_unslash($_POST['date_from'])) : '';
+        $date_to = isset($_POST['date_to']) ? sanitize_text_field(wp_unslash($_POST['date_to'])) : '';
 
         // Get max records limit from configuration
         $config = AIPS_Config::get_instance();
@@ -110,6 +115,11 @@ class AIPS_History {
             'per_page' => $max_records,
             'status' => $status_filter,
             'search' => $search_query,
+            'domain' => $domain_filter,
+            'actor' => $actor_filter,
+            'correlation_id' => $correlation_id,
+            'date_from' => $date_from,
+            'date_to' => $date_to,
         ));
 
         $filename = 'aips-history-export-' . date('Y-m-d-H-i-s') . '.csv';
@@ -321,12 +331,22 @@ class AIPS_History {
 
         $status_filter = isset($_POST['status']) ? sanitize_text_field(wp_unslash($_POST['status'])) : '';
         $search_query = isset($_POST['search']) ? sanitize_text_field(wp_unslash($_POST['search'])) : '';
+        $domain_filter = isset($_POST['domain']) ? sanitize_key(wp_unslash($_POST['domain'])) : '';
+        $actor_filter = isset($_POST['actor']) ? sanitize_key(wp_unslash($_POST['actor'])) : '';
+        $correlation_id = isset($_POST['correlation_id']) ? sanitize_text_field(wp_unslash($_POST['correlation_id'])) : '';
+        $date_from = isset($_POST['date_from']) ? sanitize_text_field(wp_unslash($_POST['date_from'])) : '';
+        $date_to = isset($_POST['date_to']) ? sanitize_text_field(wp_unslash($_POST['date_to'])) : '';
         $paged = isset($_POST['paged']) ? max(1, absint($_POST['paged'])) : 1;
 
         $history = $this->get_history(array(
             'page'   => $paged,
             'status' => $status_filter,
             'search' => $search_query,
+            'domain' => $domain_filter,
+            'actor' => $actor_filter,
+            'correlation_id' => $correlation_id,
+            'date_from' => $date_from,
+            'date_to' => $date_to,
             'fields' => 'list',
         ));
 
@@ -493,11 +513,21 @@ class AIPS_History {
         $current_page = isset($_GET['paged']) ? absint($_GET['paged']) : 1;
         $status_filter = isset($_GET['status']) ? sanitize_text_field(wp_unslash($_GET['status'])) : '';
         $search_query = isset($_GET['s']) ? sanitize_text_field(wp_unslash($_GET['s'])) : '';
+        $domain_filter = isset($_GET['domain']) ? sanitize_key(wp_unslash($_GET['domain'])) : '';
+        $actor_filter = isset($_GET['actor']) ? sanitize_key(wp_unslash($_GET['actor'])) : '';
+        $correlation_id = isset($_GET['correlation_id']) ? sanitize_text_field(wp_unslash($_GET['correlation_id'])) : '';
+        $date_from = isset($_GET['date_from']) ? sanitize_text_field(wp_unslash($_GET['date_from'])) : '';
+        $date_to = isset($_GET['date_to']) ? sanitize_text_field(wp_unslash($_GET['date_to'])) : '';
 
         $history = $this->get_history(array(
             'page'   => $current_page,
             'status' => $status_filter,
             'search' => $search_query,
+            'domain' => $domain_filter,
+            'actor' => $actor_filter,
+            'correlation_id' => $correlation_id,
+            'date_from' => $date_from,
+            'date_to' => $date_to,
             'fields' => 'list',
         ));
 

--- a/ai-post-scheduler/templates/admin/history.php
+++ b/ai-post-scheduler/templates/admin/history.php
@@ -144,7 +144,7 @@ if (is_object($history)) {
                         <?php
                         $has_bucket = false;
                         foreach ($items as $item):
-                            $ts = (int) $item->created_at;
+                            $ts = (int) $item->created_at; // created_at is stored as a Unix timestamp.
                             $item_date = wp_date('Y-m-d', $ts, $utc_timezone);
                             $bucket = ($item_date === $today) ? 'today' : (($item_date === $yesterday) ? 'yesterday' : 'earlier');
                             if ($bucket !== $bucket_key) { continue; }

--- a/ai-post-scheduler/templates/admin/history.php
+++ b/ai-post-scheduler/templates/admin/history.php
@@ -132,10 +132,24 @@ if (is_object($history)) {
 
             <div class="aips-panel-body">
                 <h3><?php esc_html_e('Timeline', 'ai-post-scheduler'); ?></h3>
-                <?php $now = current_time('timestamp'); foreach (array('today' => 'Today', 'yesterday' => 'Yesterday', 'earlier' => 'Earlier') as $bucket_key => $bucket_label): ?>
+                <?php
+                $now = current_time('timestamp', true);
+                $utc_timezone = new DateTimeZone('UTC');
+                $today = wp_date('Y-m-d', $now, $utc_timezone);
+                $yesterday = wp_date('Y-m-d', $now - DAY_IN_SECONDS, $utc_timezone);
+                foreach (array('today' => 'Today', 'yesterday' => 'Yesterday', 'earlier' => 'Earlier') as $bucket_key => $bucket_label):
+                ?>
                     <div class="aips-timeline-group">
                         <h4><?php echo esc_html($bucket_label); ?></h4>
-                        <?php $has_bucket = false; foreach ($items as $item): $ts = strtotime($item->created_at); $days = floor(($now - $ts) / DAY_IN_SECONDS); $bucket = $days === 0 ? 'today' : ($days === 1 ? 'yesterday' : 'earlier'); if ($bucket !== $bucket_key) { continue; } $has_bucket = true; ?>
+                        <?php
+                        $has_bucket = false;
+                        foreach ($items as $item):
+                            $ts = (int) $item->created_at;
+                            $item_date = wp_date('Y-m-d', $ts, $utc_timezone);
+                            $bucket = ($item_date === $today) ? 'today' : (($item_date === $yesterday) ? 'yesterday' : 'earlier');
+                            if ($bucket !== $bucket_key) { continue; }
+                            $has_bucket = true;
+                            ?>
                             <details class="aips-timeline-card">
                                 <summary><strong><?php echo esc_html(!empty($item->event_label) ? $item->event_label : __('Generation Event', 'ai-post-scheduler')); ?></strong> — <?php echo esc_html($item->formatted_date); ?> <span class="aips-badge aips-badge-neutral"><?php echo esc_html($item->event_domain); ?></span></summary>
                                 <div style="padding:8px 0;">

--- a/ai-post-scheduler/templates/admin/history.php
+++ b/ai-post-scheduler/templates/admin/history.php
@@ -8,6 +8,11 @@ if (!defined('ABSPATH')) {
 $current_page  = isset($current_page) ? absint($current_page) : (isset($_GET['paged']) ? absint($_GET['paged']) : 1);
 $status_filter = isset($status_filter) ? $status_filter : (isset($_GET['status']) ? sanitize_text_field(wp_unslash($_GET['status'])) : '');
 $search_query  = isset($search_query) ? $search_query : (isset($_GET['s']) ? sanitize_text_field(wp_unslash($_GET['s'])) : '');
+$domain_filter = isset($domain_filter) ? $domain_filter : (isset($_GET['domain']) ? sanitize_key(wp_unslash($_GET['domain'])) : '');
+$actor_filter = isset($actor_filter) ? $actor_filter : (isset($_GET['actor']) ? sanitize_key(wp_unslash($_GET['actor'])) : '');
+$correlation_filter = isset($correlation_id) ? $correlation_id : (isset($_GET['correlation_id']) ? sanitize_text_field(wp_unslash($_GET['correlation_id'])) : '');
+$date_from = isset($date_from) ? $date_from : (isset($_GET['date_from']) ? sanitize_text_field(wp_unslash($_GET['date_from'])) : '');
+$date_to = isset($date_to) ? $date_to : (isset($_GET['date_to']) ? sanitize_text_field(wp_unslash($_GET['date_to'])) : '');
 
 $items       = array();
 $total_items = 0;
@@ -60,6 +65,21 @@ if (is_object($history)) {
             <!-- Filter Bar -->
             <div class="aips-filter-bar">
                 <div class="aips-filter-left">
+                    <select id="aips-filter-domain" class="aips-form-select">
+                        <option value=""><?php esc_html_e('All Domains', 'ai-post-scheduler'); ?></option>
+                        <option value="post_generation" <?php selected($domain_filter, 'post_generation'); ?>>Post Generation</option>
+                        <option value="author_topics" <?php selected($domain_filter, 'author_topics'); ?>>Author Topics</option>
+                        <option value="research" <?php selected($domain_filter, 'research'); ?>>Research</option>
+                        <option value="sources" <?php selected($domain_filter, 'sources'); ?>>Sources</option>
+                        <option value="embeddings" <?php selected($domain_filter, 'embeddings'); ?>>Embeddings</option>
+                        <option value="internal_links" <?php selected($domain_filter, 'internal_links'); ?>>Internal Links</option>
+                        <option value="batch_jobs" <?php selected($domain_filter, 'batch_jobs'); ?>>Batch Jobs</option>
+                    </select>
+                    <select id="aips-filter-actor" class="aips-form-select">
+                        <option value=""><?php esc_html_e('All Actors', 'ai-post-scheduler'); ?></option>
+                        <option value="system" <?php selected($actor_filter, 'system'); ?>>System</option>
+                        <option value="admin" <?php selected($actor_filter, 'admin'); ?>>Admin</option>
+                    </select>
                     <select id="aips-filter-status" class="aips-form-select">
                         <option value=""><?php esc_html_e('All Statuses', 'ai-post-scheduler'); ?></option>
                         <option value="completed" <?php selected($status_filter, 'completed'); ?>><?php esc_html_e('Completed', 'ai-post-scheduler'); ?></option>
@@ -73,6 +93,9 @@ if (is_object($history)) {
                 </div>
                 <div class="aips-filter-right">
                     <label class="screen-reader-text" for="aips-history-search-input"><?php esc_html_e('Search History:', 'ai-post-scheduler'); ?></label>
+                    <input type="date" id="aips-filter-date-from" class="aips-form-input" value="<?php echo esc_attr($date_from); ?>">
+                    <input type="date" id="aips-filter-date-to" class="aips-form-input" value="<?php echo esc_attr($date_to); ?>">
+                    <input type="text" id="aips-filter-correlation" class="aips-form-input" placeholder="Correlation ID" value="<?php echo esc_attr($correlation_filter); ?>">
                     <input type="search" id="aips-history-search-input" class="aips-form-input" placeholder="<?php esc_attr_e('Search history...', 'ai-post-scheduler'); ?>" value="<?php echo esc_attr($search_query); ?>">
                     <button type="button" id="aips-history-search-clear" class="aips-btn aips-btn-sm aips-btn-ghost" style="<?php echo $has_active_filter ? '' : 'display: none;'; ?>"><?php esc_html_e('Clear', 'ai-post-scheduler'); ?></button>
                 </div>
@@ -105,6 +128,25 @@ if (is_object($history)) {
                         <span class="aips-history-pagination-info"><?php printf(esc_html__('%d items', 'ai-post-scheduler'), $total_items); ?></span>
                     <?php endif; ?>
                 </div>
+            </div>
+
+            <div class="aips-panel-body">
+                <h3><?php esc_html_e('Timeline', 'ai-post-scheduler'); ?></h3>
+                <?php $now = current_time('timestamp'); foreach (array('today' => 'Today', 'yesterday' => 'Yesterday', 'earlier' => 'Earlier') as $bucket_key => $bucket_label): ?>
+                    <div class="aips-timeline-group">
+                        <h4><?php echo esc_html($bucket_label); ?></h4>
+                        <?php $has_bucket = false; foreach ($items as $item): $ts = strtotime($item->created_at); $days = floor(($now - $ts) / DAY_IN_SECONDS); $bucket = $days === 0 ? 'today' : ($days === 1 ? 'yesterday' : 'earlier'); if ($bucket !== $bucket_key) { continue; } $has_bucket = true; ?>
+                            <details class="aips-timeline-card">
+                                <summary><strong><?php echo esc_html(!empty($item->event_label) ? $item->event_label : __('Generation Event', 'ai-post-scheduler')); ?></strong> — <?php echo esc_html($item->formatted_date); ?> <span class="aips-badge aips-badge-neutral"><?php echo esc_html($item->event_domain); ?></span></summary>
+                                <div style="padding:8px 0;">
+                                    <p><strong>Status:</strong> <?php echo esc_html($item->status); ?> | <strong>Actor:</strong> <?php echo esc_html(isset($item->actor_type) ? $item->actor_type : 'system'); ?></p>
+                                    <?php if (!empty($item->correlation_id)): ?><p><strong>Correlation ID:</strong> <?php echo esc_html($item->correlation_id); ?></p><?php endif; ?>
+                                    <?php if (!empty($item->error_message)): ?><p style="color:#b32d2e;"><?php echo esc_html($item->error_message); ?></p><?php endif; ?>
+                                </div>
+                            </details>
+                        <?php endforeach; if (!$has_bucket): ?><p class="aips-meta-text">No events.</p><?php endif; ?>
+                    </div>
+                <?php endforeach; ?>
             </div>
 
             <!-- History Containers Table -->


### PR DESCRIPTION
### Motivation
- Provide a timeline-oriented History view that merges events from major domains to make troubleshooting and observability easier. 
- Allow operators to quickly narrow history by domain, status, date range, actor (system/admin), and correlation ID for faster root-cause analysis.

### Description
- Introduced computed metadata in `AIPS_History_Repository::get_history()` (`event_domain`, `event_label`, `actor_type`) and added query parameters `domain`, `actor`, `date_from`, `date_to`, and `correlation_id`, implemented via `CASE` expressions so no DB schema change is required. 
- Updated `AIPS_History` handlers (`render_page`, `ajax_reload_history`, `ajax_export_history`) to accept the new filter parameters and forward them to the repository. 
- Extended the admin History UI (`templates/admin/history.php`) with top-level filter controls for Domain, Actor, Date range, and Correlation ID and added a grouped timeline rendering section with `Today`, `Yesterday`, and `Earlier` cards that provide compact summaries and expandable details. 
- Updated client JS (`assets/js/admin-history.js`) to track the new filter state, include the filters in AJAX reload/export requests, and keep the URL query state synchronized.

### Testing
- Linted modified PHP files with `php -l includes/class-aips-history-repository.php` and the check passed with no syntax errors. 
- Linted modified PHP files with `php -l includes/class-aips-history.php` and the check passed with no syntax errors. 
- Linted modified template with `php -l templates/admin/history.php` and the check passed with no syntax errors. 
- Attempted to run `gh pr list` to satisfy the repository PR-check requirement but the `gh` CLI is not available in this environment, so please verify there are no conflicting open PRs before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03488201288321b51df9a492548916)