### PR TITLE
Add Task Type filtering and badges to History (UI, AJAX, repo, DB index)

### DIFF
--- a/ai-post-scheduler/assets/js/admin-history.js
+++ b/ai-post-scheduler/assets/js/admin-history.js
@@ -31,6 +31,9 @@
 		/** @type {string} Current status filter value */
 		statusFilter: '',
 
+		/** @type {string} Current task-type filter value */
+		taskTypeFilter: '',
+
 		/** @type {string} Raw search query as entered by the user */
 		searchQuery: '',
 
@@ -43,6 +46,7 @@
 		 */
 		init: function () {
 			this.statusFilter = $('#aips-filter-status').val() || '';
+			this.taskTypeFilter = $('#aips-filter-task-type').val() || '';
 			this.searchQuery  = $('#aips-history-search-input').val() || '';
 			this.syncSearchClearButton();
 			this.bindEvents();
@@ -877,6 +881,7 @@
 					action: 'aips_reload_history',
 					nonce: aipsAjax.nonce,
 					status: self.statusFilter,
+					task_type: self.taskTypeFilter,
 					search: self.searchQuery,
 					paged: paged
 				},
@@ -968,6 +973,7 @@
 				e.preventDefault();
 			}
 			this.statusFilter = $('#aips-filter-status').val() || '';
+			this.taskTypeFilter = $('#aips-filter-task-type').val() || '';
 
 			// Reflect change in the URL without reloading.
 			var url = new URL(window.location.href);
@@ -975,6 +981,11 @@
 				url.searchParams.set('status', this.statusFilter);
 			} else {
 				url.searchParams.delete('status');
+			}
+			if (this.taskTypeFilter) {
+				url.searchParams.set('task_type', this.taskTypeFilter);
+			} else {
+				url.searchParams.delete('task_type');
 			}
 			url.searchParams.delete('paged');
 			window.history.pushState({}, '', url.toString());
@@ -1073,6 +1084,7 @@
 			form.append($('<input type="hidden" name="action" value="aips_export_history">'));
 			form.append($('<input type="hidden" name="nonce">').val(aipsAjax.nonce));
 			form.append($('<input type="hidden" name="status">').val(this.statusFilter));
+			form.append($('<input type="hidden" name="task_type">').val(this.taskTypeFilter));
 			form.append($('<input type="hidden" name="search">').val(this.searchQuery));
 			$('body').append(form);
 			form.submit();

--- a/ai-post-scheduler/includes/class-aips-db-manager.php
+++ b/ai-post-scheduler/includes/class-aips-db-manager.php
@@ -124,7 +124,8 @@ class AIPS_DB_Manager {
             KEY created_at (created_at),
             KEY status_created (status, created_at),
             KEY template_created (template_id, created_at),
-            KEY correlation_id (correlation_id)
+            KEY correlation_id (correlation_id),
+            KEY creation_method (creation_method)
         ) $charset_collate;";
 
         $sql[] = "CREATE TABLE $table_history_log (

--- a/ai-post-scheduler/includes/class-aips-history-repository.php
+++ b/ai-post-scheduler/includes/class-aips-history-repository.php
@@ -199,6 +199,7 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
             'search' => '',
             'template_id' => 0,
             'author_id' => 0,
+            'task_type' => '',
             'correlation_id' => '',
             'orderby' => 'created_at',
             'order' => 'DESC',
