### PR TITLE
Atlas: Extract AIPS_History_Stats_Repository to separate analytical queries

### DIFF
--- a/.build/atlas-journal.md
+++ b/.build/atlas-journal.md
@@ -1438,3 +1438,12 @@ This refactoring resolves the "unexpected title prompts" issue by eliminating du
 **Decision:** Extracted post-execution cleanup, failure logging, success logging, and history container logic into a dedicated `AIPS_Schedule_Result_Handler` class.
 **Consequence:** `AIPS_Schedule_Processor` is now strictly focused on the execution logic. Reduced the class size significantly and decoupled the specific handling of success and error states.
 **Tests:** Created `test-schedule-result-handler.php` to verify result handling. Test execution skipped per user request.
+
+## 2024-05-29 - [Extract History Stats Repository]
+**Context:** The `AIPS_History_Repository` class was a "God Object" (1300+ lines) handling both core CRUD operations for history and complex analytical queries (`get_stats`, `get_daily_success_failure_trend`, etc.). This violated the Single Responsibility Principle and made the file difficult to navigate.
+**Decision:** Applied "Separation of Concerns". Extracted 10 analytical query methods into a new `AIPS_History_Stats_Repository` class. The `AIPS_History_Repository` constructor was updated to instantiate this stats repository, and the original methods were converted to proxies that delegate to the stats repository.
+**Consequence:**
+* `AIPS_History_Repository` is more focused on CRUD operations and core history management.
+* Analytical queries are isolated in `AIPS_History_Stats_Repository`, improving cohesion.
+* Maintains 100% backward compatibility because the public API of `AIPS_History_Repository` remains unchanged via the proxy methods (with updated DocBlocks indicating legacy status).
+**Tests:** The autoloader test suite was updated to cover `AIPS_History_Stats_Repository`. A new test class `Test_AIPS_History_Stats_Repository` was created to verify the extracted methods.

--- a/ai-post-scheduler/includes/class-aips-history-repository.php
+++ b/ai-post-scheduler/includes/class-aips-history-repository.php
@@ -44,8 +44,8 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
     private $table_name;
     private $table_name_log;
 	private $schedule_table;
-    
-    /**
+	private $stats_repository;
+/**
      * @var wpdb WordPress database abstraction object
      */
     private $wpdb;
@@ -59,6 +59,7 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
         $this->table_name = $wpdb->prefix . 'aips_history';
         $this->table_name_log = $wpdb->prefix . 'aips_history_log';
         $this->schedule_table = $wpdb->prefix . 'aips_schedule';
+        $this->stats_repository = new AIPS_History_Stats_Repository($this->wpdb, $this->table_name, $this->table_name_log);
     }
 
     /**
@@ -131,43 +132,44 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
         delete_transient('aips_schedule_completed_count_' . absint($schedule_id));
     }
 
+        /**
+     * Legacy proxy method for backward compatibility.
+     * Delegated to AIPS_History_Stats_Repository.
+     *
+     * @see AIPS_History_Stats_Repository::get_daily_success_failure_trend()
+     */
     public function get_daily_success_failure_trend($days = 14) {
-        $days = max(1, absint($days));
-
-        return $this->wpdb->get_results($this->wpdb->prepare(
-            "SELECT DATE(FROM_UNIXTIME(created_at)) AS metric_date, SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS success_count, SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failure_count FROM {$this->table_name} WHERE created_at >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY metric_date ORDER BY metric_date ASC",
-            $days
-        ), ARRAY_A);
+        return $this->stats_repository->get_daily_success_failure_trend($days);
     }
 
