### PR TITLE
Optimize AIPS DB cache has() to use existence query

### DIFF
--- a/ai-post-scheduler/includes/class-aips-cache-db-driver.php
+++ b/ai-post-scheduler/includes/class-aips-cache-db-driver.php
@@ -150,7 +150,19 @@ class AIPS_Cache_Db_Driver implements AIPS_Cache_Driver {
 	 * {@inheritdoc}
 	 */
 	public function has( $key, $group = 'default' ) {
-		return $this->get( $key, $group ) !== null;
+		global $wpdb;
+
+		$table = $wpdb->prefix . 'aips_cache';
+		$row   = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+			$wpdb->prepare(
+				"SELECT 1 FROM `{$table}` WHERE cache_key = %s AND cache_group = %s AND " . $this->get_non_expired_predicate_sql() . " LIMIT 1", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$this->namespace_key( $key ),
+				(string) $group,
+				AIPS_DateTime::now()->timestamp()
+			)
+		);
+
+		return null !== $row;
 	}
 
 	/**
@@ -176,6 +188,18 @@ class AIPS_Cache_Db_Driver implements AIPS_Cache_Driver {
 	// -----------------------------------------------------------------------
 	// Internal helpers
 	// -----------------------------------------------------------------------
+
+	/**
+	 * SQL predicate for rows that should be treated as non-expired.
+	 *
+	 * Mirrors get() semantics: expires_at = 0 never expires, otherwise
+	 * expires_at must be greater than or equal to the current timestamp.
+	 *
+	 * @return string
+	 */
+	private function get_non_expired_predicate_sql() {
+		return '(expires_at = 0 OR expires_at >= %d)';
+	}
 
 	/**
 	 * Optionally prepend the configured prefix to a cache key.


### PR DESCRIPTION
### Motivation

- Reduce work done by `AIPS_Cache_Db_Driver::has()` by avoiding loading and unserializing the `value` column while keeping expiration behavior identical to `get()`.

### Description

- Implemented `has()` to perform a lightweight existence query using `SELECT 1 ... LIMIT 1` with `$wpdb->get_var` instead of delegating to `get()` so it does not fetch `value`.
- Added a private helper `get_non_expired_predicate_sql()` that returns `'(expires_at = 0 OR expires_at >= %d)'` and used it in `has()` so expiration semantics mirror `get()` (where `expires_at = 0` means never expires).
- Modified file: `ai-post-scheduler/includes/class-aips-cache-db-driver.php`.

### Testing

- Ran `php -l ai-post-scheduler/includes/class-aips-cache-db-driver.php` which returned no syntax errors.
- Attempted the required pre-change PR check `gh pr list` but the `gh` CLI was not available in the environment so that check could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a5d3f8aa88321a885afd995071045)