### PR TITLE
Refactor AIPS_Cache::remember to use sentinel-based single get

### DIFF
--- a/ai-post-scheduler/includes/class-aips-cache.php
+++ b/ai-post-scheduler/includes/class-aips-cache.php
@@ -29,6 +29,16 @@ class AIPS_Cache {
 	private $driver;
 
 	/**
+	 * Internal sentinel used by remember() to detect cache misses.
+	 *
+	 * Must remain distinct from null so cached null values can still be
+	 * treated as cache hits on drivers that support them.
+	 *
+	 * @var object|null
+	 */
+	private $remember_sentinel = null;
+
+	/**
 	 * Per-request memoised result of the system-enabled check.
 	 *
 	 * Null means "not yet read". Populated on the first call to
@@ -235,7 +245,9 @@ class AIPS_Cache {
 		if (!self::is_system_enabled()) {
 			return $callback();
 		}
-		if ($this->has( $key, $group )) {
+		$sentinel = $this->get_remember_sentinel();
+		$cached   = $this->get( $key, $group, $sentinel );
+		if ($cached !== $sentinel) {
 			$this->record_cache_event(
 				'remember',
 				array(
@@ -245,7 +257,7 @@ class AIPS_Cache {
 					'hit'   => true,
 				)
 			);
-			return $this->get( $key, $group );
+			return $cached;
 		}
 
 		$value = $callback();
@@ -261,6 +273,18 @@ class AIPS_Cache {
 		);
 
 		return $value;
+	}
+
+	/**
+	 * Return the remember() miss sentinel, initialising it lazily.
+	 *
+	 * @return object
+	 */
+	private function get_remember_sentinel() {
+		if ($this->remember_sentinel === null) {
+			$this->remember_sentinel = new stdClass();
+		}
+		return $this->remember_sentinel;
 	}
 
 	/**


### PR DESCRIPTION
### Motivation
- Reduce double reads against the cache backend and preserve support for cached `null` values by distinguishing misses with an internal sentinel rather than calling `has()` then `get()`.

### Description
- Replace the `has()` + `get()` double-read in `AIPS_Cache::remember()` with a single `get($key, $group, $sentinel)` call and compare the result against a private sentinel to detect misses.
- Add a private `$remember_sentinel` property and a `get_remember_sentinel()` helper that lazily initialises a unique `stdClass` sentinel so cached `null` remains a valid hit.
- Preserve telemetry behavior by continuing to emit the `cache`/`remember` event with `hit => true` for hits and `hit => false` for misses using the new flow.

### Testing
- Ran a syntax check with `php -l ai-post-scheduler/includes/class-aips-cache.php` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a5d30e0588321b54c2501d85ed4dc)