+        /**
+     * Legacy proxy method for backward compatibility.
+     * Delegated to AIPS_History_Stats_Repository.
+     *
+     * @see AIPS_History_Stats_Repository::get_average_duration_by_flow()
+     */
     public function get_average_duration_by_flow($days = 14) {
-        $days = max(1, absint($days));
-
-        return $this->wpdb->get_results($this->wpdb->prepare(
-            "SELECT COALESCE(NULLIF(creation_method, ''), 'unknown') AS flow_type, AVG(completed_at - created_at) AS avg_duration_seconds, COUNT(*) AS sample_count FROM {$this->table_name} WHERE completed_at IS NOT NULL AND created_at >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY flow_type ORDER BY avg_duration_seconds DESC",
-            $days
-        ), ARRAY_A);
+        return $this->stats_repository->get_average_duration_by_flow($days);
     }
 
+        /**
+     * Legacy proxy method for backward compatibility.
+     * Delegated to AIPS_History_Stats_Repository.
+     *
+     * @see AIPS_History_Stats_Repository::get_retry_counts_by_service()
+     */
     public function get_retry_counts_by_service($days = 14) {
-        $days = max(1, absint($days));
-
-        return $this->wpdb->get_results($this->wpdb->prepare(
-            "SELECT COALESCE(NULLIF(JSON_UNQUOTE(JSON_EXTRACT(details, '$.context')), ''), 'unknown') AS service_key, COUNT(*) AS retry_count FROM {$this->table_name_log} WHERE log_type = %s AND timestamp >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY service_key ORDER BY retry_count DESC",
-            'retry',
-            $days
-        ), ARRAY_A);
+        return $this->stats_repository->get_retry_counts_by_service($days);
     }
 
+        /**
+     * Legacy proxy method for backward compatibility.
+     * Delegated to AIPS_History_Stats_Repository.
+     *
+     * @see AIPS_History_Stats_Repository::get_top_failure_reasons()
+     */
     public function get_top_failure_reasons($days = 14, $limit = 8) {
-        $days = max(1, absint($days));
-        $limit = max(1, absint($limit));
-
-        return $this->wpdb->get_results($this->wpdb->prepare(
-            "SELECT COALESCE(NULLIF(TRIM(error_message), ''), 'Unknown failure') AS reason, COUNT(*) AS failure_count FROM {$this->table_name} WHERE status = 'failed' AND created_at >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY reason ORDER BY failure_count DESC LIMIT %d",
-            $days,
-            $limit
-        ), ARRAY_A);
+        return $this->stats_repository->get_top_failure_reasons($days, $limit);
     }
     
     /**
@@ -643,221 +645,64 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
      * }
      */
 
-    /**
-     * Get the estimated generation time based on recent successful generations.
+        /**
+     * Legacy proxy method for backward compatibility.
+     * Delegated to AIPS_History_Stats_Repository.
      *
-     * Retrieves the average of the most recent recorded generation times
-     * from post metadata to provide an estimate for bulk generation tasks.
-     *
-     * @param int $limit Number of recent samples to use for calculation (default: 20).
-     * @return array {
-     *     @type int $per_post_seconds Estimated seconds per post.
-     *     @type int $sample_size      Number of valid samples used for the estimate.
-     * }
+     * @see AIPS_History_Stats_Repository::get_estimated_generation_time()
      */
     public function get_estimated_generation_time($limit = 20) {
-        $default_seconds = 30;
-        $limit           = absint($limit);
-
-        // Retrieve the most recent recorded generation times.
-        $times = $this->wpdb->get_col(
-            $this->wpdb->prepare(
-                "SELECT meta_value FROM {$this->wpdb->postmeta}
-                 WHERE meta_key = %s
-                 ORDER BY meta_id DESC
-                 LIMIT %d",
-                '_aips_post_generation_total_time',
-                $limit
-            )
-        );
-
-        if (!empty($times)) {
-            $numeric_times = array_filter(array_map('floatval', $times), function($v) {
-                return $v > 0;
-            });
-
-            if (!empty($numeric_times)) {
-                $avg              = array_sum($numeric_times) / count($numeric_times);
-                $per_post_seconds = (int) ceil($avg);
-            } else {
-                $per_post_seconds = $default_seconds;
-            }
-
-            $sample_size = count($numeric_times);
-        } else {
-            $per_post_seconds = $default_seconds;
-            $sample_size      = 0;
-        }
-
-        return array(
-            'per_post_seconds' => $per_post_seconds,
-            'sample_size'      => $sample_size,
-        );
+        return $this->stats_repository->get_estimated_generation_time($limit);
     }
 
