### PR TITLE
Atlas: Extract AIPS_History_Stats_Repository

### DIFF
--- a/.build/atlas-journal.md
+++ b/.build/atlas-journal.md
@@ -1438,3 +1438,12 @@ This refactoring resolves the "unexpected title prompts" issue by eliminating du
 **Decision:** Extracted post-execution cleanup, failure logging, success logging, and history container logic into a dedicated `AIPS_Schedule_Result_Handler` class.
 **Consequence:** `AIPS_Schedule_Processor` is now strictly focused on the execution logic. Reduced the class size significantly and decoupled the specific handling of success and error states.
 **Tests:** Created `test-schedule-result-handler.php` to verify result handling. Test execution skipped per user request.
+
+## 2024-05-30 - [Extract History Stats Repository]
+**Context:** `AIPS_History_Repository` had grown to over 1300 lines, violating the Single Responsibility Principle by mixing complex analytical and statistics queries with basic CRUD operations and logs management.
+**Decision:** Applied the Repository and Separation of Concerns patterns by extracting all analytical queries into a new `AIPS_History_Stats_Repository` class. The main `AIPS_History_Repository` now injects this new class and preserves legacy public methods as proxies.
+**Consequence:**
+* `AIPS_History_Stats_Repository` focuses solely on analytics.
+* `AIPS_History_Repository` focuses mainly on standard CRUD database operations.
+* Backward compatibility is 100% maintained via proxy methods in `AIPS_History_Repository`.
+**Tests:** Included `AIPS_History_Stats_Repository` in the `AIPS_Autoloader_Test` array and ran tests to ensure proper loading. Full test suite ran and verified no new regressions were introduced.

--- a/ai-post-scheduler/includes/class-aips-history-repository.php
+++ b/ai-post-scheduler/includes/class-aips-history-repository.php
@@ -44,6 +44,11 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
     private $table_name;
     private $table_name_log;
 	private $schedule_table;
