### PR TITLE
🐞 Hunter: Fix type errors and missing unslash on superglobals

### DIFF
--- a/ai-post-scheduler/includes/class-aips-ai-edit-controller.php
+++ b/ai-post-scheduler/includes/class-aips-ai-edit-controller.php
@@ -264,7 +264,7 @@ class AIPS_AI_Edit_Controller {
 		$post_id = isset($_POST['post_id']) ? absint($_POST['post_id']) : 0;
 		$history_id = isset($_POST['history_id']) ? absint($_POST['history_id']) : 0;
 		$manual_snapshots = isset($_POST['manual_snapshots']) && is_array($_POST['manual_snapshots'])
-			? $_POST['manual_snapshots']
+			? wp_unslash($_POST['manual_snapshots'])
 			: array();
 
 		if (!$post_id || !$history_id) {
@@ -364,7 +364,7 @@ class AIPS_AI_Edit_Controller {
 		}
 		
 		$post_id = isset($_POST['post_id']) ? absint($_POST['post_id']) : 0;
-		$components = isset($_POST['components']) ? $_POST['components'] : array();
+		$components = isset($_POST['components']) && is_array($_POST['components']) ? wp_unslash($_POST['components']) : array();
 		
 		if (!$post_id || empty($components)) {
 			AIPS_Ajax_Response::error(__('Invalid request.', 'ai-post-scheduler'));

--- a/ai-post-scheduler/includes/class-aips-article-structure-repository.php
+++ b/ai-post-scheduler/includes/class-aips-article-structure-repository.php
@@ -268,8 +268,8 @@ class AIPS_Article_Structure_Repository {
 		");
 		
 		return array(
-			'total' => isset($results->total) ? (int) $results->total : 0,
-			'active' => isset($results->active) ? (int) $results->active : 0,
+			'total' => is_object($results) && isset($results->total) ? (int) $results->total : 0,
+			'active' => is_object($results) && isset($results->active) ? (int) $results->active : 0,
 		);
 	}
 	

--- a/ai-post-scheduler/includes/class-aips-feedback-repository.php
+++ b/ai-post-scheduler/includes/class-aips-feedback-repository.php
@@ -234,9 +234,9 @@ class AIPS_Feedback_Repository {
 		));
 		
 		return array(
-			'total' => isset($results->total) ? (int) $results->total : 0,
-			'approved' => isset($results->approved) ? (int) $results->approved : 0,
-			'rejected' => isset($results->rejected) ? (int) $results->rejected : 0
+			'total' => is_object($results) && isset($results->total) ? (int) $results->total : 0,
+			'approved' => is_object($results) && isset($results->approved) ? (int) $results->approved : 0,
+			'rejected' => is_object($results) && isset($results->rejected) ? (int) $results->rejected : 0
 		);
 	}
 	

--- a/ai-post-scheduler/includes/class-aips-history-repository.php
+++ b/ai-post-scheduler/includes/class-aips-history-repository.php
@@ -715,11 +715,11 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
         ");
 
         $stats = array(
-            'total' => isset($results->total) ? (int) $results->total : 0,
-            'completed' => isset($results->completed) ? (int) $results->completed : 0,
-            'failed' => isset($results->failed) ? (int) $results->failed : 0,
-            'processing' => isset($results->processing) ? (int) $results->processing : 0,
-            'partial' => isset($results->partial) ? (int) $results->partial : 0,
+            'total' => is_object($results) && isset($results->total) ? (int) $results->total : 0,
+            'completed' => is_object($results) && isset($results->completed) ? (int) $results->completed : 0,
+            'failed' => is_object($results) && isset($results->failed) ? (int) $results->failed : 0,
+            'processing' => is_object($results) && isset($results->processing) ? (int) $results->processing : 0,
+            'partial' => is_object($results) && isset($results->partial) ? (int) $results->partial : 0,
         );
         
         $stats['success_rate'] = $stats['total'] > 0 

--- a/ai-post-scheduler/includes/class-aips-post-review.php
+++ b/ai-post-scheduler/includes/class-aips-post-review.php
@@ -837,7 +837,7 @@ class AIPS_Post_Review {
 			AIPS_Ajax_Response::permission_denied();
 		}
 		
-		$items = (isset($_POST['items']) && is_array($_POST['items'])) ? $_POST['items'] : array();
+		$items = (isset($_POST['items']) && is_array($_POST['items'])) ? wp_unslash($_POST['items']) : array();
 		
 		if (empty($items)) {
 			AIPS_Ajax_Response::error(__('No posts selected.', 'ai-post-scheduler'));

--- a/ai-post-scheduler/includes/class-aips-prompt-section-repository.php
+++ b/ai-post-scheduler/includes/class-aips-prompt-section-repository.php
@@ -296,8 +296,8 @@ class AIPS_Prompt_Section_Repository {
 		");
 		
 		return array(
-			'total' => isset($results->total) ? (int) $results->total : 0,
-			'active' => isset($results->active) ? (int) $results->active : 0,
+			'total' => is_object($results) && isset($results->total) ? (int) $results->total : 0,
+			'active' => is_object($results) && isset($results->active) ? (int) $results->active : 0,
 		);
 	}
 	

--- a/ai-post-scheduler/includes/class-aips-schedule-controller.php
+++ b/ai-post-scheduler/includes/class-aips-schedule-controller.php
@@ -707,7 +707,7 @@ class AIPS_Schedule_Controller {
             AIPS_Ajax_Response::permission_denied();
         }
 
-        $items     = isset($_POST['items']) && is_array($_POST['items']) ? $_POST['items'] : array();
+        $items     = isset($_POST['items']) && is_array($_POST['items']) ? wp_unslash($_POST['items']) : array();
         $is_active = isset($_POST['is_active']) ? absint($_POST['is_active']) : 0;
 
         if (empty($items)) {
@@ -763,7 +763,7 @@ class AIPS_Schedule_Controller {
             AIPS_Ajax_Response::permission_denied();
         }
 
-        $items = isset($_POST['items']) && is_array($_POST['items']) ? $_POST['items'] : array();
+        $items = isset($_POST['items']) && is_array($_POST['items']) ? wp_unslash($_POST['items']) : array();
 
         if (empty($items)) {
             AIPS_Ajax_Response::error(__('No items provided.', 'ai-post-scheduler'));
@@ -862,7 +862,7 @@ class AIPS_Schedule_Controller {
             AIPS_Ajax_Response::permission_denied();
         }
 
-        $items = isset($_POST['items']) && is_array($_POST['items']) ? $_POST['items'] : array();
+        $items = isset($_POST['items']) && is_array($_POST['items']) ? wp_unslash($_POST['items']) : array();
 
         if (empty($items)) {
             AIPS_Ajax_Response::error(__('No items provided.', 'ai-post-scheduler'));

--- a/ai-post-scheduler/includes/class-aips-schedule-repository.php
+++ b/ai-post-scheduler/includes/class-aips-schedule-repository.php
@@ -748,8 +748,8 @@ class AIPS_Schedule_Repository implements AIPS_Schedule_Repository_Interface {
         ");
         
         return array(
-            'total' => isset($results->total) ? (int) $results->total : 0,
-            'active' => isset($results->active) ? (int) $results->active : 0,
+            'total' => is_object($results) && isset($results->total) ? (int) $results->total : 0,
+            'active' => is_object($results) && isset($results->active) ? (int) $results->active : 0,
         );
     }
 

--- a/ai-post-scheduler/includes/class-aips-template-repository.php
+++ b/ai-post-scheduler/includes/class-aips-template-repository.php
@@ -346,8 +346,8 @@ class AIPS_Template_Repository {
         ");
         
         return array(
-            'total' => isset($results->total) ? (int) $results->total : 0,
-            'active' => isset($results->active) ? (int) $results->active : 0,
+            'total' => is_object($results) && isset($results->total) ? (int) $results->total : 0,
+            'active' => is_object($results) && isset($results->active) ? (int) $results->active : 0,
         );
     }
     


### PR DESCRIPTION
🐛 **Bug:** The codebase had potential TypeErrors and magic quote bypasses in several places. `AIPS_AI_Edit_Controller` was accessing `$_POST['components']` as an array without verifying its type, leading to fatal string offset errors in PHP 8.3 if malformed data was passed. Many repositories used `$this->wpdb->get_row(...)` and blindly checked `isset($results->total)`, which triggers warnings/fatals in PHP 8 if the query returns `null`. Lastly, a few controllers checked `is_array($_POST['items'])` but failed to apply `wp_unslash()`, risking magic quote artifacts.
🔍 **Root Cause:** Incomplete type validation of array superglobals (`$_POST`) before extraction, lack of defensive checks on database row objects before property access, and missing `wp_unslash()` sanitization on known array structures.
🛠️ **Fix:** 
- In `class-aips-ai-edit-controller.php`, added strict `is_array()` checks to `$_POST['components']` and applied `wp_unslash()`.
- Across all repositories using `$wpdb->get_row()` for aggregate counts (e.g. `AIPS_History_Repository`), changed property access guards from `isset($results->prop)` to `is_object($results) && isset($results->prop)`.
- Applied `wp_unslash()` to missing array items in `AIPS_Post_Review` and `AIPS_Schedule_Controller`.
🧪 **Verification:** Ran `php -l` on all modified files to ensure syntax correctness. Executed `phpunit` suite to confirm changes did not introduce regressions (pre-existing failures remain unaffected). Code review verified changes successfully mitigate potential TypeErrors.

---
*PR created automatically by Jules for task [9966218590834182603](https://jules.google.com/task/9966218590834182603) started by @rpnunez*