-    public function get_stats() {
-        $cached_stats = get_transient('aips_history_stats');
-
-        if ($cached_stats !== false) {
-            return $cached_stats;
-        }
-
-        $results = $this->wpdb->get_row("
-            SELECT
-                COUNT(*) as total,
-                SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as completed,
-                SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) as failed,
-                SUM(CASE WHEN status = 'processing' THEN 1 ELSE 0 END) as processing,
-                SUM(CASE WHEN status = 'partial' THEN 1 ELSE 0 END) as partial
-            FROM {$this->table_name}
-            WHERE COALESCE(creation_method, '') <> 'schedule_lifecycle'
-                AND NOT (creation_method IS NULL AND template_id IS NULL AND topic_id IS NULL AND post_id IS NULL AND author_id IS NULL)
-        ");
-
-        $stats = array(
-            'total' => isset($results->total) ? (int) $results->total : 0,
-            'completed' => isset($results->completed) ? (int) $results->completed : 0,
-            'failed' => isset($results->failed) ? (int) $results->failed : 0,
-            'processing' => isset($results->processing) ? (int) $results->processing : 0,
-            'partial' => isset($results->partial) ? (int) $results->partial : 0,
-        );
-        
-        $stats['success_rate'] = $stats['total'] > 0 
-            ? round(($stats['completed'] / $stats['total']) * 100, 1) 
-            : 0;
-
-        set_transient('aips_history_stats', $stats, HOUR_IN_SECONDS);
-        
-        return $stats;
-    }
-
-    /**
-     * Get per-day generation counts for the last N days.
+        /**
+     * Legacy proxy method for backward compatibility.
+     * Delegated to AIPS_History_Stats_Repository.
      *
-     * Returns an array keyed by ISO date string (Y-m-d) where each value is an
-     * associative array with 'completed', 'failed', and 'total' counts.
-     * Days with no records are omitted; callers should fill gaps as needed.
-     *
-     * Applies the same row-exclusion filters as get_stats() so that
-     * schedule-lifecycle rows and empty-shell records are not counted.
-     *
-     * @param int $days Number of calendar days to look back (inclusive today). Default 14.
-     * @return array<string, array{completed: int, failed: int, total: int}>
+     * @see AIPS_History_Stats_Repository::get_stats()
      */