+
+    /**
+     * @var AIPS_History_Stats_Repository Stats repository instance.
+     */
+    private $stats_repository;
     
     /**
      * @var wpdb WordPress database abstraction object
@@ -59,6 +64,13 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
         $this->table_name = $wpdb->prefix . 'aips_history';
         $this->table_name_log = $wpdb->prefix . 'aips_history_log';
         $this->schedule_table = $wpdb->prefix . 'aips_schedule';
+
+        $this->stats_repository = new AIPS_History_Stats_Repository(
+            $this->wpdb,
+            $this->table_name,
+            $this->table_name_log,
+            $this->schedule_table
+        );
     }
 
     /**
@@ -66,59 +78,11 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
      *
      * @param int|object $schedule Schedule ID or schedule object.
      * @return int
-     */
-    public function count_completed_for_schedule($schedule) {
-        if (is_numeric($schedule)) {
-            $schedule_id = absint($schedule);
-            if (!$schedule_id) {
-                return 0;
-            }
-
-            $schedule = $this->wpdb->get_row($this->wpdb->prepare(
-                "SELECT id, template_id FROM {$this->schedule_table} WHERE id = %d",
-                $schedule_id
-            ));
-        } else {
-            if (!is_object($schedule) || empty($schedule->id)) {
-                return 0;
-            }
-
-            $schedule_id = absint($schedule->id);
-
-            if (empty($schedule->template_id)) {
-                $schedule = $this->wpdb->get_row($this->wpdb->prepare(
-                    "SELECT id, template_id FROM {$this->schedule_table} WHERE id = %d",
-                    $schedule_id
-                ));
-            }
-        }
-
-        if (!$schedule || empty($schedule->template_id)) {
-            return 0;
-        }
-
-        $cache_key = 'aips_schedule_completed_count_' . $schedule_id;
-        $cached_count = get_transient($cache_key);
-
-        if ($cached_count !== false) {
-            return (int) $cached_count;
-        }
-
-        $count = (int) $this->wpdb->get_var($this->wpdb->prepare(
-            "SELECT COUNT(*) FROM {$this->table_name}
-            WHERE template_id = %d
-            AND status = %s
-            AND created_at >= (
-                SELECT created_at FROM {$this->schedule_table} WHERE id = %d
-            )",
-            (int) $schedule->template_id,
-            'completed',
-            $schedule_id
-        ));
-
-        set_transient($cache_key, $count, DAY_IN_SECONDS);
-
-        return $count;
+     *
+     * @deprecated Use AIPS_History_Stats_Repository instead. Preserved as a proxy for backward compatibility.
+ */
+        public function count_completed_for_schedule($schedule) {
+        return $this->stats_repository->count_completed_for_schedule($schedule);
     }
 
     /**
@@ -131,43 +95,20 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
         delete_transient('aips_schedule_completed_count_' . absint($schedule_id));
     }
 
-    public function get_daily_success_failure_trend($days = 14) {
-        $days = max(1, absint($days));
-
-        return $this->wpdb->get_results($this->wpdb->prepare(
-            "SELECT DATE(FROM_UNIXTIME(created_at)) AS metric_date, SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS success_count, SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failure_count FROM {$this->table_name} WHERE created_at >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY metric_date ORDER BY metric_date ASC",
-            $days
-        ), ARRAY_A);
+        public function get_daily_success_failure_trend($days = 14) {
+        return $this->stats_repository->get_daily_success_failure_trend($days);
     }
 
-    public function get_average_duration_by_flow($days = 14) {
-        $days = max(1, absint($days));
-
-        return $this->wpdb->get_results($this->wpdb->prepare(
-            "SELECT COALESCE(NULLIF(creation_method, ''), 'unknown') AS flow_type, AVG(completed_at - created_at) AS avg_duration_seconds, COUNT(*) AS sample_count FROM {$this->table_name} WHERE completed_at IS NOT NULL AND created_at >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY flow_type ORDER BY avg_duration_seconds DESC",
-            $days
-        ), ARRAY_A);
+        public function get_average_duration_by_flow($days = 14) {
+        return $this->stats_repository->get_average_duration_by_flow($days);
     }
 
-    public function get_retry_counts_by_service($days = 14) {
-        $days = max(1, absint($days));
-
-        return $this->wpdb->get_results($this->wpdb->prepare(
-            "SELECT COALESCE(NULLIF(JSON_UNQUOTE(JSON_EXTRACT(details, '$.context')), ''), 'unknown') AS service_key, COUNT(*) AS retry_count FROM {$this->table_name_log} WHERE log_type = %s AND timestamp >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY service_key ORDER BY retry_count DESC",
-            'retry',
-            $days
-        ), ARRAY_A);
+        public function get_retry_counts_by_service($days = 14) {
+        return $this->stats_repository->get_retry_counts_by_service($days);
     }
 
-    public function get_top_failure_reasons($days = 14, $limit = 8) {
-        $days = max(1, absint($days));
-        $limit = max(1, absint($limit));
-
-        return $this->wpdb->get_results($this->wpdb->prepare(
-            "SELECT COALESCE(NULLIF(TRIM(error_message), ''), 'Unknown failure') AS reason, COUNT(*) AS failure_count FROM {$this->table_name} WHERE status = 'failed' AND created_at >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY reason ORDER BY failure_count DESC LIMIT %d",
-            $days,
-            $limit
-        ), ARRAY_A);
+        public function get_top_failure_reasons($days = 14, $limit = 8) {
+        return $this->stats_repository->get_top_failure_reasons($days, $limit);
     }
     
     /**
@@ -654,81 +595,15 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
      *     @type int $per_post_seconds Estimated seconds per post.
      *     @type int $sample_size      Number of valid samples used for the estimate.
      * }
-     */
-    public function get_estimated_generation_time($limit = 20) {
-        $default_seconds = 30;
-        $limit           = absint($limit);
-
-        // Retrieve the most recent recorded generation times.
-        $times = $this->wpdb->get_col(
-            $this->wpdb->prepare(
-                "SELECT meta_value FROM {$this->wpdb->postmeta}
-                 WHERE meta_key = %s
-                 ORDER BY meta_id DESC
-                 LIMIT %d",
-                '_aips_post_generation_total_time',
-                $limit
-            )
-        );
-
-        if (!empty($times)) {
-            $numeric_times = array_filter(array_map('floatval', $times), function($v) {
-                return $v > 0;
-            });
-
-            if (!empty($numeric_times)) {
-                $avg              = array_sum($numeric_times) / count($numeric_times);
-                $per_post_seconds = (int) ceil($avg);
-            } else {
-                $per_post_seconds = $default_seconds;
-            }
-
-            $sample_size = count($numeric_times);
-        } else {
-            $per_post_seconds = $default_seconds;
-            $sample_size      = 0;
-        }
-
-        return array(
-            'per_post_seconds' => $per_post_seconds,
-            'sample_size'      => $sample_size,
-        );
+     *
+     * @deprecated Use AIPS_History_Stats_Repository instead. Preserved as a proxy for backward compatibility.
+ */
+        public function get_estimated_generation_time($limit = 20) {
+        return $this->stats_repository->get_estimated_generation_time($limit);
     }
 
-    public function get_stats() {
-        $cached_stats = get_transient('aips_history_stats');
-
-        if ($cached_stats !== false) {
-            return $cached_stats;
-        }
-
-        $results = $this->wpdb->get_row("
-            SELECT
-                COUNT(*) as total,
-                SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as completed,
-                SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) as failed,
-                SUM(CASE WHEN status = 'processing' THEN 1 ELSE 0 END) as processing,
-                SUM(CASE WHEN status = 'partial' THEN 1 ELSE 0 END) as partial
-            FROM {$this->table_name}
-            WHERE COALESCE(creation_method, '') <> 'schedule_lifecycle'
-                AND NOT (creation_method IS NULL AND template_id IS NULL AND topic_id IS NULL AND post_id IS NULL AND author_id IS NULL)
-        ");
-
-        $stats = array(
-            'total' => isset($results->total) ? (int) $results->total : 0,
-            'completed' => isset($results->completed) ? (int) $results->completed : 0,
-            'failed' => isset($results->failed) ? (int) $results->failed : 0,
-            'processing' => isset($results->processing) ? (int) $results->processing : 0,
-            'partial' => isset($results->partial) ? (int) $results->partial : 0,
-        );
-        
-        $stats['success_rate'] = $stats['total'] > 0 
-            ? round(($stats['completed'] / $stats['total']) * 100, 1) 
-            : 0;
-
-        set_transient('aips_history_stats', $stats, HOUR_IN_SECONDS);
-        
-        return $stats;
+        public function get_stats() {
+        return $this->stats_repository->get_stats();
     }
 
     /**
@@ -743,38 +618,11 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
      *
      * @param int $days Number of calendar days to look back (inclusive today). Default 14.
      * @return array<string, array{completed: int, failed: int, total: int}>
-     */
-    public function get_daily_generation_counts( $days = 14 ) {
-        $days  = max( 1, absint( $days ) );
-        $start = wp_date( 'Y-m-d', current_time( 'timestamp', true ) - ( ( $days - 1 ) * DAY_IN_SECONDS ), wp_timezone() );
-
-        $results = $this->wpdb->get_results(
-            $this->wpdb->prepare(
-                "SELECT
-                    DATE(created_at) AS day,
-                    SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS completed,
-                    SUM(CASE WHEN status = 'failed'    THEN 1 ELSE 0 END) AS failed,
-                    COUNT(*) AS total
-                 FROM {$this->table_name}
-                 WHERE created_at >= %s
-                   AND COALESCE(creation_method, '') <> 'schedule_lifecycle'
-                   AND NOT (creation_method IS NULL AND template_id IS NULL AND topic_id IS NULL AND post_id IS NULL AND author_id IS NULL)
-                 GROUP BY DATE(created_at)
-                 ORDER BY day ASC",
-                $start
-            )
-        );
-
-        $data = array();
-        foreach ( $results as $row ) {
-            $data[ $row->day ] = array(
-                'completed' => (int) $row->completed,
-                'failed'    => (int) $row->failed,
-                'total'     => (int) $row->total,
-            );
-        }
-
-        return $data;
+     *
+     * @deprecated Use AIPS_History_Stats_Repository instead. Preserved as a proxy for backward compatibility.
+ */
+        public function get_daily_generation_counts($days = 14) {
+        return $this->stats_repository->get_daily_generation_counts($days);
     }
 
     /**
@@ -782,33 +630,22 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
      *
      * @param int $template_id Template ID.
      * @return int Number of completed posts for this template.
-     */
-    public function get_template_stats($template_id) {
-        return (int) $this->wpdb->get_var($this->wpdb->prepare(
-            "SELECT COUNT(*) FROM {$this->table_name} WHERE template_id = %d AND status = 'completed'",
-            $template_id
-        ));
+     *
+     * @deprecated Use AIPS_History_Stats_Repository instead. Preserved as a proxy for backward compatibility.
+ */
+        public function get_template_stats($template_id) {
+        return $this->stats_repository->get_template_stats($template_id);
     }
 
     /**
      * Get statistics for all templates.
      *
      * @return array Associative array of template ID => count.
-     */
-    public function get_all_template_stats() {
-        $results = $this->wpdb->get_results("
-            SELECT template_id, COUNT(*) as count
-            FROM {$this->table_name}
-            WHERE status = 'completed'
-            GROUP BY template_id
-        ");
-
-        $stats = array();
-        foreach ($results as $row) {
-            $stats[$row->template_id] = (int) $row->count;
-        }
-
-        return $stats;
+     *
+     * @deprecated Use AIPS_History_Stats_Repository instead. Preserved as a proxy for backward compatibility.
+ */
+        public function get_all_template_stats() {
+        return $this->stats_repository->get_all_template_stats();
     }
 
     /**
@@ -819,45 +656,11 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
      *
      * @param array $history_ids History container IDs.
      * @return array Associative array of history_id => generated count.
-     */
-    public function get_schedule_generated_post_counts($history_ids) {
-        $history_ids = array_map('absint', (array) $history_ids);
-        $history_ids = array_filter($history_ids);
-
-        if (empty($history_ids)) {
-            return array();
-        }
-
-        $placeholders = implode(',', array_fill(0, count($history_ids), '%d'));
-
-        $sql = "
-            SELECT history_id, COUNT(*) AS count
-            FROM {$this->table_name_log}
-            WHERE history_id IN ({$placeholders})
-                AND history_type_id IN (%d, %d)
-                AND (
-                    details LIKE %s
-                    OR details LIKE %s
-                    OR details LIKE %s
-                )
-            GROUP BY history_id
-        ";
-
-        $args = $history_ids;
-        $args[] = AIPS_History_Type::ACTIVITY;
-        $args[] = AIPS_History_Type::ERROR;
-        $args[] = '%"event_type":"post_published"%';
-        $args[] = '%"event_type":"post_draft"%';
-        $args[] = '%"event_type":"manual_schedule_completed"%';
-
-        $results = $this->wpdb->get_results($this->wpdb->prepare($sql, $args));
-
-        $counts = array();
-        foreach ($results as $row) {
-            $counts[(int) $row->history_id] = (int) $row->count;
-        }
-
-        return $counts;
+     *
+     * @deprecated Use AIPS_History_Stats_Repository instead. Preserved as a proxy for backward compatibility.
+ */
+        public function get_schedule_generated_post_counts($history_ids) {
+        return $this->stats_repository->get_schedule_generated_post_counts($history_ids);
     }
 
     /**
@@ -867,42 +670,11 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
      * @param array $event_types Event types to include.
      * @param int   $limit Max rows to return.
      * @return array Raw log rows from aips_history_log.
-     */
-    public function get_author_schedule_logs_by_event_types($author_id, $event_types = array(), $limit = 100) {
-        $author_id = absint($author_id);
-        $limit = absint($limit);
-        $event_types = array_filter(array_map('sanitize_key', (array) $event_types));
-
-        if (!$author_id || $limit < 1 || empty($event_types)) {
-            return array();
-        }
-
-        $where_events = array();
-        $args = array(
-            $author_id,
-            AIPS_History_Type::ACTIVITY,
-            AIPS_History_Type::ERROR,
-        );
-
-        foreach ($event_types as $event_type) {
-            $where_events[] = 'hl.details LIKE %s';
-            $args[] = '%"event_type":"' . $this->wpdb->esc_like($event_type) . '"%';
-        }
-
-        $args[] = $limit;
-
-        $sql = "
-            SELECT hl.*
-            FROM {$this->table_name_log} hl
-            INNER JOIN {$this->table_name} h ON hl.history_id = h.id
-            WHERE h.author_id = %d
-                AND hl.history_type_id IN (%d, %d)
-                AND (" . implode(' OR ', $where_events) . ")
-            ORDER BY hl.timestamp DESC
-            LIMIT %d
-        ";
-
-        return $this->wpdb->get_results($this->wpdb->prepare($sql, $args));
+     *
+     * @deprecated Use AIPS_History_Stats_Repository instead. Preserved as a proxy for backward compatibility.
+ */
+        public function get_author_schedule_logs_by_event_types($author_id, $event_types = array(), $limit = 100) {
+        return $this->stats_repository->get_author_schedule_logs_by_event_types($author_id, $event_types, $limit);
     }
     
     /**

--- a/ai-post-scheduler/includes/class-aips-history-stats-repository.php
+++ b/ai-post-scheduler/includes/class-aips-history-stats-repository.php
@@ -1,0 +1,450 @@
+<?php
+/**
+ * History Stats Repository
+ *
+ * Database abstraction layer for complex history analytics and statistics operations.
+ * Extracts these concerns from the main History Repository to enforce Separation of Concerns.
+ *
+ * @package AI_Post_Scheduler
+ * @since 1.5.0
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Class AIPS_History_Stats_Repository
+ *
+ * Repository pattern implementation for history analytics and statistics.
+ */
+class AIPS_History_Stats_Repository {
+
+    /**
+     * @var wpdb WordPress database abstraction object
+     */
+    private $wpdb;
+
+    /**
+     * @var string The history table name (with prefix)
+     */
+    private $table_name;
+
+    /**
+     * @var string The history log table name (with prefix)
+     */
+    private $table_name_log;
+
+    /**
+     * @var string The schedule table name (with prefix)
+     */
+    private $schedule_table;
+
+    /**
+     * Constructor.
+     *
+     * @param wpdb   $wpdb           WordPress database abstraction object.
+     * @param string $table_name     History table name.
+     * @param string $table_name_log History log table name.
+     * @param string $schedule_table Schedule table name.
+     */
+    public function __construct($wpdb, $table_name, $table_name_log, $schedule_table) {
+        $this->wpdb = $wpdb;
+        $this->table_name = $table_name;
+        $this->table_name_log = $table_name_log;
+        $this->schedule_table = $schedule_table;
+    }
+
+
+    /**
+     * Count completed generations for a schedule.
+     *
+     * @param int|object $schedule Schedule ID or schedule object.
+     * @return int
+     */
+    public function count_completed_for_schedule($schedule) {
+        if (is_numeric($schedule)) {
+            $schedule_id = absint($schedule);
+            if (!$schedule_id) {
+                return 0;
+            }
+
+            $schedule = $this->wpdb->get_row($this->wpdb->prepare(
+                "SELECT id, template_id FROM {$this->schedule_table} WHERE id = %d",
+                $schedule_id
+            ));
+        } else {
+            if (!is_object($schedule) || empty($schedule->id)) {
+                return 0;
+            }
+
+            $schedule_id = absint($schedule->id);
+
+            if (empty($schedule->template_id)) {
+                $schedule = $this->wpdb->get_row($this->wpdb->prepare(
+                    "SELECT id, template_id FROM {$this->schedule_table} WHERE id = %d",
+                    $schedule_id
+                ));
+            }
+        }
+
+        if (!$schedule || empty($schedule->template_id)) {
+            return 0;
+        }
+
+        $cache_key = 'aips_schedule_completed_count_' . $schedule_id;
+        $cached_count = get_transient($cache_key);
+
+        if ($cached_count !== false) {
+            return (int) $cached_count;
+        }
+
+        $count = (int) $this->wpdb->get_var($this->wpdb->prepare(
+            "SELECT COUNT(*) FROM {$this->table_name}
+            WHERE template_id = %d
+            AND status = %s
+            AND created_at >= (
+                SELECT created_at FROM {$this->schedule_table} WHERE id = %d
+            )",
+            (int) $schedule->template_id,
+            'completed',
+            $schedule_id
+        ));
+
+        set_transient($cache_key, $count, DAY_IN_SECONDS);
+
+        return $count;
+    }
+
+    /**
+     * Get daily success and failure trend.
+     *
+     * @param int $days Number of days.
+     * @return array
+     */
+    public function get_daily_success_failure_trend($days = 14) {
+        $days = max(1, absint($days));
+
+        return $this->wpdb->get_results($this->wpdb->prepare(
+            "SELECT DATE(FROM_UNIXTIME(created_at)) AS metric_date, SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS success_count, SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failure_count FROM {$this->table_name} WHERE created_at >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY metric_date ORDER BY metric_date ASC",
+            $days
+        ), ARRAY_A);
+    }
+
+    /**
+     * Get average duration by flow.
+     *
+     * @param int $days Number of days.
+     * @return array
+     */
+    public function get_average_duration_by_flow($days = 14) {
+        $days = max(1, absint($days));
+
+        return $this->wpdb->get_results($this->wpdb->prepare(
+            "SELECT COALESCE(NULLIF(creation_method, ''), 'unknown') AS flow_type, AVG(completed_at - created_at) AS avg_duration_seconds, COUNT(*) AS sample_count FROM {$this->table_name} WHERE completed_at IS NOT NULL AND created_at >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY flow_type ORDER BY avg_duration_seconds DESC",
+            $days
+        ), ARRAY_A);
+    }
+
+    /**
+     * Get retry counts by service.
+     *
+     * @param int $days Number of days.
+     * @return array
+     */
+    public function get_retry_counts_by_service($days = 14) {
+        $days = max(1, absint($days));
+
+        return $this->wpdb->get_results($this->wpdb->prepare(
+            "SELECT COALESCE(NULLIF(JSON_UNQUOTE(JSON_EXTRACT(details, '$.context')), ''), 'unknown') AS service_key, COUNT(*) AS retry_count FROM {$this->table_name_log} WHERE log_type = %s AND timestamp >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY service_key ORDER BY retry_count DESC",
+            'retry',
+            $days
+        ), ARRAY_A);
+    }
+
+    /**
+     * Get top failure reasons.
+     *
+     * @param int $days Number of days.
+     * @param int $limit Limit.
+     * @return array
+     */
+    public function get_top_failure_reasons($days = 14, $limit = 8) {
+        $days = max(1, absint($days));
+        $limit = max(1, absint($limit));
+
+        return $this->wpdb->get_results($this->wpdb->prepare(
+            "SELECT COALESCE(NULLIF(TRIM(error_message), ''), 'Unknown failure') AS reason, COUNT(*) AS failure_count FROM {$this->table_name} WHERE status = 'failed' AND created_at >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY reason ORDER BY failure_count DESC LIMIT %d",
+            $days,
+            $limit
+        ), ARRAY_A);
+    }
+
+    /**
+     * Get the estimated generation time based on recent successful generations.
+     *
+     * Retrieves the average of the most recent recorded generation times
+     * from post metadata to provide an estimate for bulk generation tasks.
+     *
+     * @param int $limit Number of recent samples to use for calculation (default: 20).
+     * @return array {
+     *     @type int $per_post_seconds Estimated seconds per post.
+     *     @type int $sample_size      Number of valid samples used for the estimate.
+     * }
+     */
+    public function get_estimated_generation_time($limit = 20) {
+        $default_seconds = 30;
+        $limit           = absint($limit);
+
+        // Retrieve the most recent recorded generation times.
+        $times = $this->wpdb->get_col(
+            $this->wpdb->prepare(
+                "SELECT meta_value FROM {$this->wpdb->postmeta}
+                 WHERE meta_key = %s
+                 ORDER BY meta_id DESC
+                 LIMIT %d",
+                '_aips_post_generation_total_time',
+                $limit
+            )
+        );
+
+        if (!empty($times)) {
+            $numeric_times = array_filter(array_map('floatval', $times), function($v) {
+                return $v > 0;
+            });
+
+            if (!empty($numeric_times)) {
+                $avg              = array_sum($numeric_times) / count($numeric_times);
+                $per_post_seconds = (int) ceil($avg);
+            } else {
+                $per_post_seconds = $default_seconds;
+            }
+
+            $sample_size = count($numeric_times);
+        } else {
+            $per_post_seconds = $default_seconds;
+            $sample_size      = 0;
+        }
+
+        return array(
+            'per_post_seconds' => $per_post_seconds,
+            'sample_size'      => $sample_size,
+        );
+    }
+
+    /**
+     * Get overall stats.
+     *
+     * @return array
+     */
+    public function get_stats() {
+        $cached_stats = get_transient('aips_history_stats');
+
+        if ($cached_stats !== false) {
+            return $cached_stats;
+        }
+
+        $results = $this->wpdb->get_row("
+            SELECT
+                COUNT(*) as total,
+                SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as completed,
+                SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) as failed,
+                SUM(CASE WHEN status = 'processing' THEN 1 ELSE 0 END) as processing,
+                SUM(CASE WHEN status = 'partial' THEN 1 ELSE 0 END) as partial
+            FROM {$this->table_name}
+            WHERE COALESCE(creation_method, '') <> 'schedule_lifecycle'
+                AND NOT (creation_method IS NULL AND template_id IS NULL AND topic_id IS NULL AND post_id IS NULL AND author_id IS NULL)
+        ");
+
+        $stats = array(
+            'total' => isset($results->total) ? (int) $results->total : 0,
+            'completed' => isset($results->completed) ? (int) $results->completed : 0,
+            'failed' => isset($results->failed) ? (int) $results->failed : 0,
+            'processing' => isset($results->processing) ? (int) $results->processing : 0,
+            'partial' => isset($results->partial) ? (int) $results->partial : 0,
+        );
+
+        $stats['success_rate'] = $stats['total'] > 0
+            ? round(($stats['completed'] / $stats['total']) * 100, 1)
+            : 0;
+
+        set_transient('aips_history_stats', $stats, HOUR_IN_SECONDS);
+
+        return $stats;
+    }
+
+    /**
+     * Get per-day generation counts for the last N days.
+     *
+     * Returns an array keyed by ISO date string (Y-m-d) where each value is an
+     * associative array with 'completed', 'failed', and 'total' counts.
+     * Days with no records are omitted; callers should fill gaps as needed.
+     *
+     * Applies the same row-exclusion filters as get_stats() so that
+     * schedule-lifecycle rows and empty-shell records are not counted.
+     *
+     * @param int $days Number of calendar days to look back (inclusive today). Default 14.
+     * @return array<string, array{completed: int, failed: int, total: int}>
+     */
+    public function get_daily_generation_counts( $days = 14 ) {
+        $days  = max( 1, absint( $days ) );
+        $start = wp_date( 'Y-m-d', current_time( 'timestamp', true ) - ( ( $days - 1 ) * DAY_IN_SECONDS ), wp_timezone() );
+
+        $results = $this->wpdb->get_results(
+            $this->wpdb->prepare(
+                "SELECT
+                    DATE(created_at) AS day,
+                    SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS completed,
+                    SUM(CASE WHEN status = 'failed'    THEN 1 ELSE 0 END) AS failed,
+                    COUNT(*) AS total
+                 FROM {$this->table_name}
+                 WHERE created_at >= %s
+                   AND COALESCE(creation_method, '') <> 'schedule_lifecycle'
+                   AND NOT (creation_method IS NULL AND template_id IS NULL AND topic_id IS NULL AND post_id IS NULL AND author_id IS NULL)
+                 GROUP BY DATE(created_at)
+                 ORDER BY day ASC",
+                $start
+            )
+        );
+
+        $data = array();
+        foreach ( $results as $row ) {
+            $data[ $row->day ] = array(
+                'completed' => (int) $row->completed,
+                'failed'    => (int) $row->failed,
+                'total'     => (int) $row->total,
+            );
+        }
+
+        return $data;
+    }
+
+    /**
+     * Get statistics for a specific template.
+     *
+     * @param int $template_id Template ID.
+     * @return int Number of completed posts for this template.
+     */
+    public function get_template_stats($template_id) {
+        return (int) $this->wpdb->get_var($this->wpdb->prepare(
+            "SELECT COUNT(*) FROM {$this->table_name} WHERE template_id = %d AND status = 'completed'",
+            $template_id
+        ));
+    }
+
+    /**
+     * Get statistics for all templates.
+     *
+     * @return array Associative array of template ID => count.
+     */
+    public function get_all_template_stats() {
+        $results = $this->wpdb->get_results("
+            SELECT template_id, COUNT(*) as count
+            FROM {$this->table_name}
+            WHERE status = 'completed'
+            GROUP BY template_id
+        ");
+
+        $stats = array();
+        foreach ($results as $row) {
+            $stats[$row->template_id] = (int) $row->count;
+        }
+
+        return $stats;
+    }
+
+    /**
+     * Get generated-post counts for schedule history containers.
+     *
+     * Counts activity/error logs that represent a generated post event.
+     * The key is history_id (schedule_history_id on schedules table).
+     *
+     * @param array $history_ids History container IDs.
+     * @return array Associative array of history_id => generated count.
+     */
+    public function get_schedule_generated_post_counts($history_ids) {
+        $history_ids = array_map('absint', (array) $history_ids);
+        $history_ids = array_filter($history_ids);
+
+        if (empty($history_ids)) {
+            return array();
+        }
+
+        $placeholders = implode(',', array_fill(0, count($history_ids), '%d'));
+
+        $sql = "
+            SELECT history_id, COUNT(*) AS count
+            FROM {$this->table_name_log}
+            WHERE history_id IN ({$placeholders})
+                AND history_type_id IN (%d, %d)
+                AND (
+                    details LIKE %s
+                    OR details LIKE %s
+                    OR details LIKE %s
+                )
+            GROUP BY history_id
+        ";
+
+        $args = $history_ids;
+        $args[] = AIPS_History_Type::ACTIVITY;
+        $args[] = AIPS_History_Type::ERROR;
+        $args[] = '%"event_type":"post_published"%';
+        $args[] = '%"event_type":"post_draft"%';
+        $args[] = '%"event_type":"manual_schedule_completed"%';
+
+        $results = $this->wpdb->get_results($this->wpdb->prepare($sql, $args));
+
+        $counts = array();
+        foreach ($results as $row) {
+            $counts[(int) $row->history_id] = (int) $row->count;
+        }
+
+        return $counts;
+    }
+
+    /**
+     * Get author schedule logs filtered by event types.
+     *
+     * @param int   $author_id Author ID.
+     * @param array $event_types Event types to include.
+     * @param int   $limit Max rows to return.
+     * @return array Raw log rows from aips_history_log.
+     */
+    public function get_author_schedule_logs_by_event_types($author_id, $event_types = array(), $limit = 100) {
+        $author_id = absint($author_id);
+        $limit = absint($limit);
+        $event_types = array_filter(array_map('sanitize_key', (array) $event_types));
+
+        if (!$author_id || $limit < 1 || empty($event_types)) {
+            return array();
+        }
+
+        $where_events = array();
+        $args = array(
+            $author_id,
+            AIPS_History_Type::ACTIVITY,
+            AIPS_History_Type::ERROR,
+        );
+
+        foreach ($event_types as $event_type) {
+            $where_events[] = 'hl.details LIKE %s';
+            $args[] = '%"event_type":"' . $this->wpdb->esc_like($event_type) . '"%';
+        }
+
+        $args[] = $limit;
+
+        $sql = "
+            SELECT hl.*
+            FROM {$this->table_name_log} hl
+            INNER JOIN {$this->table_name} h ON hl.history_id = h.id
+            WHERE h.author_id = %d
+                AND hl.history_type_id IN (%d, %d)
+                AND (" . implode(' OR ', $where_events) . ")
+            ORDER BY hl.timestamp DESC
+            LIMIT %d
+        ";
+
+        return $this->wpdb->get_results($this->wpdb->prepare($sql, $args));
+    }
+
+}

--- a/ai-post-scheduler/tests/AIPS_Autoloader_Test.php
+++ b/ai-post-scheduler/tests/AIPS_Autoloader_Test.php
@@ -78,6 +78,7 @@ class AIPS_Autoloader_Test extends WP_UnitTestCase {
 	public function test_autoloader_converts_class_names_correctly() {
 		$test_cases = array(
 			'AIPS_History_Repository' => 'class-aips-history-repository.php',
+			'AIPS_History_Stats_Repository' => 'class-aips-history-stats-repository.php',
 			'AIPS_Template_Processor' => 'class-aips-template-processor.php',
 			'AIPS_AI_Service' => 'class-aips-ai-service.php',
 			'AIPS_Config' => 'class-aips-config.php',
@@ -171,6 +172,7 @@ class AIPS_Autoloader_Test extends WP_UnitTestCase {
 	public function test_autoloader_loads_repository_classes() {
 		$repositories = array(
 			'AIPS_History_Repository',
+			'AIPS_History_Stats_Repository',
 			'AIPS_Schedule_Repository',
 			'AIPS_Template_Repository',
 		);


### PR DESCRIPTION
**Tangle:**
`AIPS_History_Repository` had grown into a God Object (~1300 lines), mixing fundamental CRUD and logging logic with complex analytical and statistics SQL queries.

**Detangle:**
Extracted analytical and statistics methods into a new `AIPS_History_Stats_Repository` class to enforce Separation of Concerns. `AIPS_History_Repository` now injects the new repository and delegates to it via proxy methods to guarantee 100% backward compatibility. 

**Journal:**
Appended architectural decision to `.build/atlas-journal.md`.

---
*PR created automatically by Jules for task [9327569828700634669](https://jules.google.com/task/9327569828700634669) started by @rpnunez*