### PR TITLE
Add centralized cache policy, invalidation bus, and admin cache rebuild tool

### DIFF
--- a/ai-post-scheduler/assets/css/admin.css
+++ b/ai-post-scheduler/assets/css/admin.css
@@ -3726,6 +3726,10 @@ margin-right: 5px;
 font-size: 13px;
 }
 
+.aips-cache-rebuild-controls {
+	margin-top: 12px;
+}
+
 /* Dashboard stats bar: stack vertically on mobile — see consolidated @media below */
 
 /* Dashboard stats bar */

--- a/ai-post-scheduler/assets/js/admin-system-status.js
+++ b/ai-post-scheduler/assets/js/admin-system-status.js
@@ -49,6 +49,7 @@
 			$(document).on('click', '.aips-toggle-log-details', this.toggleLogDetails.bind(this));
 			$(document).on('click', '.aips-reset-circuit-breaker', this.resetCircuitBreaker.bind(this));
 			$(document).on('click', '.aips-status-op', this.runStatusOperation.bind(this));
+			$(document).on('click', '.aips-rebuild-cache-btn', this.rebuildCaches.bind(this));
 		},
 
 		/**
@@ -148,6 +149,27 @@
 
 			$btn.prop('disabled', true);
 			$.post(ajaxurl, { action: action, nonce: nonce }, function(response) {
+				if (response && response.success) {
+					$result.text((response.data && response.data.message) ? response.data.message : 'Done.').show();
+				} else {
+					$result.text((response && response.data && response.data.message) ? response.data.message : (l10n.requestFailed || 'Request failed.')).show();
+				}
+				$btn.prop('disabled', false);
+			}).fail(function() {
+				$result.text(l10n.requestFailed || 'Request failed.').show();
+				$btn.prop('disabled', false);
+			});
+		},
+
+
+		rebuildCaches: function(e) {
+			e.preventDefault();
+			var l10n = window.aipsSystemStatusL10n || {};
+			var $btn = $(e.currentTarget);
+			var subsystem = $('#aips-cache-subsystem').val() || 'all';
+			var $result = $('.aips-status-op-result');
+			$btn.prop('disabled', true);
+			$.post(ajaxurl, { action: 'aips_rebuild_caches', nonce: l10n.nonceRebuildCaches || '', subsystem: subsystem }, function(response) {
 				if (response && response.success) {
 					$result.text((response.data && response.data.message) ? response.data.message : 'Done.').show();
 				} else {

--- a/ai-post-scheduler/includes/class-aips-admin-assets.php
+++ b/ai-post-scheduler/includes/class-aips-admin-assets.php
@@ -1275,6 +1275,7 @@ class AIPS_Admin_Assets {
                 'nonceRetrySlices'                      => wp_create_nonce('aips_status_retry_failed_slices'),
                 'nonceClearPartialGenerations'          => wp_create_nonce('aips_status_clear_partial_generations'),
                 'nonceCleanupStaleJobsCache'            => wp_create_nonce('aips_status_cleanup_stale_jobs_cache'),
+                'nonceRebuildCaches'                  => wp_create_nonce('aips_rebuild_caches'),
                 'hideDetails'                           => __('Hide Details', 'ai-post-scheduler'),
                 'showDetails'                           => __('Show Details', 'ai-post-scheduler'),
                 'resetSuccess'                          => __('Circuit reset. Reload the page to confirm.', 'ai-post-scheduler'),

--- a/ai-post-scheduler/includes/class-aips-admin-bar.php
+++ b/ai-post-scheduler/includes/class-aips-admin-bar.php
@@ -98,10 +98,10 @@ class AIPS_Admin_Bar {
 		}
 
 		$cache        = AIPS_Cache_Factory::instance();
-		$cache_key    = 'aips_unread_count_' . get_current_user_id();
+		$cache_key    = AIPS_Cache_Policy::key( AIPS_Cache_Policy::SUBSYSTEM_ADMIN_BAR, 'unread_count', array('user_id' => get_current_user_id()) );
 		$unread_count = $cache->remember(
 			$cache_key,
-			MINUTE_IN_SECONDS,
+			AIPS_Cache_Policy::default_ttl( AIPS_Cache_Policy::SUBSYSTEM_ADMIN_BAR ),
 			function() {
 				return $this->get_repository()->count_unread();
 			},
@@ -256,10 +256,10 @@ class AIPS_Admin_Bar {
 			AIPS_Ajax_Response::error(__('Notification could not be updated or was already read.', 'ai-post-scheduler'));
 		}
 
-		$cache_key    = 'aips_unread_count_' . get_current_user_id();
+		$cache_key    = AIPS_Cache_Policy::key( AIPS_Cache_Policy::SUBSYSTEM_ADMIN_BAR, 'unread_count', array('user_id' => get_current_user_id()) );
 		$unread_count = $this->get_repository()->count_unread();
 
-		AIPS_Cache_Factory::instance()->set($cache_key, $unread_count, MINUTE_IN_SECONDS, 'aips_admin_bar');
+		AIPS_Cache_Factory::instance()->set($cache_key, $unread_count, AIPS_Cache_Policy::default_ttl( AIPS_Cache_Policy::SUBSYSTEM_ADMIN_BAR ), 'aips_admin_bar');
 
 		AIPS_Ajax_Response::success(array(
 			'unread_count' => $unread_count,
@@ -280,10 +280,10 @@ class AIPS_Admin_Bar {
 
 		$result       = $this->get_repository()->mark_all_as_read();
 
-		$cache_key    = 'aips_unread_count_' . get_current_user_id();
+		$cache_key    = AIPS_Cache_Policy::key( AIPS_Cache_Policy::SUBSYSTEM_ADMIN_BAR, 'unread_count', array('user_id' => get_current_user_id()) );
 		$unread_count = $this->get_repository()->count_unread();
 
-		AIPS_Cache_Factory::instance()->set($cache_key, $unread_count, MINUTE_IN_SECONDS, 'aips_admin_bar');
+		AIPS_Cache_Factory::instance()->set($cache_key, $unread_count, AIPS_Cache_Policy::default_ttl( AIPS_Cache_Policy::SUBSYSTEM_ADMIN_BAR ), 'aips_admin_bar');
 
 		// If the repository reported a failure and there are still unread notifications, return an error.
 		if (false === $result && $unread_count > 0) {

--- a/ai-post-scheduler/includes/class-aips-article-structure-repository.php
+++ b/ai-post-scheduler/includes/class-aips-article-structure-repository.php
@@ -60,7 +60,7 @@ class AIPS_Article_Structure_Repository {
 		global $wpdb;
 		$this->wpdb = $wpdb;
 		$this->table_name = $wpdb->prefix . 'aips_article_structures';
-		$this->cache = AIPS_Cache_Factory::named( 'aips_article_structure_repository' );
+		$this->cache = AIPS_Cache_Factory::named( AIPS_Cache_Policy::cache_name( AIPS_Cache_Policy::SUBSYSTEM_ARTICLE_STRUCTURE_REPOSITORY ) );
 	}
 	
 	/**
@@ -74,7 +74,7 @@ class AIPS_Article_Structure_Repository {
 	 * @return array Array of structure objects.
 	 */
 	public function get_all($active_only = false) {
-		$key = 'all:' . ( $active_only ? '1' : '0' );
+		$key = AIPS_Cache_Policy::key( AIPS_Cache_Policy::SUBSYSTEM_ARTICLE_STRUCTURE_REPOSITORY, 'all', array('active_only' => $active_only) );
 		if ( $this->cache->has( $key ) ) {
 			return $this->cache->get( $key );
 		}
@@ -94,7 +94,7 @@ class AIPS_Article_Structure_Repository {
 	 * @return object|null Structure object or null if not found.
 	 */
 	public function get_by_id($id) {
-		$key = 'id:' . (int) $id;
+		$key = AIPS_Cache_Policy::key( AIPS_Cache_Policy::SUBSYSTEM_ARTICLE_STRUCTURE_REPOSITORY, 'id', array('id' => $id) );
 		if ( $this->cache->has( $key ) ) {
 			return $this->cache->get( $key );
 		}
@@ -167,7 +167,7 @@ class AIPS_Article_Structure_Repository {
 		$result = $this->wpdb->insert($this->table_name, $insert_data, $format);
 		
 		if ( $result ) {
-			$this->cache->flush();
+			AIPS_Cache_Invalidation_Bus::invalidate( AIPS_Cache_Policy::SUBSYSTEM_ARTICLE_STRUCTURE_REPOSITORY, 'update' );
 		}
 
 		return $result ? $this->wpdb->insert_id : false;
@@ -220,7 +220,7 @@ class AIPS_Article_Structure_Repository {
 		) !== false;
 
 		if ( $result ) {
-			$this->cache->flush();
+			AIPS_Cache_Invalidation_Bus::invalidate( AIPS_Cache_Policy::SUBSYSTEM_ARTICLE_STRUCTURE_REPOSITORY, 'update' );
 		}
 
 		return $result;
@@ -235,7 +235,7 @@ class AIPS_Article_Structure_Repository {
 	public function delete($id) {
 		$result = $this->wpdb->delete($this->table_name, array('id' => $id), array('%d')) !== false;
 		if ( $result ) {
-			$this->cache->flush();
+			AIPS_Cache_Invalidation_Bus::invalidate( AIPS_Cache_Policy::SUBSYSTEM_ARTICLE_STRUCTURE_REPOSITORY, 'update' );
 		}
 		return $result;
 	}

--- a/ai-post-scheduler/includes/class-aips-cache-invalidation-bus.php
+++ b/ai-post-scheduler/includes/class-aips-cache-invalidation-bus.php
@@ -1,0 +1,36 @@
+<?php
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+class AIPS_Cache_Invalidation_Bus {
+
+	public static function invalidate($subsystem, $operation, $context = array()) {
+		$targets = AIPS_Cache_Policy::invalidation_targets($subsystem, $operation);
+		foreach ($targets as $cache_name) {
+			$cache = AIPS_Cache_Factory::named($cache_name);
+			$cache->flush();
+		}
+
+		do_action('aips_cache_invalidated', $subsystem, $operation, $context, $targets);
+		return $targets;
+	}
+
+	public static function rebuild($subsystem = 'all') {
+		$subsystems = array(
+			AIPS_Cache_Policy::SUBSYSTEM_ADMIN_BAR,
+			AIPS_Cache_Policy::SUBSYSTEM_SCHEDULE_REPOSITORY,
+			AIPS_Cache_Policy::SUBSYSTEM_ARTICLE_STRUCTURE_REPOSITORY,
+			AIPS_Cache_Policy::SUBSYSTEM_PROMPT_SECTION_REPOSITORY,
+			AIPS_Cache_Policy::SUBSYSTEM_POST_SLICES_REPOSITORY,
+		);
+		if ('all' !== $subsystem) {
+			$subsystems = array($subsystem);
+		}
+		$affected = array();
+		foreach ($subsystems as $item) {
+			$affected = array_merge($affected, self::invalidate($item, 'update'));
+		}
+		return array_values(array_unique($affected));
+	}
+}

--- a/ai-post-scheduler/includes/class-aips-cache-invalidation-bus.php
+++ b/ai-post-scheduler/includes/class-aips-cache-invalidation-bus.php
@@ -17,16 +17,15 @@ class AIPS_Cache_Invalidation_Bus {
 	}
 
 	public static function rebuild($subsystem = 'all') {
-		$subsystems = array(
-			AIPS_Cache_Policy::SUBSYSTEM_ADMIN_BAR,
-			AIPS_Cache_Policy::SUBSYSTEM_SCHEDULE_REPOSITORY,
-			AIPS_Cache_Policy::SUBSYSTEM_ARTICLE_STRUCTURE_REPOSITORY,
-			AIPS_Cache_Policy::SUBSYSTEM_PROMPT_SECTION_REPOSITORY,
-			AIPS_Cache_Policy::SUBSYSTEM_POST_SLICES_REPOSITORY,
-		);
+		if ('all' !== $subsystem && !AIPS_Cache_Policy::is_valid_subsystem($subsystem)) {
+			$subsystem = 'all';
+		}
+
+		$subsystems = array_keys(AIPS_Cache_Policy::get_subsystems());
 		if ('all' !== $subsystem) {
 			$subsystems = array($subsystem);
 		}
+
 		$affected = array();
 		foreach ($subsystems as $item) {
 			$affected = array_merge($affected, self::invalidate($item, 'update'));

--- a/ai-post-scheduler/includes/class-aips-cache-policy.php
+++ b/ai-post-scheduler/includes/class-aips-cache-policy.php
@@ -11,23 +11,45 @@ class AIPS_Cache_Policy {
 	const SUBSYSTEM_PROMPT_SECTION_REPOSITORY = 'prompt_section_repository';
 	const SUBSYSTEM_POST_SLICES_REPOSITORY = 'post_slices_repository';
 
-	public static function cache_name($subsystem) {
-		$map = array(
-			self::SUBSYSTEM_SCHEDULE_REPOSITORY => 'aips_schedule_repository',
-			self::SUBSYSTEM_ARTICLE_STRUCTURE_REPOSITORY => 'aips_article_structure_repository',
-			self::SUBSYSTEM_PROMPT_SECTION_REPOSITORY => 'aips_prompt_section_repository',
-			self::SUBSYSTEM_POST_SLICES_REPOSITORY => 'aips_post_slices_repository',
+	public static function get_subsystems() {
+		return array(
+			self::SUBSYSTEM_ADMIN_BAR => array(
+				'label' => __('Admin Bar', 'ai-post-scheduler'),
+				'cache_name' => 'aips_admin_bar',
+				'default_ttl' => MINUTE_IN_SECONDS,
+			),
+			self::SUBSYSTEM_SCHEDULE_REPOSITORY => array(
+				'label' => __('Schedule Repository', 'ai-post-scheduler'),
+				'cache_name' => 'aips_schedule_repository',
+			),
+			self::SUBSYSTEM_ARTICLE_STRUCTURE_REPOSITORY => array(
+				'label' => __('Article Structure Repository', 'ai-post-scheduler'),
+				'cache_name' => 'aips_article_structure_repository',
+			),
+			self::SUBSYSTEM_PROMPT_SECTION_REPOSITORY => array(
+				'label' => __('Prompt Section Repository', 'ai-post-scheduler'),
+				'cache_name' => 'aips_prompt_section_repository',
+			),
+			self::SUBSYSTEM_POST_SLICES_REPOSITORY => array(
+				'label' => __('Post Slices Repository', 'ai-post-scheduler'),
+				'cache_name' => 'aips_post_slices_repository',
+			),
 		);
+	}
 
-		return isset($map[$subsystem]) ? $map[$subsystem] : '';
+	public static function is_valid_subsystem($subsystem) {
+		$subsystems = self::get_subsystems();
+		return isset($subsystems[$subsystem]);
+	}
+
+	public static function cache_name($subsystem) {
+		$subsystems = self::get_subsystems();
+		return (isset($subsystems[$subsystem]['cache_name']) && $subsystems[$subsystem]['cache_name']) ? (string) $subsystems[$subsystem]['cache_name'] : '';
 	}
 
 	public static function default_ttl($subsystem) {
-		$ttls = array(
-			self::SUBSYSTEM_ADMIN_BAR => MINUTE_IN_SECONDS,
-		);
-
-		return isset($ttls[$subsystem]) ? (int) $ttls[$subsystem] : (int) HOUR_IN_SECONDS;
+		$subsystems = self::get_subsystems();
+		return (isset($subsystems[$subsystem]['default_ttl']) && $subsystems[$subsystem]['default_ttl']) ? (int) $subsystems[$subsystem]['default_ttl'] : (int) HOUR_IN_SECONDS;
 	}
 
 	public static function key($subsystem, $operation, $context = array()) {
@@ -68,22 +90,20 @@ class AIPS_Cache_Policy {
 				break;
 		}
 
-		return $operation . ':' . md5(wp_json_encode($context));
+		$encoded = wp_json_encode($context);
+		if (false === $encoded) {
+			$encoded = maybe_serialize($context);
+		}
+
+		return $operation . ':' . md5((string) $encoded);
 	}
 
 	public static function invalidation_targets($subsystem, $operation) {
-		$targets = array(
-			self::SUBSYSTEM_ADMIN_BAR => array('aips_admin_bar'),
-			self::SUBSYSTEM_SCHEDULE_REPOSITORY => array(self::cache_name(self::SUBSYSTEM_SCHEDULE_REPOSITORY)),
-			self::SUBSYSTEM_ARTICLE_STRUCTURE_REPOSITORY => array(self::cache_name(self::SUBSYSTEM_ARTICLE_STRUCTURE_REPOSITORY)),
-			self::SUBSYSTEM_PROMPT_SECTION_REPOSITORY => array(self::cache_name(self::SUBSYSTEM_PROMPT_SECTION_REPOSITORY)),
-			self::SUBSYSTEM_POST_SLICES_REPOSITORY => array(self::cache_name(self::SUBSYSTEM_POST_SLICES_REPOSITORY)),
-		);
-
-		if (in_array($operation, array('create', 'update', 'delete', 'bulk_update', 'set_active'), true) && isset($targets[$subsystem])) {
-			return $targets[$subsystem];
+		if (!in_array($operation, array('create', 'update', 'delete', 'bulk_update', 'set_active'), true)) {
+			return array();
 		}
 
-		return array();
+		$cache_name = self::cache_name($subsystem);
+		return $cache_name ? array($cache_name) : array();
 	}
 }

--- a/ai-post-scheduler/includes/class-aips-cache-policy.php
+++ b/ai-post-scheduler/includes/class-aips-cache-policy.php
@@ -1,0 +1,89 @@
+<?php
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+class AIPS_Cache_Policy {
+
+	const SUBSYSTEM_ADMIN_BAR = 'admin_bar';
+	const SUBSYSTEM_SCHEDULE_REPOSITORY = 'schedule_repository';
+	const SUBSYSTEM_ARTICLE_STRUCTURE_REPOSITORY = 'article_structure_repository';
+	const SUBSYSTEM_PROMPT_SECTION_REPOSITORY = 'prompt_section_repository';
+	const SUBSYSTEM_POST_SLICES_REPOSITORY = 'post_slices_repository';
+
+	public static function cache_name($subsystem) {
+		$map = array(
+			self::SUBSYSTEM_SCHEDULE_REPOSITORY => 'aips_schedule_repository',
+			self::SUBSYSTEM_ARTICLE_STRUCTURE_REPOSITORY => 'aips_article_structure_repository',
+			self::SUBSYSTEM_PROMPT_SECTION_REPOSITORY => 'aips_prompt_section_repository',
+			self::SUBSYSTEM_POST_SLICES_REPOSITORY => 'aips_post_slices_repository',
+		);
+
+		return isset($map[$subsystem]) ? $map[$subsystem] : '';
+	}
+
+	public static function default_ttl($subsystem) {
+		$ttls = array(
+			self::SUBSYSTEM_ADMIN_BAR => MINUTE_IN_SECONDS,
+		);
+
+		return isset($ttls[$subsystem]) ? (int) $ttls[$subsystem] : (int) HOUR_IN_SECONDS;
+	}
+
+	public static function key($subsystem, $operation, $context = array()) {
+		switch ($subsystem) {
+			case self::SUBSYSTEM_ADMIN_BAR:
+				$user_id = isset($context['user_id']) ? (int) $context['user_id'] : 0;
+				return 'aips_unread_count_' . $user_id;
+			case self::SUBSYSTEM_SCHEDULE_REPOSITORY:
+				if ('all' === $operation) {
+					return 'all:' . (!empty($context['active_only']) ? '1' : '0');
+				}
+				if ('id' === $operation) {
+					return 'id:' . (int) $context['id'];
+				}
+				if ('due' === $operation) {
+					return 'due:' . (int) $context['current_time'] . ':' . (int) $context['limit'];
+				}
+				break;
+			case self::SUBSYSTEM_ARTICLE_STRUCTURE_REPOSITORY:
+			case self::SUBSYSTEM_POST_SLICES_REPOSITORY:
+				if ('all' === $operation) {
+					return 'all:' . (!empty($context['active_only']) ? '1' : '0');
+				}
+				if ('id' === $operation) {
+					return 'id:' . (int) $context['id'];
+				}
+				break;
+			case self::SUBSYSTEM_PROMPT_SECTION_REPOSITORY:
+				if ('all' === $operation) {
+					return 'all:' . (!empty($context['active_only']) ? '1' : '0');
+				}
+				if ('id' === $operation) {
+					return 'id:' . (int) $context['id'];
+				}
+				if ('key' === $operation) {
+					return 'key:' . (string) $context['section_key'];
+				}
+				break;
+		}
+
+		return $operation . ':' . md5(wp_json_encode($context));
+	}
+
+	public static function invalidation_targets($subsystem, $operation) {
+		$targets = array(
+			self::SUBSYSTEM_ADMIN_BAR => array('aips_admin_bar'),
+			self::SUBSYSTEM_SCHEDULE_REPOSITORY => array(self::cache_name(self::SUBSYSTEM_SCHEDULE_REPOSITORY)),
+			self::SUBSYSTEM_ARTICLE_STRUCTURE_REPOSITORY => array(self::cache_name(self::SUBSYSTEM_ARTICLE_STRUCTURE_REPOSITORY)),
+			self::SUBSYSTEM_PROMPT_SECTION_REPOSITORY => array(self::cache_name(self::SUBSYSTEM_PROMPT_SECTION_REPOSITORY)),
+			self::SUBSYSTEM_POST_SLICES_REPOSITORY => array(self::cache_name(self::SUBSYSTEM_POST_SLICES_REPOSITORY)),
+		);
+
+		if (in_array($operation, array('create', 'update', 'delete', 'bulk_update', 'set_active'), true) && isset($targets[$subsystem])) {
+			return $targets[$subsystem];
+		}
+
+		return array();
+	}
+}

--- a/ai-post-scheduler/includes/class-aips-post-slices-repository.php
+++ b/ai-post-scheduler/includes/class-aips-post-slices-repository.php
@@ -55,7 +55,7 @@ class AIPS_Post_Slices_Repository {
 		global $wpdb;
 		$this->wpdb = $wpdb;
 		$this->table_name = $wpdb->prefix . 'aips_post_slices';
-		$this->cache = AIPS_Cache_Factory::named('aips_post_slices_repository');
+		$this->cache = AIPS_Cache_Factory::named( AIPS_Cache_Policy::cache_name( AIPS_Cache_Policy::SUBSYSTEM_POST_SLICES_REPOSITORY ) );
 	}
 
 	/**
@@ -65,7 +65,7 @@ class AIPS_Post_Slices_Repository {
 	 * @return array
 	 */
 	public function get_all($active_only = false) {
-		$key = 'all:' . ($active_only ? '1' : '0');
+		$key = AIPS_Cache_Policy::key( AIPS_Cache_Policy::SUBSYSTEM_POST_SLICES_REPOSITORY, 'all', array('active_only' => $active_only) );
 		if ($this->cache->has($key)) {
 			return $this->cache->get($key);
 		}
@@ -96,7 +96,7 @@ class AIPS_Post_Slices_Repository {
 	 * @return object|null
 	 */
 	public function get_by_id($id) {
-		$key = 'id:' . (int) $id;
+		$key = AIPS_Cache_Policy::key( AIPS_Cache_Policy::SUBSYSTEM_POST_SLICES_REPOSITORY, 'id', array('id' => $id) );
 		if ($this->cache->has($key)) {
 			return $this->cache->get($key);
 		}
@@ -139,7 +139,7 @@ class AIPS_Post_Slices_Repository {
 		);
 
 		if ($result) {
-			$this->cache->flush();
+			AIPS_Cache_Invalidation_Bus::invalidate( AIPS_Cache_Policy::SUBSYSTEM_POST_SLICES_REPOSITORY, 'update' );
 		}
 
 		return $result ? $this->wpdb->insert_id : false;
@@ -188,7 +188,7 @@ class AIPS_Post_Slices_Repository {
 		);
 
 		if ($result !== false) {
-			$this->cache->flush();
+			AIPS_Cache_Invalidation_Bus::invalidate( AIPS_Cache_Policy::SUBSYSTEM_POST_SLICES_REPOSITORY, 'update' );
 		}
 
 		return $result;
@@ -208,7 +208,7 @@ class AIPS_Post_Slices_Repository {
 		);
 
 		if ($result !== false) {
-			$this->cache->flush();
+			AIPS_Cache_Invalidation_Bus::invalidate( AIPS_Cache_Policy::SUBSYSTEM_POST_SLICES_REPOSITORY, 'update' );
 		}
 
 		return $result;
@@ -261,7 +261,7 @@ class AIPS_Post_Slices_Repository {
 		$result = $this->wpdb->query($sql);
 
 		if ($result !== false) {
-			$this->cache->flush();
+			AIPS_Cache_Invalidation_Bus::invalidate( AIPS_Cache_Policy::SUBSYSTEM_POST_SLICES_REPOSITORY, 'update' );
 		}
 
 		return $result;
@@ -295,7 +295,7 @@ class AIPS_Post_Slices_Repository {
 		$result = $this->wpdb->query($sql);
 
 		if ($result !== false) {
-			$this->cache->flush();
+			AIPS_Cache_Invalidation_Bus::invalidate( AIPS_Cache_Policy::SUBSYSTEM_POST_SLICES_REPOSITORY, 'update' );
 		}
 
 		return $result;

--- a/ai-post-scheduler/includes/class-aips-prompt-section-repository.php
+++ b/ai-post-scheduler/includes/class-aips-prompt-section-repository.php
@@ -60,7 +60,7 @@ class AIPS_Prompt_Section_Repository {
 		global $wpdb;
 		$this->wpdb = $wpdb;
 		$this->table_name = $wpdb->prefix . 'aips_prompt_sections';
-		$this->cache = AIPS_Cache_Factory::named( 'aips_prompt_section_repository' );
+		$this->cache = AIPS_Cache_Factory::named( AIPS_Cache_Policy::cache_name( AIPS_Cache_Policy::SUBSYSTEM_PROMPT_SECTION_REPOSITORY ) );
 	}
 	
 	/**
@@ -74,7 +74,7 @@ class AIPS_Prompt_Section_Repository {
 	 * @return array Array of section objects.
 	 */
 	public function get_all($active_only = false) {
-		$key = 'all:' . ( $active_only ? '1' : '0' );
+		$key = AIPS_Cache_Policy::key( AIPS_Cache_Policy::SUBSYSTEM_PROMPT_SECTION_REPOSITORY, 'all', array('active_only' => $active_only) );
 		if ( $this->cache->has( $key ) ) {
 			return $this->cache->get( $key );
 		}
@@ -94,7 +94,7 @@ class AIPS_Prompt_Section_Repository {
 	 * @return object|null Section object or null if not found.
 	 */
 	public function get_by_id($id) {
-		$key = 'id:' . (int) $id;
+		$key = AIPS_Cache_Policy::key( AIPS_Cache_Policy::SUBSYSTEM_PROMPT_SECTION_REPOSITORY, 'id', array('id' => $id) );
 		if ( $this->cache->has( $key ) ) {
 			return $this->cache->get( $key );
 		}
@@ -118,7 +118,7 @@ class AIPS_Prompt_Section_Repository {
 	 * @return object|null Section object or null if not found.
 	 */
 	public function get_by_key($section_key) {
-		$key = 'key:' . $section_key;
+		$key = AIPS_Cache_Policy::key( AIPS_Cache_Policy::SUBSYSTEM_PROMPT_SECTION_REPOSITORY, 'key', array('section_key' => $section_key) );
 		if ( $this->cache->has( $key ) ) {
 			return $this->cache->get( $key );
 		}
@@ -190,7 +190,7 @@ class AIPS_Prompt_Section_Repository {
 		$result = $this->wpdb->insert($this->table_name, $insert_data, $format);
 		
 		if ( $result ) {
-			$this->cache->flush();
+			AIPS_Cache_Invalidation_Bus::invalidate( AIPS_Cache_Policy::SUBSYSTEM_PROMPT_SECTION_REPOSITORY, 'update' );
 		}
 
 		return $result ? $this->wpdb->insert_id : false;
@@ -248,7 +248,7 @@ class AIPS_Prompt_Section_Repository {
 		) !== false;
 
 		if ( $result ) {
-			$this->cache->flush();
+			AIPS_Cache_Invalidation_Bus::invalidate( AIPS_Cache_Policy::SUBSYSTEM_PROMPT_SECTION_REPOSITORY, 'update' );
 		}
 
 		return $result;
@@ -263,7 +263,7 @@ class AIPS_Prompt_Section_Repository {
 	public function delete($id) {
 		$result = $this->wpdb->delete($this->table_name, array('id' => $id), array('%d')) !== false;
 		if ( $result ) {
-			$this->cache->flush();
+			AIPS_Cache_Invalidation_Bus::invalidate( AIPS_Cache_Policy::SUBSYSTEM_PROMPT_SECTION_REPOSITORY, 'update' );
 		}
 		return $result;
 	}

--- a/ai-post-scheduler/includes/class-aips-schedule-repository.php
+++ b/ai-post-scheduler/includes/class-aips-schedule-repository.php
@@ -66,7 +66,7 @@ class AIPS_Schedule_Repository implements AIPS_Schedule_Repository_Interface {
         $this->wpdb = $wpdb;
         $this->schedule_table = $wpdb->prefix . 'aips_schedule';
         $this->templates_table = $wpdb->prefix . 'aips_templates';
-        $this->cache = AIPS_Cache_Factory::named( 'aips_schedule_repository' );
+        $this->cache = AIPS_Cache_Factory::named( AIPS_Cache_Policy::cache_name( AIPS_Cache_Policy::SUBSYSTEM_SCHEDULE_REPOSITORY ) );
     }
     
     /**
@@ -79,7 +79,7 @@ class AIPS_Schedule_Repository implements AIPS_Schedule_Repository_Interface {
      * @return array Array of schedule objects with template names.
      */
     public function get_all($active_only = false) {
-        $key = 'all:' . ( $active_only ? '1' : '0' );
+        $key = AIPS_Cache_Policy::key( AIPS_Cache_Policy::SUBSYSTEM_SCHEDULE_REPOSITORY, 'all', array('active_only' => $active_only) );
         if ( $this->cache->has( $key ) ) {
             return $this->cache->get( $key );
         }
@@ -104,7 +104,7 @@ class AIPS_Schedule_Repository implements AIPS_Schedule_Repository_Interface {
      * @return object|null Schedule object or null if not found.
      */
     public function get_by_id($id) {
-        $key = 'id:' . (int) $id;
+        $key = AIPS_Cache_Policy::key( AIPS_Cache_Policy::SUBSYSTEM_SCHEDULE_REPOSITORY, 'id', array('id' => $id) );
         if ( $this->cache->has( $key ) ) {
             return $this->cache->get( $key );
         }
@@ -135,7 +135,7 @@ class AIPS_Schedule_Repository implements AIPS_Schedule_Repository_Interface {
             $current_time = AIPS_DateTime::now()->timestamp();
         }
         $current_time = (int) $current_time;
-        $key = 'due:' . $current_time . ':' . (int) $limit;
+        $key = AIPS_Cache_Policy::key( AIPS_Cache_Policy::SUBSYSTEM_SCHEDULE_REPOSITORY, 'due', array('current_time' => $current_time, 'limit' => $limit) );
         if ( $this->cache->has( $key ) ) {
             return $this->cache->get( $key );
         }
@@ -252,7 +252,7 @@ class AIPS_Schedule_Repository implements AIPS_Schedule_Repository_Interface {
         
         if ($result) {
             delete_transient('aips_pending_schedule_stats');
-            $this->cache->flush();
+            AIPS_Cache_Invalidation_Bus::invalidate( AIPS_Cache_Policy::SUBSYSTEM_SCHEDULE_REPOSITORY, 'update' );
         }
 
         return $result ? $this->wpdb->insert_id : false;
@@ -360,7 +360,7 @@ class AIPS_Schedule_Repository implements AIPS_Schedule_Repository_Interface {
 
         if ($result !== false) {
             delete_transient('aips_pending_schedule_stats');
-            $this->cache->flush();
+            AIPS_Cache_Invalidation_Bus::invalidate( AIPS_Cache_Policy::SUBSYSTEM_SCHEDULE_REPOSITORY, 'update' );
         }
 
 		return $result !== false;
@@ -394,7 +394,7 @@ class AIPS_Schedule_Repository implements AIPS_Schedule_Repository_Interface {
 
 		if ($result !== false && $result > 0) {
 			delete_transient('aips_pending_schedule_stats');
-			$this->cache->flush();
+			AIPS_Cache_Invalidation_Bus::invalidate( AIPS_Cache_Policy::SUBSYSTEM_SCHEDULE_REPOSITORY, 'update' );
 			return true;
 		}
 
@@ -412,7 +412,7 @@ class AIPS_Schedule_Repository implements AIPS_Schedule_Repository_Interface {
 
         if ($result !== false) {
             delete_transient('aips_pending_schedule_stats');
-            $this->cache->flush();
+            AIPS_Cache_Invalidation_Bus::invalidate( AIPS_Cache_Policy::SUBSYSTEM_SCHEDULE_REPOSITORY, 'update' );
         }
 
         return $result !== false;
@@ -429,7 +429,7 @@ class AIPS_Schedule_Repository implements AIPS_Schedule_Repository_Interface {
 
         if ($result !== false) {
             delete_transient('aips_pending_schedule_stats');
-            $this->cache->flush();
+            AIPS_Cache_Invalidation_Bus::invalidate( AIPS_Cache_Policy::SUBSYSTEM_SCHEDULE_REPOSITORY, 'update' );
         }
 
         return $result;
@@ -512,7 +512,7 @@ class AIPS_Schedule_Repository implements AIPS_Schedule_Repository_Interface {
             array('%d')
         );
         if ( $result !== false ) {
-            $this->cache->flush();
+            AIPS_Cache_Invalidation_Bus::invalidate( AIPS_Cache_Policy::SUBSYSTEM_SCHEDULE_REPOSITORY, 'update' );
         }
         return $result !== false;
     }
@@ -584,7 +584,7 @@ class AIPS_Schedule_Repository implements AIPS_Schedule_Repository_Interface {
 
         if ($result) {
             delete_transient('aips_pending_schedule_stats');
-            $this->cache->flush();
+            AIPS_Cache_Invalidation_Bus::invalidate( AIPS_Cache_Policy::SUBSYSTEM_SCHEDULE_REPOSITORY, 'update' );
         }
 
         return $result;
@@ -618,7 +618,7 @@ class AIPS_Schedule_Repository implements AIPS_Schedule_Repository_Interface {
 
         if ($result !== false) {
             delete_transient('aips_pending_schedule_stats');
-            $this->cache->flush();
+            AIPS_Cache_Invalidation_Bus::invalidate( AIPS_Cache_Policy::SUBSYSTEM_SCHEDULE_REPOSITORY, 'update' );
         }
 
         return $result;
@@ -655,7 +655,7 @@ class AIPS_Schedule_Repository implements AIPS_Schedule_Repository_Interface {
 
         if ($result !== false) {
             delete_transient('aips_pending_schedule_stats');
-            $this->cache->flush();
+            AIPS_Cache_Invalidation_Bus::invalidate( AIPS_Cache_Policy::SUBSYSTEM_SCHEDULE_REPOSITORY, 'update' );
         }
 
         return $result;

--- a/ai-post-scheduler/includes/class-aips-system-status-controller.php
+++ b/ai-post-scheduler/includes/class-aips-system-status-controller.php
@@ -12,6 +12,7 @@ if (!defined('ABSPATH')) {
 	exit;
 }
 
+
 /**
  * Class AIPS_System_Status_Controller
  *
@@ -25,6 +26,7 @@ class AIPS_System_Status_Controller {
 		add_action('wp_ajax_aips_status_retry_failed_slices', array($this, 'ajax_retry_failed_slices'));
 		add_action('wp_ajax_aips_status_clear_partial_generations', array($this, 'ajax_clear_partial_generations'));
 		add_action('wp_ajax_aips_status_cleanup_stale_jobs_cache', array($this, 'ajax_cleanup_stale_jobs_cache'));
+		add_action('wp_ajax_aips_rebuild_caches', array($this, 'ajax_rebuild_caches'));
 	}
 
 	/**
@@ -132,5 +134,24 @@ class AIPS_System_Status_Controller {
 		}
 		AIPS_Ajax_Response::success(array('message' => sprintf(__('Cleaned %1$d stale jobs. Cache flushed: %2$s.', 'ai-post-scheduler'), $deleted, $cache_flushed ? __('yes', 'ai-post-scheduler') : __('no', 'ai-post-scheduler'))));
 	}
+	public function ajax_rebuild_caches() {
+		if ( ! check_ajax_referer('aips_rebuild_caches', 'nonce', false) ) {
+			AIPS_Ajax_Response::error(__('Invalid nonce.', 'ai-post-scheduler'));
+		}
+		if (!current_user_can('manage_options')) {
+			AIPS_Ajax_Response::permission_denied();
+		}
+
+		$subsystem = isset($_POST['subsystem']) ? sanitize_key(wp_unslash($_POST['subsystem'])) : 'all';
+		$allowed = array('all','admin_bar','schedule_repository','article_structure_repository','prompt_section_repository','post_slices_repository');
+		if (!in_array($subsystem, $allowed, true)) {
+			$subsystem = 'all';
+		}
+
+		$affected = AIPS_Cache_Invalidation_Bus::rebuild($subsystem);
+		AIPS_Logger::instance()->info('Cache rebuild requested from admin tool.', array('subsystem' => $subsystem, 'affected_caches' => $affected));
+		AIPS_Ajax_Response::success(array('message' => sprintf(__('Rebuilt caches for %1$s. Affected caches: %2$s', 'ai-post-scheduler'), $subsystem, implode(', ', $affected)), 'subsystem' => $subsystem));
+	}
+
 }
 

--- a/ai-post-scheduler/includes/class-aips-system-status-controller.php
+++ b/ai-post-scheduler/includes/class-aips-system-status-controller.php
@@ -134,6 +134,7 @@ class AIPS_System_Status_Controller {
 		}
 		AIPS_Ajax_Response::success(array('message' => sprintf(__('Cleaned %1$d stale jobs. Cache flushed: %2$s.', 'ai-post-scheduler'), $deleted, $cache_flushed ? __('yes', 'ai-post-scheduler') : __('no', 'ai-post-scheduler'))));
 	}
+
 	public function ajax_rebuild_caches() {
 		if ( ! check_ajax_referer('aips_rebuild_caches', 'nonce', false) ) {
 			AIPS_Ajax_Response::error(__('Invalid nonce.', 'ai-post-scheduler'));
@@ -143,15 +144,22 @@ class AIPS_System_Status_Controller {
 		}
 
 		$subsystem = isset($_POST['subsystem']) ? sanitize_key(wp_unslash($_POST['subsystem'])) : 'all';
-		$allowed = array('all','admin_bar','schedule_repository','article_structure_repository','prompt_section_repository','post_slices_repository');
-		if (!in_array($subsystem, $allowed, true)) {
+		$subsystems = AIPS_Cache_Policy::get_subsystems();
+		$allowed_subsystems = array_keys($subsystems);
+		if ('all' !== $subsystem && !in_array($subsystem, $allowed_subsystems, true)) {
 			$subsystem = 'all';
 		}
 
 		$affected = AIPS_Cache_Invalidation_Bus::rebuild($subsystem);
+		$subsystem_label = ('all' === $subsystem) ? __('All subsystems', 'ai-post-scheduler') : (isset($subsystems[$subsystem]['label']) ? (string) $subsystems[$subsystem]['label'] : $subsystem);
+		$affected_display = !empty($affected) ? implode(', ', $affected) : __('none', 'ai-post-scheduler');
+
 		AIPS_Logger::instance()->info('Cache rebuild requested from admin tool.', array('subsystem' => $subsystem, 'affected_caches' => $affected));
-		AIPS_Ajax_Response::success(array('message' => sprintf(__('Rebuilt caches for %1$s. Affected caches: %2$s', 'ai-post-scheduler'), $subsystem, implode(', ', $affected)), 'subsystem' => $subsystem));
+		AIPS_Ajax_Response::success(array(
+			'message' => sprintf(__('Rebuilt caches for %1$s. Affected caches: %2$s', 'ai-post-scheduler'), $subsystem_label, $affected_display),
+			'subsystem' => $subsystem,
+			'affected' => $affected,
+		));
 	}
 
 }
-

--- a/ai-post-scheduler/templates/admin/system-status.php
+++ b/ai-post-scheduler/templates/admin/system-status.php
@@ -109,15 +109,14 @@ if (!defined('ABSPATH')) {
                         <button type="button" class="aips-btn aips-btn-secondary aips-status-op" data-op="aips_status_cleanup_stale_jobs_cache"><?php esc_html_e('Cleanup Stale Batch Jobs/Cache', 'ai-post-scheduler'); ?></button>
                     </div>
                     <div class="aips-status-op-result"></div>
-                    <div style="margin-top:12px;">
+                    <?php $cache_subsystems = AIPS_Cache_Policy::get_subsystems(); ?>
+                    <div class="aips-cache-rebuild-controls">
                         <label for="aips-cache-subsystem"><strong><?php esc_html_e('Rebuild caches:', 'ai-post-scheduler'); ?></strong></label>
                         <select id="aips-cache-subsystem">
                             <option value="all"><?php esc_html_e('All subsystems', 'ai-post-scheduler'); ?></option>
-                            <option value="admin_bar"><?php esc_html_e('Admin Bar', 'ai-post-scheduler'); ?></option>
-                            <option value="schedule_repository"><?php esc_html_e('Schedule Repository', 'ai-post-scheduler'); ?></option>
-                            <option value="article_structure_repository"><?php esc_html_e('Article Structure Repository', 'ai-post-scheduler'); ?></option>
-                            <option value="prompt_section_repository"><?php esc_html_e('Prompt Section Repository', 'ai-post-scheduler'); ?></option>
-                            <option value="post_slices_repository"><?php esc_html_e('Post Slices Repository', 'ai-post-scheduler'); ?></option>
+                            <?php foreach ($cache_subsystems as $key => $info) : ?>
+                                <option value="<?php echo esc_attr($key); ?>"><?php echo esc_html($info['label']); ?></option>
+                            <?php endforeach; ?>
                         </select>
                         <button type="button" class="aips-btn aips-btn-secondary aips-rebuild-cache-btn"><?php esc_html_e('Rebuild Caches', 'ai-post-scheduler'); ?></button>
                     </div>

--- a/ai-post-scheduler/templates/admin/system-status.php
+++ b/ai-post-scheduler/templates/admin/system-status.php
@@ -109,6 +109,18 @@ if (!defined('ABSPATH')) {
                         <button type="button" class="aips-btn aips-btn-secondary aips-status-op" data-op="aips_status_cleanup_stale_jobs_cache"><?php esc_html_e('Cleanup Stale Batch Jobs/Cache', 'ai-post-scheduler'); ?></button>
                     </div>
                     <div class="aips-status-op-result"></div>
+                    <div style="margin-top:12px;">
+                        <label for="aips-cache-subsystem"><strong><?php esc_html_e('Rebuild caches:', 'ai-post-scheduler'); ?></strong></label>
+                        <select id="aips-cache-subsystem">
+                            <option value="all"><?php esc_html_e('All subsystems', 'ai-post-scheduler'); ?></option>
+                            <option value="admin_bar"><?php esc_html_e('Admin Bar', 'ai-post-scheduler'); ?></option>
+                            <option value="schedule_repository"><?php esc_html_e('Schedule Repository', 'ai-post-scheduler'); ?></option>
+                            <option value="article_structure_repository"><?php esc_html_e('Article Structure Repository', 'ai-post-scheduler'); ?></option>
+                            <option value="prompt_section_repository"><?php esc_html_e('Prompt Section Repository', 'ai-post-scheduler'); ?></option>
+                            <option value="post_slices_repository"><?php esc_html_e('Post Slices Repository', 'ai-post-scheduler'); ?></option>
+                        </select>
+                        <button type="button" class="aips-btn aips-btn-secondary aips-rebuild-cache-btn"><?php esc_html_e('Rebuild Caches', 'ai-post-scheduler'); ?></button>
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
### Motivation
- Centralize cache key construction, TTLs, and invalidation logic so multiple subsystems use canonical keys and invalidation targets instead of ad-hoc strings and inline `flush()` calls.
- Provide a single light-weight invalidation bus so repository and service write operations can invalidate related caches consistently.
- Expose an admin-facing cache rebuild tool to allow targeted or global cache rebuilds and log admin requests via `AIPS_Logger`.

### Description
- Added `includes/class-aips-cache-policy.php` implementing subsystem constants, `cache_name()`, `default_ttl()`, canonical `key()` builders, and `invalidation_targets()` mapping. 
- Added `includes/class-aips-cache-invalidation-bus.php` providing `invalidate($subsystem, $operation, $context = array())` and `rebuild($subsystem = 'all')` that flush named caches and fire the `aips_cache_invalidated` action. 
- Refactored cache usage to call policy helpers and the invalidation bus in the following places: `includes/class-aips-admin-bar.php`, `includes/class-aips-schedule-repository.php`, `includes/class-aips-article-structure-repository.php`, `includes/class-aips-prompt-section-repository.php`, and `includes/class-aips-post-slices-repository.php`, replacing inline key strings, TTL constants, and repository `flush()` calls with `AIPS_Cache_Policy::key(...)`, `AIPS_Cache_Policy::default_ttl(...)`, and `AIPS_Cache_Invalidation_Bus::invalidate(...)` respectively. 
- Added an admin UI element on the System Status page (`templates/admin/system-status.php`) to select a subsystem (or `all`) and trigger a cache rebuild. 
- Implemented an AJAX endpoint `aips_rebuild_caches` in `includes/class-aips-system-status-controller.php` that validates nonce/capabilities, calls `AIPS_Cache_Invalidation_Bus::rebuild()`, logs via `AIPS_Logger::instance()->info(...)`, and returns a success message. 
- Wired client-side support in `assets/js/admin-system-status.js` to call the new AJAX action and localized the new nonce in `includes/class-aips-admin-assets.php`. 

### Testing
- Ran PHP lint (`php -l`) on all modified PHP files including `includes/class-aips-cache-policy.php`, `includes/class-aips-cache-invalidation-bus.php`, `includes/class-aips-system-status-controller.php`, `includes/class-aips-admin-bar.php`, `includes/class-aips-schedule-repository.php`, `includes/class-aips-article-structure-repository.php`, `includes/class-aips-prompt-section-repository.php`, and `includes/class-aips-post-slices-repository.php`, and no syntax errors were reported. 
- Attempted to check open PRs with `gh pr list` but the GitHub CLI is not available in the execution environment (`gh: command not found`), so an external PR de-duplication check could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a5d602b5883219403bcba4fed1de1)