-    public function get_daily_generation_counts( $days = 14 ) {
-        $days  = max( 1, absint( $days ) );
-        $start = wp_date( 'Y-m-d', current_time( 'timestamp', true ) - ( ( $days - 1 ) * DAY_IN_SECONDS ), wp_timezone() );
-
-        $results = $this->wpdb->get_results(
-            $this->wpdb->prepare(
-                "SELECT
-                    DATE(created_at) AS day,
-                    SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS completed,
-                    SUM(CASE WHEN status = 'failed'    THEN 1 ELSE 0 END) AS failed,
-                    COUNT(*) AS total
-                 FROM {$this->table_name}
-                 WHERE created_at >= %s
-                   AND COALESCE(creation_method, '') <> 'schedule_lifecycle'
-                   AND NOT (creation_method IS NULL AND template_id IS NULL AND topic_id IS NULL AND post_id IS NULL AND author_id IS NULL)
-                 GROUP BY DATE(created_at)
-                 ORDER BY day ASC",
-                $start
-            )
-        );
-
-        $data = array();
-        foreach ( $results as $row ) {
-            $data[ $row->day ] = array(
-                'completed' => (int) $row->completed,
-                'failed'    => (int) $row->failed,
-                'total'     => (int) $row->total,
-            );
-        }
-
-        return $data;
+    public function get_stats() {
+        return $this->stats_repository->get_stats();
     }
 
-    /**
-     * Get statistics for a specific template.
+        /**
+     * Legacy proxy method for backward compatibility.
+     * Delegated to AIPS_History_Stats_Repository.
      *
-     * @param int $template_id Template ID.
-     * @return int Number of completed posts for this template.
+     * @see AIPS_History_Stats_Repository::get_daily_generation_counts()
+     */
+    public function get_daily_generation_counts($days = 14) {
+        return $this->stats_repository->get_daily_generation_counts($days);
+    }
+
+        /**
+     * Legacy proxy method for backward compatibility.
+     * Delegated to AIPS_History_Stats_Repository.
+     *
+     * @see AIPS_History_Stats_Repository::get_template_stats()
      */
     public function get_template_stats($template_id) {
-        return (int) $this->wpdb->get_var($this->wpdb->prepare(
-            "SELECT COUNT(*) FROM {$this->table_name} WHERE template_id = %d AND status = 'completed'",
-            $template_id
-        ));
+        return $this->stats_repository->get_template_stats($template_id);
     }
 
-    /**
-     * Get statistics for all templates.
+        /**
+     * Legacy proxy method for backward compatibility.
+     * Delegated to AIPS_History_Stats_Repository.
      *
-     * @return array Associative array of template ID => count.
+     * @see AIPS_History_Stats_Repository::get_all_template_stats()
      */
     public function get_all_template_stats() {
-        $results = $this->wpdb->get_results("
-            SELECT template_id, COUNT(*) as count
-            FROM {$this->table_name}
-            WHERE status = 'completed'
-            GROUP BY template_id
-        ");
-
-        $stats = array();
-        foreach ($results as $row) {
-            $stats[$row->template_id] = (int) $row->count;
-        }
-
-        return $stats;
+        return $this->stats_repository->get_all_template_stats();
     }
 
-    /**
-     * Get generated-post counts for schedule history containers.
+        /**
+     * Legacy proxy method for backward compatibility.
+     * Delegated to AIPS_History_Stats_Repository.
      *
-     * Counts activity/error logs that represent a generated post event.
-     * The key is history_id (schedule_history_id on schedules table).
-     *
-     * @param array $history_ids History container IDs.
-     * @return array Associative array of history_id => generated count.
+     * @see AIPS_History_Stats_Repository::get_schedule_generated_post_counts()
      */
     public function get_schedule_generated_post_counts($history_ids) {
-        $history_ids = array_map('absint', (array) $history_ids);
-        $history_ids = array_filter($history_ids);
-
-        if (empty($history_ids)) {
-            return array();
-        }
-
-        $placeholders = implode(',', array_fill(0, count($history_ids), '%d'));
-
-        $sql = "
-            SELECT history_id, COUNT(*) AS count
-            FROM {$this->table_name_log}
-            WHERE history_id IN ({$placeholders})
-                AND history_type_id IN (%d, %d)
-                AND (
-                    details LIKE %s
-                    OR details LIKE %s
-                    OR details LIKE %s
-                )
-            GROUP BY history_id
-        ";
-
-        $args = $history_ids;
-        $args[] = AIPS_History_Type::ACTIVITY;
-        $args[] = AIPS_History_Type::ERROR;
-        $args[] = '%"event_type":"post_published"%';
-        $args[] = '%"event_type":"post_draft"%';
-        $args[] = '%"event_type":"manual_schedule_completed"%';
-
-        $results = $this->wpdb->get_results($this->wpdb->prepare($sql, $args));
-
-        $counts = array();
-        foreach ($results as $row) {
-            $counts[(int) $row->history_id] = (int) $row->count;
-        }
-
-        return $counts;
+        return $this->stats_repository->get_schedule_generated_post_counts($history_ids);
     }
 
     /**

--- a/ai-post-scheduler/includes/class-aips-history-stats-repository.php
+++ b/ai-post-scheduler/includes/class-aips-history-stats-repository.php
@@ -1,0 +1,303 @@
+<?php
+
+/**
+ * Repository for History analytical queries.
+ */
+class AIPS_History_Stats_Repository {
+    private $wpdb;
+    private $table_name;
+    private $table_name_log;
+
+    public function __construct($wpdb, $table_name, $table_name_log) {
+        $this->wpdb = $wpdb;
+        $this->table_name = $table_name;
+        $this->table_name_log = $table_name_log;
+    }
+
+    /**
+     * Get the daily success and failure trend.
+     *
+     * @param int $days Number of days to look back.
+     * @return array Results containing trend data.
+     */
+    public function get_daily_success_failure_trend($days = 14) {
+        $days = max(1, absint($days));
+
+        return $this->wpdb->get_results($this->wpdb->prepare(
+            "SELECT DATE(FROM_UNIXTIME(created_at)) AS metric_date, SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS success_count, SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failure_count FROM {$this->table_name} WHERE created_at >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY metric_date ORDER BY metric_date ASC",
+            $days
+        ), ARRAY_A);
+    }
+
+    /**
+     * Get the average duration by generation flow.
+     *
+     * @param int $days Number of days to look back.
+     * @return array Results containing average duration data.
+     */
+    public function get_average_duration_by_flow($days = 14) {
+        $days = max(1, absint($days));
+
+        return $this->wpdb->get_results($this->wpdb->prepare(
+            "SELECT COALESCE(NULLIF(creation_method, ''), 'unknown') AS flow_type, AVG(completed_at - created_at) AS avg_duration_seconds, COUNT(*) AS sample_count FROM {$this->table_name} WHERE completed_at IS NOT NULL AND created_at >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY flow_type ORDER BY avg_duration_seconds DESC",
+            $days
+        ), ARRAY_A);
+    }
+
+    /**
+     * Get the retry counts by service.
+     *
+     * @param int $days Number of days to look back.
+     * @return array Results containing retry counts.
+     */
+    public function get_retry_counts_by_service($days = 14) {
+        $days = max(1, absint($days));
+
+        return $this->wpdb->get_results($this->wpdb->prepare(
+            "SELECT COALESCE(NULLIF(JSON_UNQUOTE(JSON_EXTRACT(details, '$.context')), ''), 'unknown') AS service_key, COUNT(*) AS retry_count FROM {$this->table_name_log} WHERE log_type = %s AND timestamp >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY service_key ORDER BY retry_count DESC",
+            'retry',
+            $days
+        ), ARRAY_A);
+    }
+
+    /**
+     * Get the top failure reasons.
+     *
+     * @param int $days Number of days to look back.
+     * @param int $limit Maximum number of reasons to return.
+     * @return array Results containing top failure reasons.
+     */
+    public function get_top_failure_reasons($days = 14, $limit = 8) {
+        $days = max(1, absint($days));
+        $limit = max(1, absint($limit));
+
+        return $this->wpdb->get_results($this->wpdb->prepare(
+            "SELECT COALESCE(NULLIF(TRIM(error_message), ''), 'Unknown failure') AS reason, COUNT(*) AS failure_count FROM {$this->table_name} WHERE status = 'failed' AND created_at >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY reason ORDER BY failure_count DESC LIMIT %d",
+            $days,
+            $limit
+        ), ARRAY_A);
+    }
+
+    /**
+     * Get the estimated generation time based on recent successful generations.
+     *
+     * Retrieves the average of the most recent recorded generation times
+     * from post metadata to provide an estimate for bulk generation tasks.
+     *
+     * @param int $limit Number of recent samples to use for calculation (default: 20).
+     * @return array {
+     *     @type int $per_post_seconds Estimated seconds per post.
+     *     @type int $sample_size      Number of valid samples used for the estimate.
+     * }
+     */
+    public function get_estimated_generation_time($limit = 20) {
+        $default_seconds = 30;
+        $limit           = absint($limit);
+
+        // Retrieve the most recent recorded generation times.
+        $times = $this->wpdb->get_col(
+            $this->wpdb->prepare(
+                "SELECT meta_value FROM {$this->wpdb->postmeta}
+                 WHERE meta_key = %s
+                 ORDER BY meta_id DESC
+                 LIMIT %d",
+                '_aips_post_generation_total_time',
+                $limit
+            )
+        );
+
+        if (!empty($times)) {
+            $numeric_times = array_filter(array_map('floatval', $times), function($v) {
+                return $v > 0;
+            });
+
+            if (!empty($numeric_times)) {
+                $avg              = array_sum($numeric_times) / count($numeric_times);
+                $per_post_seconds = (int) ceil($avg);
+            } else {
+                $per_post_seconds = $default_seconds;
+            }
+
+            $sample_size = count($numeric_times);
+        } else {
+            $per_post_seconds = $default_seconds;
+            $sample_size      = 0;
+        }
+
+        return array(
+            'per_post_seconds' => $per_post_seconds,
+            'sample_size'      => $sample_size,
+        );
+    }
+
+    /**
+     * Get overall generation statistics.
+     *
+     * @return array Results containing total, completed, failed, processing, partial, and success rate.
+     */
+    public function get_stats() {
+        $cached_stats = get_transient('aips_history_stats');
+
+        if ($cached_stats !== false) {
+            return $cached_stats;
+        }
+
+        $results = $this->wpdb->get_row("
+            SELECT
+                COUNT(*) as total,
+                SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as completed,
+                SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) as failed,
+                SUM(CASE WHEN status = 'processing' THEN 1 ELSE 0 END) as processing,
+                SUM(CASE WHEN status = 'partial' THEN 1 ELSE 0 END) as partial
+            FROM {$this->table_name}
+            WHERE COALESCE(creation_method, '') <> 'schedule_lifecycle'
+                AND NOT (creation_method IS NULL AND template_id IS NULL AND topic_id IS NULL AND post_id IS NULL AND author_id IS NULL)
+        ");
+
+        $stats = array(
+            'total' => isset($results->total) ? (int) $results->total : 0,
+            'completed' => isset($results->completed) ? (int) $results->completed : 0,
+            'failed' => isset($results->failed) ? (int) $results->failed : 0,
+            'processing' => isset($results->processing) ? (int) $results->processing : 0,
+            'partial' => isset($results->partial) ? (int) $results->partial : 0,
+        );
+
+        $stats['success_rate'] = $stats['total'] > 0
+            ? round(($stats['completed'] / $stats['total']) * 100, 1)
+            : 0;
+
+        set_transient('aips_history_stats', $stats, HOUR_IN_SECONDS);
+
+        return $stats;
+    }
+
+    /**
+     * Get per-day generation counts for the last N days.
+     *
+     * Returns an array keyed by ISO date string (Y-m-d) where each value is an
+     * associative array with 'completed', 'failed', and 'total' counts.
+     * Days with no records are omitted; callers should fill gaps as needed.
+     *
+     * Applies the same row-exclusion filters as get_stats() so that
+     * schedule-lifecycle rows and empty-shell records are not counted.
+     *
+     * @param int $days Number of calendar days to look back (inclusive today). Default 14.
+     * @return array<string, array{completed: int, failed: int, total: int}>
+     */
+    public function get_daily_generation_counts( $days = 14 ) {
+        $days  = max( 1, absint( $days ) );
+        $start = wp_date( 'Y-m-d', current_time( 'timestamp', true ) - ( ( $days - 1 ) * DAY_IN_SECONDS ), wp_timezone() );
+
+        $results = $this->wpdb->get_results(
+            $this->wpdb->prepare(
+                "SELECT
+                    DATE(created_at) AS day,
+                    SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS completed,
+                    SUM(CASE WHEN status = 'failed'    THEN 1 ELSE 0 END) AS failed,
+                    COUNT(*) AS total
+                 FROM {$this->table_name}
+                 WHERE created_at >= %s
+                   AND COALESCE(creation_method, '') <> 'schedule_lifecycle'
+                   AND NOT (creation_method IS NULL AND template_id IS NULL AND topic_id IS NULL AND post_id IS NULL AND author_id IS NULL)
+                 GROUP BY DATE(created_at)
+                 ORDER BY day ASC",
+                $start
+            )
+        );
+
+        $data = array();
+        foreach ( $results as $row ) {
+            $data[ $row->day ] = array(
+                'completed' => (int) $row->completed,
+                'failed'    => (int) $row->failed,
+                'total'     => (int) $row->total,
+            );
+        }
+
+        return $data;
+    }
+
+    /**
+     * Get statistics for a specific template.
+     *
+     * @param int $template_id Template ID.
+     * @return int Number of completed posts for this template.
+     */
+    public function get_template_stats($template_id) {
+        return (int) $this->wpdb->get_var($this->wpdb->prepare(
+            "SELECT COUNT(*) FROM {$this->table_name} WHERE template_id = %d AND status = 'completed'",
+            $template_id
+        ));
+    }
+
+    /**
+     * Get statistics for all templates.
+     *
+     * @return array Associative array of template ID => count.
+     */
+    public function get_all_template_stats() {
+        $results = $this->wpdb->get_results("
+            SELECT template_id, COUNT(*) as count
+            FROM {$this->table_name}
+            WHERE status = 'completed'
+            GROUP BY template_id
+        ");
+
+        $stats = array();
+        foreach ($results as $row) {
+            $stats[$row->template_id] = (int) $row->count;
+        }
+
+        return $stats;
+    }
+
+    /**
+     * Get generated-post counts for schedule history containers.
+     *
+     * Counts activity/error logs that represent a generated post event.
+     * The key is history_id (schedule_history_id on schedules table).
+     *
+     * @param array $history_ids History container IDs.
+     * @return array Associative array of history_id => generated count.
+     */
+    public function get_schedule_generated_post_counts($history_ids) {
+        $history_ids = array_map('absint', (array) $history_ids);
+        $history_ids = array_filter($history_ids);
+
+        if (empty($history_ids)) {
+            return array();
+        }
+
+        $placeholders = implode(',', array_fill(0, count($history_ids), '%d'));
+
+        $sql = "
+            SELECT history_id, COUNT(*) AS count
+            FROM {$this->table_name_log}
+            WHERE history_id IN ({$placeholders})
+                AND history_type_id IN (%d, %d)
+                AND (
+                    details LIKE %s
+                    OR details LIKE %s
+                    OR details LIKE %s
+                )
+            GROUP BY history_id
+        ";
+
+        $args = $history_ids;
+        $args[] = AIPS_History_Type::ACTIVITY;
+        $args[] = AIPS_History_Type::ERROR;
+        $args[] = '%"event_type":"post_published"%';
+        $args[] = '%"event_type":"post_draft"%';
+        $args[] = '%"event_type":"manual_schedule_completed"%';
+
+        $results = $this->wpdb->get_results($this->wpdb->prepare($sql, $args));
+
+        $counts = array();
+        foreach ($results as $row) {
+            $counts[(int) $row->history_id] = (int) $row->count;
+        }
+
+        return $counts;
+    }
+
+}

--- a/ai-post-scheduler/tests/AIPS_Autoloader_Test.php
+++ b/ai-post-scheduler/tests/AIPS_Autoloader_Test.php
@@ -78,6 +78,7 @@ class AIPS_Autoloader_Test extends WP_UnitTestCase {
 	public function test_autoloader_converts_class_names_correctly() {
 		$test_cases = array(
 			'AIPS_History_Repository' => 'class-aips-history-repository.php',
+			'AIPS_History_Stats_Repository' => 'class-aips-history-stats-repository.php',
 			'AIPS_Template_Processor' => 'class-aips-template-processor.php',
 			'AIPS_AI_Service' => 'class-aips-ai-service.php',
 			'AIPS_Config' => 'class-aips-config.php',
@@ -171,6 +172,7 @@ class AIPS_Autoloader_Test extends WP_UnitTestCase {
 	public function test_autoloader_loads_repository_classes() {
 		$repositories = array(
 			'AIPS_History_Repository',
+			'AIPS_History_Stats_Repository',
 			'AIPS_Schedule_Repository',
 			'AIPS_Template_Repository',
 		);

--- a/ai-post-scheduler/tests/Test_AIPS_History_Stats_Repository.php
+++ b/ai-post-scheduler/tests/Test_AIPS_History_Stats_Repository.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Test case for AIPS_History_Stats_Repository
+ */
+
+class Test_AIPS_History_Stats_Repository extends WP_UnitTestCase {
+
+    private $stats_repo;
+    private $wpdb;
+
+    public function setUp(): void {
+        parent::setUp();
+        global $wpdb;
+        $this->wpdb = $wpdb;
+        $this->stats_repo = new AIPS_History_Stats_Repository($wpdb, $wpdb->prefix . 'aips_history', $wpdb->prefix . 'aips_history_log');
+    }
+
+    public function test_get_daily_success_failure_trend() {
+        $result = $this->stats_repo->get_daily_success_failure_trend(7);
+        $this->assertIsArray($result);
+    }
+
+    public function test_get_average_duration_by_flow() {
+        $result = $this->stats_repo->get_average_duration_by_flow(7);
+        $this->assertIsArray($result);
+    }
+
+    public function test_get_retry_counts_by_service() {
+        $result = $this->stats_repo->get_retry_counts_by_service(7);
+        $this->assertIsArray($result);
+    }
+
+    public function test_get_top_failure_reasons() {
+        $result = $this->stats_repo->get_top_failure_reasons(7, 5);
+        $this->assertIsArray($result);
+    }
+
+    public function test_get_estimated_generation_time() {
+        $result = $this->stats_repo->get_estimated_generation_time(10);
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('per_post_seconds', $result);
+        $this->assertArrayHasKey('sample_size', $result);
+    }
+
+    public function test_get_stats() {
+        $result = $this->stats_repo->get_stats();
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('total', $result);
+    }
+
+    public function test_get_daily_generation_counts() {
+        if (!function_exists('wp_date')) {
+            $this->markTestSkipped('wp_date is not available in limited test mode.');
+        }
+        $result = $this->stats_repo->get_daily_generation_counts(7);
+        $this->assertIsArray($result);
+    }
+
+    public function test_get_template_stats() {
+        $result = $this->stats_repo->get_template_stats(1);
+        $this->assertIsInt($result);
+    }
+
+    public function test_get_all_template_stats() {
+        $result = $this->stats_repo->get_all_template_stats();
+        $this->assertIsArray($result);
+    }
+
+    public function test_get_schedule_generated_post_counts() {
+        $result = $this->stats_repo->get_schedule_generated_post_counts([1, 2, 3]);
+        $this->assertIsArray($result);
+    }
+}


### PR DESCRIPTION
**Tangle:** The `AIPS_History_Repository` class was a "God Object" (1300+ lines) handling both core CRUD operations for history and complex analytical queries (`get_stats`, `get_daily_success_failure_trend`, etc.). This violated the Single Responsibility Principle and made the file difficult to navigate.

**Detangle:** Applied "Separation of Concerns". Extracted 10 analytical query methods into a new `AIPS_History_Stats_Repository` class. The `AIPS_History_Repository` constructor was updated to instantiate this stats repository, and the original methods were converted to proxies that delegate to the stats repository, retaining 100% backward compatibility.

**Journal:** Added an entry to `.build/atlas-journal.md` to record the architectural decision.

**Tests:** The autoloader test suite was updated to cover `AIPS_History_Stats_Repository`. A new test class `Test_AIPS_History_Stats_Repository` was created to verify the extracted methods.

---
*PR created automatically by Jules for task [12529943983251933450](https://jules.google.com/task/12529943983251933450) started by @rpnunez*