@@ -243,6 +244,32 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
         if (!empty($args['author_id'])) {
             $where_clauses[] = "h.author_id = %d";
             $where_args[] = $args['author_id'];
+        }
+
+
+        if (!empty($args['task_type'])) {
+            $task_type = sanitize_key($args['task_type']);
+            $task_methods = array(
+                'post_generation' => array('manual', 'scheduled', 'post', 'template', 'generator'),
+                'research' => array('research'),
+                'sources_fetch' => array('source'),
+                'embeddings' => array('embedding'),
+                'internal_links' => array('internal_link'),
+                'author_topics' => array('author_topic'),
+                'bulk_batch' => array('bulk', 'batch'),
+                'taxonomy' => array('taxonomy'),
+            );
+
+            if ($task_type === 'other') {
+                $where_clauses[] = "(h.creation_method IS NULL OR h.creation_method = '')";
+            } elseif (isset($task_methods[$task_type])) {
+                $likes = array();
+                foreach ($task_methods[$task_type] as $fragment) {
+                    $likes[] = 'h.creation_method LIKE %s';
+                    $where_args[] = '%' . $this->wpdb->esc_like($fragment) . '%';
+                }
+                $where_clauses[] = '(' . implode(' OR ', $likes) . ')';
+            }
         }
 
         if (!empty($args['correlation_id'])) {

--- a/ai-post-scheduler/includes/class-aips-history.php
+++ b/ai-post-scheduler/includes/class-aips-history.php
@@ -98,6 +98,7 @@ class AIPS_History {
         }
 
         $status_filter = isset($_POST['status']) ? sanitize_text_field(wp_unslash($_POST['status'])) : '';
+        $task_type_filter = isset($_POST['task_type']) ? sanitize_key(wp_unslash($_POST['task_type'])) : '';
         $search_query = isset($_POST['search']) ? sanitize_text_field(wp_unslash($_POST['search'])) : '';
 
         // Get max records limit from configuration
@@ -109,6 +110,7 @@ class AIPS_History {
             'page' => 1,
             'per_page' => $max_records,
             'status' => $status_filter,
+            'task_type' => $task_type_filter,
             'search' => $search_query,
         ));
 
@@ -320,12 +322,14 @@ class AIPS_History {
         }
 
         $status_filter = isset($_POST['status']) ? sanitize_text_field(wp_unslash($_POST['status'])) : '';
+        $task_type_filter = isset($_POST['task_type']) ? sanitize_key(wp_unslash($_POST['task_type'])) : '';
         $search_query = isset($_POST['search']) ? sanitize_text_field(wp_unslash($_POST['search'])) : '';
         $paged = isset($_POST['paged']) ? max(1, absint($_POST['paged'])) : 1;
 
         $history = $this->get_history(array(
             'page'   => $paged,
             'status' => $status_filter,
+            'task_type' => $task_type_filter,
             'search' => $search_query,
             'fields' => 'list',
         ));
