### PR TITLE
Add scoped cache invalidation (group/prefix) and namespace force-rebuild

### DIFF
--- a/ai-post-scheduler/includes/class-aips-cache-array-driver.php
+++ b/ai-post-scheduler/includes/class-aips-cache-array-driver.php
@@ -81,6 +81,32 @@ class AIPS_Cache_Array_Driver implements AIPS_Cache_Driver {
 	/**
 	 * {@inheritdoc}
 	 */
+	public function flush_group( $group ) {
+		$group_prefix = (string) $group . ':';
+		foreach (array_keys( $this->store ) as $composite_key) {
+			if (str_starts_with( $composite_key, $group_prefix )) {
+				unset( $this->store[ $composite_key ], $this->expiries[ $composite_key ] );
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function flush_prefix( $prefix, $group = 'default' ) {
+		$key_prefix = (string) $group . ':' . (string) $prefix;
+		foreach (array_keys( $this->store ) as $composite_key) {
+			if (str_starts_with( $composite_key, $key_prefix )) {
+				unset( $this->store[ $composite_key ], $this->expiries[ $composite_key ] );
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
 	public function has( $key, $group = 'default' ) {
 		return $this->get( $key, $group ) !== null;
 	}

--- a/ai-post-scheduler/includes/class-aips-cache-db-driver.php
+++ b/ai-post-scheduler/includes/class-aips-cache-db-driver.php
@@ -149,6 +149,43 @@ class AIPS_Cache_Db_Driver implements AIPS_Cache_Driver {
 	/**
 	 * {@inheritdoc}
 	 */
+	public function flush_group( $group ) {
+		global $wpdb;
+
+		$table = $wpdb->prefix . 'aips_cache';
+		$wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+			$wpdb->prepare(
+				"DELETE FROM `{$table}` WHERE cache_group = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				(string) $group
+			)
+		);
+
+		return true;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function flush_prefix( $prefix, $group = 'default' ) {
+		global $wpdb;
+
+		$table          = $wpdb->prefix . 'aips_cache';
+		$key_namespace  = $this->namespace_key( (string) $prefix );
+		$prefix_pattern = $wpdb->esc_like( $key_namespace ) . '%';
+		$wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+			$wpdb->prepare(
+				"DELETE FROM `{$table}` WHERE cache_group = %s AND cache_key LIKE %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				(string) $group,
+				$prefix_pattern
+			)
+		);
+
+		return true;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
 	public function has( $key, $group = 'default' ) {
 		return $this->get( $key, $group ) !== null;
 	}

--- a/ai-post-scheduler/includes/class-aips-cache-factory.php
+++ b/ai-post-scheduler/includes/class-aips-cache-factory.php
@@ -100,7 +100,7 @@ class AIPS_Cache_Factory {
 
 		switch ( (string) $driver_name ) {
 			case 'db':
-				$prefix = (string) get_option( 'aips_cache_db_prefix', '' );
+				$prefix = self::build_namespaced_prefix( (string) get_option( 'aips_cache_db_prefix', '' ) );
 				return new AIPS_Cache_Db_Driver( $prefix );
 
 			case 'session':
@@ -117,7 +117,7 @@ class AIPS_Cache_Factory {
 				return new AIPS_Cache_Array_Driver();
 
 			case 'wp_object_cache':
-				return new AIPS_Cache_Wp_Object_Cache_Driver();
+				return new AIPS_Cache_Wp_Object_Cache_Driver( self::build_namespaced_prefix( 'aips' ) );
 
 			case 'array':
 			default:
@@ -134,6 +134,22 @@ class AIPS_Cache_Factory {
 	public static function reset() {
 		self::$instance = null;
 		self::$named    = array();
+	}
+
+	/**
+	 * Force cache rebuild by bumping namespace version.
+	 *
+	 * Existing cache entries become unreachable for drivers that include the
+	 * version in their key prefix.
+	 *
+	 * @return int New namespace version.
+	 */
+	public static function force_rebuild() {
+		$current = (int) get_option( 'aips_cache_namespace_version', 1 );
+		$next    = max( 1, $current + 1 );
+		update_option( 'aips_cache_namespace_version', $next );
+		self::reset();
+		return $next;
 	}
 
 	// -----------------------------------------------------------------------
@@ -215,7 +231,7 @@ class AIPS_Cache_Factory {
 		$port     = (int) get_option( 'aips_cache_redis_port', 6379 );
 		$password = (string) get_option( 'aips_cache_redis_password', '' );
 		$db       = (int) get_option( 'aips_cache_redis_db', 0 );
-		$prefix   = (string) get_option( 'aips_cache_redis_prefix', 'aips' );
+		$prefix   = self::build_namespaced_prefix( (string) get_option( 'aips_cache_redis_prefix', 'aips' ) );
 		$timeout  = (float) get_option( 'aips_cache_redis_timeout', 2.0 );
 
 		$driver = new AIPS_Cache_Redis_Driver( $host, $port, $password, $db, $prefix, $timeout );
@@ -233,6 +249,18 @@ class AIPS_Cache_Factory {
 		}
 
 		return $driver;
+	}
+
+	/**
+	 * Build a cache-key prefix with namespace version suffix.
+	 *
+	 * @param string $base_prefix Base prefix from settings.
+	 * @return string Versioned prefix.
+	 */
+	private static function build_namespaced_prefix( $base_prefix ) {
+		$base_prefix = !empty( $base_prefix ) ? (string) $base_prefix : 'aips';
+		$version     = (int) get_option( 'aips_cache_namespace_version', 1 );
+		return $base_prefix . '_v' . max( 1, $version );
 	}
 
 	/**

--- a/ai-post-scheduler/includes/class-aips-cache-invalidation-bus.php
+++ b/ai-post-scheduler/includes/class-aips-cache-invalidation-bus.php
@@ -1,0 +1,93 @@
+<?php
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+/**
+ * Class AIPS_Cache_Invalidation_Bus
+ *
+ * High-level cache invalidation entrypoint to keep invalidation calls
+ * centralized and policy-driven.
+ *
+ * @package AI_Post_Scheduler
+ * @since   2.5.0
+ */
+class AIPS_Cache_Invalidation_Bus {
+
+	/**
+	 * Cache instance.
+	 *
+	 * @var AIPS_Cache
+	 */
+	private $cache;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param AIPS_Cache|null $cache Optional injected cache instance.
+	 */
+	public function __construct( AIPS_Cache $cache = null ) {
+		$this->cache = $cache ? $cache : AIPS_Cache_Factory::instance();
+	}
+
+	/**
+	 * Emergency full cache reset.
+	 *
+	 * @return bool
+	 */
+	public function flush_all() {
+		return $this->cache->flush();
+	}
+
+	/**
+	 * Force rebuild by namespace bump.
+	 *
+	 * @return int New namespace version.
+	 */
+	public function force_rebuild() {
+		return AIPS_Cache_Factory::force_rebuild();
+	}
+
+	/**
+	 * Flush all entries in a cache group.
+	 *
+	 * @param string $group Group name.
+	 * @return bool
+	 */
+	public function flush_group( $group ) {
+		return $this->cache->flush_group( $group );
+	}
+
+	/**
+	 * Flush entries by key prefix within a group.
+	 *
+	 * @param string $prefix Prefix.
+	 * @param string $group  Group name.
+	 * @return bool
+	 */
+	public function flush_prefix( $prefix, $group = 'default' ) {
+		return $this->cache->flush_prefix( $prefix, $group );
+	}
+
+	/**
+	 * Flush a named subsystem using policy rules.
+	 *
+	 * @param string $subsystem Subsystem identifier.
+	 * @return bool
+	 */
+	public function flush_subsystem( $subsystem ) {
+		$rule = AIPS_Cache_Policy::get_rule( (string) $subsystem );
+		if (!$rule) {
+			return false;
+		}
+
+		$group  = isset( $rule['group'] ) ? (string) $rule['group'] : 'default';
+		$prefix = isset( $rule['prefix'] ) ? (string) $rule['prefix'] : '';
+
+		if ($prefix !== '') {
+			return $this->flush_prefix( $prefix, $group );
+		}
+
+		return $this->flush_group( $group );
+	}
+}

--- a/ai-post-scheduler/includes/class-aips-cache-policy.php
+++ b/ai-post-scheduler/includes/class-aips-cache-policy.php
@@ -1,0 +1,56 @@
+<?php
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+/**
+ * Class AIPS_Cache_Policy
+ *
+ * Shared cache invalidation policy for subsystem-level scoped flushes.
+ *
+ * @package AI_Post_Scheduler
+ * @since   2.5.0
+ */
+class AIPS_Cache_Policy {
+
+	/**
+	 * Return invalidation rules for known subsystems.
+	 *
+	 * @return array<string, array<string, string>>
+	 */
+	public static function get_subsystem_rules() {
+		return array(
+			'config' => array(
+				'group'  => 'default',
+				'prefix' => 'aips_config:',
+			),
+			'telemetry' => array(
+				'group'  => 'telemetry',
+				'prefix' => '',
+			),
+			'internal_links' => array(
+				'group'  => 'internal_links',
+				'prefix' => '',
+			),
+			'sources' => array(
+				'group'  => 'sources',
+				'prefix' => '',
+			),
+			'embeddings' => array(
+				'group'  => 'embeddings',
+				'prefix' => '',
+			),
+		);
+	}
+
+	/**
+	 * Get one subsystem rule.
+	 *
+	 * @param string $subsystem Subsystem identifier.
+	 * @return array<string, string>|null
+	 */
+	public static function get_rule( $subsystem ) {
+		$rules = self::get_subsystem_rules();
+		return isset( $rules[ $subsystem ] ) ? $rules[ $subsystem ] : null;
+	}
+}

--- a/ai-post-scheduler/includes/class-aips-cache-redis-driver.php
+++ b/ai-post-scheduler/includes/class-aips-cache-redis-driver.php
@@ -184,6 +184,36 @@ class AIPS_Cache_Redis_Driver implements AIPS_Cache_Driver {
 	/**
 	 * {@inheritdoc}
 	 */
+	public function flush_group( $group ) {
+		if (!$this->connected) {
+			return false;
+		}
+		$pattern = $this->prefix_key( '*', $group );
+		$keys    = $this->redis->keys( $pattern );
+		if (empty( $keys )) {
+			return true;
+		}
+		return false !== $this->redis->del( $keys );
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function flush_prefix( $prefix, $group = 'default' ) {
+		if (!$this->connected) {
+			return false;
+		}
+		$pattern = $this->prefix_key( (string) $prefix . '*', $group );
+		$keys    = $this->redis->keys( $pattern );
+		if (empty( $keys )) {
+			return true;
+		}
+		return false !== $this->redis->del( $keys );
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
 	public function has( $key, $group = 'default' ) {
 		if (!$this->connected) {
 			return false;

--- a/ai-post-scheduler/includes/class-aips-cache-session-driver.php
+++ b/ai-post-scheduler/includes/class-aips-cache-session-driver.php
@@ -155,6 +155,42 @@ class AIPS_Cache_Session_Driver implements AIPS_Cache_Driver {
 	/**
 	 * {@inheritdoc}
 	 */
+	public function flush_group( $group ) {
+		if (!$this->session_available) {
+			return false;
+		}
+
+		$group_prefix = $this->namespace . '::' . (string) $group . ':';
+		foreach (array_keys( $_SESSION ) as $k) {
+			if (str_starts_with( $k, $group_prefix )) {
+				unset( $_SESSION[ $k ] );
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function flush_prefix( $prefix, $group = 'default' ) {
+		if (!$this->session_available) {
+			return false;
+		}
+
+		$key_prefix = $this->namespace . '::' . (string) $group . ':' . (string) $prefix;
+		foreach (array_keys( $_SESSION ) as $k) {
+			if (str_starts_with( $k, $key_prefix )) {
+				unset( $_SESSION[ $k ] );
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
 	public function has( $key, $group = 'default' ) {
 		return $this->get( $key, $group ) !== null;
 	}

--- a/ai-post-scheduler/includes/class-aips-cache-wp-object-cache-driver.php
+++ b/ai-post-scheduler/includes/class-aips-cache-wp-object-cache-driver.php
@@ -115,6 +115,20 @@ class AIPS_Cache_Wp_Object_Cache_Driver implements AIPS_Cache_Driver {
 	/**
 	 * {@inheritdoc}
 	 */
+	public function flush_group( $group ) {
+		return $this->flush();
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function flush_prefix( $prefix, $group = 'default' ) {
+		return $this->flush();
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
 	public function has( $key, $group = 'default' ) {
 		$found = false;
 		wp_cache_get( $key, $this->resolve_group( $group ), false, $found );

--- a/ai-post-scheduler/includes/class-aips-cache.php
+++ b/ai-post-scheduler/includes/class-aips-cache.php
@@ -214,6 +214,50 @@ class AIPS_Cache {
 		return $result;
 	}
 
+	/**
+	 * Flush all values for a single logical cache group.
+	 *
+	 * @param string $group Cache group to clear.
+	 * @return bool True on success.
+	 */
+	public function flush_group( $group ) {
+		if (!self::is_system_enabled()) {
+			return true;
+		}
+		$result = $this->driver->flush_group( $group );
+		$this->record_cache_event(
+			'flush_group',
+			array(
+				'group'   => (string) $group,
+				'success' => (bool) $result,
+			)
+		);
+		return $result;
+	}
+
+	/**
+	 * Flush values by key prefix inside a logical cache group.
+	 *
+	 * @param string $prefix Key prefix namespace.
+	 * @param string $group  Cache group. Default 'default'.
+	 * @return bool True on success.
+	 */
+	public function flush_prefix( $prefix, $group = 'default' ) {
+		if (!self::is_system_enabled()) {
+			return true;
+		}
+		$result = $this->driver->flush_prefix( $prefix, $group );
+		$this->record_cache_event(
+			'flush_prefix',
+			array(
+				'prefix'  => (string) $prefix,
+				'group'   => (string) $group,
+				'success' => (bool) $result,
+			)
+		);
+		return $result;
+	}
+
 	// -----------------------------------------------------------------------
 	// Higher-level helpers
 	// -----------------------------------------------------------------------

--- a/ai-post-scheduler/includes/class-aips-config.php
+++ b/ai-post-scheduler/includes/class-aips-config.php
@@ -182,6 +182,7 @@ class AIPS_Config {
             'aips_enable_cache_system'  => true,
             'aips_cache_driver'         => 'array',
             'aips_cache_db_prefix'      => '',
+            'aips_cache_namespace_version' => 1,
             'aips_cache_default_ttl'    => 3600,
             'aips_cache_redis_host'     => '127.0.0.1',
             'aips_cache_redis_port'     => 6379,

--- a/ai-post-scheduler/includes/interface-aips-cache-driver.php
+++ b/ai-post-scheduler/includes/interface-aips-cache-driver.php
@@ -54,6 +54,23 @@ interface AIPS_Cache_Driver {
 	public function flush();
 
 	/**
+	 * Flush all values in a specific cache group.
+	 *
+	 * @param string $group Cache group to clear.
+	 * @return bool True on success, false on failure.
+	 */
+	public function flush_group( $group );
+
+	/**
+	 * Flush all values whose cache key starts with a prefix.
+	 *
+	 * @param string $prefix Cache key prefix (namespace) to clear.
+	 * @param string $group  Optional group scope. Default 'default'.
+	 * @return bool True on success, false on failure.
+	 */
+	public function flush_prefix( $prefix, $group = 'default' );
+
+	/**
 	 * Check whether a key exists in the cache and has not expired.
 	 *
 	 * @param string $key   Cache key.


### PR DESCRIPTION
### Motivation
- Provide safer, day-to-day cache invalidation mechanisms so subsystems can clear only relevant cache entries instead of calling a full `flush()` that truncates all storage. 
- Enable a low-risk “force rebuild” flow (namespace bump) for cross-driver invalidation that avoids mass deletes where possible. 

### Description
- Added two new driver contract methods to `AIPS_Cache_Driver`: `flush_group( $group )` and `flush_prefix( $prefix, $group = 'default' )` in `interface-aips-cache-driver.php`. 
- Implemented scoped invalidation across drivers: DB driver supports `DELETE ... WHERE cache_group = %s` and prefix deletes via `LIKE`, Redis supports pattern deletes for group/prefix, Array and Session drivers perform in-memory / session-scoped removals by group/prefix, and WP Object Cache degrades to its generation-based `flush()` behavior when scoped deletes are not feasible. 
- Exposed high-level wrappers on `AIPS_Cache`: `flush_group()` and `flush_prefix()` that delegate to the driver and record telemetry events. 
- Added `AIPS_Cache_Factory::force_rebuild()` and a `build_namespaced_prefix()` helper so drivers can include a namespace version suffix (option `aips_cache_namespace_version`) and a UI/service can bump the namespace to force rebuilds without destructive global truncation. 

### Testing
- Performed PHP syntax checks with `php -l` on the modified files (`interface-aips-cache-driver.php`, `class-aips-cache.php`, `class-aips-cache-factory.php`, `class-aips-cache-db-driver.php`, `class-aips-cache-array-driver.php`, `class-aips-cache-session-driver.php`, `class-aips-cache-redis-driver.php`, `class-aips-cache-wp-object-cache-driver.php`) and all returned no syntax errors. 
- No unit tests were added or run in this change set; full test-suite runs (e.g. `composer test`) were not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a5d4a4e108321877ba91cfca4a2b2)