@@ -341,7 +345,7 @@ class AIPS_History {
         $items_html = ob_get_clean();
 
         ob_start();
-        $this->render_pagination_html($history, $status_filter, $search_query);
+        $this->render_pagination_html($history, $status_filter, $search_query, $task_type_filter);
         $pagination_html = ob_get_clean();
 
         AIPS_Ajax_Response::success(array(
@@ -453,7 +457,7 @@ class AIPS_History {
      * @param string $status_filter Status filter value.
      * @param string $search_query  Search query.
      */
-    public function render_pagination_html($history, $status_filter = '', $search_query = '') {
+    public function render_pagination_html($history, $status_filter = '', $search_query = '', $task_type_filter = '') {
         include AIPS_PLUGIN_DIR . 'templates/partials/history-pagination.php';
     }
     
@@ -492,11 +496,13 @@ class AIPS_History {
     public function render_page() {
         $current_page = isset($_GET['paged']) ? absint($_GET['paged']) : 1;
         $status_filter = isset($_GET['status']) ? sanitize_text_field(wp_unslash($_GET['status'])) : '';
+        $task_type_filter = isset($_GET['task_type']) ? sanitize_key(wp_unslash($_GET['task_type'])) : '';
         $search_query = isset($_GET['s']) ? sanitize_text_field(wp_unslash($_GET['s'])) : '';
 
         $history = $this->get_history(array(
             'page'   => $current_page,
             'status' => $status_filter,
+            'task_type' => $task_type_filter,
             'search' => $search_query,
             'fields' => 'list',
         ));
@@ -509,6 +515,37 @@ class AIPS_History {
         include AIPS_PLUGIN_DIR . 'templates/admin/history.php';
     }
 
+
+    public function get_task_type_options() {
+        return array(
+            '' => __('All Task Types', 'ai-post-scheduler'),
+            'post_generation' => __('Post Generation', 'ai-post-scheduler'),
+            'research' => __('Research', 'ai-post-scheduler'),
+            'sources_fetch' => __('Sources Fetch', 'ai-post-scheduler'),
+            'embeddings' => __('Embeddings', 'ai-post-scheduler'),
+            'internal_links' => __('Internal Links', 'ai-post-scheduler'),
+            'author_topics' => __('Author Topics', 'ai-post-scheduler'),
+            'bulk_batch' => __('Bulk Batch', 'ai-post-scheduler'),
+            'taxonomy' => __('Taxonomy', 'ai-post-scheduler'),
+            'other' => __('Other', 'ai-post-scheduler'),
+        );
+    }
+
+    private function map_task_type($item) {
+        $type = isset($item->type) ? strtolower((string) $item->type) : '';
+        $method = isset($item->creation_method) ? strtolower((string) $item->creation_method) : '';
+
+        if (strpos($type, 'research') !== false || strpos($method, 'research') !== false) { return 'research'; }
+        if (strpos($type, 'source') !== false || strpos($method, 'source') !== false) { return 'sources_fetch'; }
+        if (strpos($type, 'embedding') !== false || strpos($method, 'embedding') !== false) { return 'embeddings'; }
+        if (strpos($type, 'internal_link') !== false || strpos($method, 'internal_link') !== false) { return 'internal_links'; }
+        if (strpos($type, 'author_topic') !== false || strpos($method, 'author_topic') !== false) { return 'author_topics'; }
+        if (strpos($type, 'bulk') !== false || strpos($method, 'bulk') !== false || strpos($method, 'batch') !== false) { return 'bulk_batch'; }
+        if (strpos($type, 'taxonomy') !== false || strpos($method, 'taxonomy') !== false) { return 'taxonomy'; }
+        if (strpos($type, 'post') !== false || strpos($method, 'post') !== false || strpos($method, 'manual') !== false || strpos($method, 'schedule') !== false) { return 'post_generation'; }
+
+        return 'other';
+    }
     /**
      * Enrich a list of history items with display-ready fields.
      *
@@ -520,11 +557,14 @@ class AIPS_History {
      */
     private function prepare_items_for_display( array &$items ) {
         $date_format = get_option('date_format');
+        $task_type_options = $this->get_task_type_options();
         $time_format = get_option('time_format');
         $format      = $date_format . ' ' . $time_format;
 
         foreach ($items as $item) {
             $item->formatted_date = date_i18n($format, strtotime($item->created_at));
+            $item->task_type = $this->map_task_type($item);
+            $item->task_type_label = isset($task_type_options[$item->task_type]) ? $task_type_options[$item->task_type] : __('Other', 'ai-post-scheduler');
         }
     }
 }

--- a/ai-post-scheduler/templates/admin/history.php
+++ b/ai-post-scheduler/templates/admin/history.php
@@ -8,6 +8,8 @@ if (!defined('ABSPATH')) {
 $current_page  = isset($current_page) ? absint($current_page) : (isset($_GET['paged']) ? absint($_GET['paged']) : 1);
 $status_filter = isset($status_filter) ? $status_filter : (isset($_GET['status']) ? sanitize_text_field(wp_unslash($_GET['status'])) : '');
 $search_query  = isset($search_query) ? $search_query : (isset($_GET['s']) ? sanitize_text_field(wp_unslash($_GET['s'])) : '');
+$task_type_filter = isset($task_type_filter) ? $task_type_filter : (isset($_GET['task_type']) ? sanitize_key(wp_unslash($_GET['task_type'])) : '');
+$task_type_options = isset($history_handler) ? $history_handler->get_task_type_options() : array();
 
 $items       = array();
 $total_items = 0;
@@ -52,7 +54,7 @@ if (is_object($history)) {
         </div>
 
         <?php
-        $has_active_filter = !empty($status_filter) || !empty($search_query);
+        $has_active_filter = !empty($status_filter) || !empty($search_query) || !empty($task_type_filter);
         $show_panel        = $total_items > 0 || $has_active_filter;
         ?>
         <?php if ($show_panel): ?>
@@ -65,6 +67,11 @@ if (is_object($history)) {
                         <option value="completed" <?php selected($status_filter, 'completed'); ?>><?php esc_html_e('Completed', 'ai-post-scheduler'); ?></option>
                         <option value="failed" <?php selected($status_filter, 'failed'); ?>><?php esc_html_e('Failed', 'ai-post-scheduler'); ?></option>
                         <option value="processing" <?php selected($status_filter, 'processing'); ?>><?php esc_html_e('Processing', 'ai-post-scheduler'); ?></option>
+                    </select>
+                    <select id="aips-filter-task-type" class="aips-form-select">
+                        <?php foreach ($task_type_options as $task_key => $task_label): ?>
+                            <option value="<?php echo esc_attr($task_key); ?>" <?php selected($task_type_filter, $task_key); ?>><?php echo esc_html($task_label); ?></option>
+                        <?php endforeach; ?>
                     </select>
                     <button class="aips-btn aips-btn-sm aips-btn-secondary" id="aips-filter-btn">
                         <span class="dashicons dashicons-filter"></span>
@@ -100,7 +107,7 @@ if (is_object($history)) {
                         <?php esc_html_e('Clear All', 'ai-post-scheduler'); ?>
                     </button>
                     <?php if (isset($history_handler)): ?>
-                        <?php $history_handler->render_pagination_html($history, $status_filter, $search_query); ?>
+                        <?php $history_handler->render_pagination_html($history, $status_filter, $search_query, $task_type_filter); ?>
                     <?php elseif ($total_items > 0): ?>
                         <span class="aips-history-pagination-info"><?php printf(esc_html__('%d items', 'ai-post-scheduler'), $total_items); ?></span>
                     <?php endif; ?>

--- a/ai-post-scheduler/templates/partials/history-row.php
+++ b/ai-post-scheduler/templates/partials/history-row.php
@@ -41,6 +41,11 @@ if (!defined('ABSPATH')) {
           }
           ?>
         </span>
+        <?php if (!empty($item->task_type_label)): ?>
+        <span class="aips-badge aips-badge-info" style="font-size:10px;margin-left:4px;">
+            <?php echo esc_html($item->task_type_label); ?>
+        </span>
+        <?php endif; ?>
         <?php if (!empty($item->creation_method)): ?>
         <span class="aips-badge aips-badge-neutral aips-creation-method-badge" style="font-size:10px;margin-left:4px;">
             <?php echo esc_html(ucfirst(str_replace('_', ' ', $item->creation_method))); ?>


### PR DESCRIPTION
### Motivation
- Provide non-technical users an explicit, discoverable way to isolate kinds of runs (Post Generation, Research, Sources Fetch, Embeddings, Internal Links, Author Topics, Bulk Batch, etc.) without parsing logs.
- Make history filtering performant and consistent by canonicalizing task-type semantics derived from `creation_method` / logged type identifiers.

### Description
- Add normalized task-type support to the history stack by introducing `get_task_type_options()` and `map_task_type()` in `AIPS_History`, and enriching each history row with `task_type` and `task_type_label` during `prepare_items_for_display()`.
- Extend repository query API by accepting a `task_type` arg in `AIPS_History_Repository::get_history()` and applying efficient `creation_method`-based SQL predicates to filter matching task groups (with an `other` fallback).
- Wire the UI and UX: add a Task Type dropdown in `templates/admin/history.php`, render a task-type badge in `templates/partials/history-row.php`, and pass the selected `task_type` through pagination rendering.
- Update AJAX and client code to round-trip the filter: accept/send `task_type` in `aips_reload_history` and `aips_export_history` (server handlers in `includes/class-aips-history.php`) and include `task_type` in `assets/js/admin-history.js` reload/export requests and URL state.
- Add a DB index on `aips_history.creation_method` in `includes/class-aips-db-manager.php` to help query performance for the new predicate matching.

### Testing
- Ran PHP syntax checks (`php -l`) on modified files and templates: `includes/class-aips-history.php`, `includes/class-aips-history-repository.php`, `includes/class-aips-db-manager.php`, `templates/admin/history.php`, and `templates/partials/history-row.php`; all returned no syntax errors.
- Verified the new AJAX payload keys are present in the history reload and export flows by inspecting `assets/js/admin-history.js` and server-side handlers in `includes/class-aips-history.php` (static review).
- Attempted the required `gh pr list` check but the GitHub CLI is not available in this environment (`gh: command not found`), so an environment limitation prevented an open-PR de-duplication check prior to making changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03406b42188321913e98eede7107b3)