### PR TITLE
Add high-frequency composite indexes in DB schema definitions

### DIFF
--- a/ai-post-scheduler/includes/class-aips-db-manager.php
+++ b/ai-post-scheduler/includes/class-aips-db-manager.php
@@ -179,6 +179,7 @@ class AIPS_DB_Manager {
             KEY article_structure_id (article_structure_id),
             KEY next_run (next_run),
             KEY is_active_next_run (is_active, next_run),
+            KEY template_active_next_run (template_id, is_active, next_run),
             KEY status (status),
             KEY schedule_history_id (schedule_history_id),
             KEY schedule_type (schedule_type),
@@ -423,7 +424,9 @@ class AIPS_DB_Manager {
             PRIMARY KEY  (id),
             UNIQUE KEY source_content_hash (source_id, content_hash),
             KEY source_id (source_id),
+            KEY source_id_id (source_id, id),
             KEY fetch_status (fetch_status),
+            KEY source_id_fetch_status_id (source_id, fetch_status, id),
             KEY fetched_at (fetched_at),
             KEY num_used (num_used)
         ) $charset_collate;";
@@ -469,6 +472,8 @@ class AIPS_DB_Manager {
             KEY source_post_id (source_post_id),
             KEY target_post_id (target_post_id),
             KEY status (status),
+            KEY status_created_at (status, created_at),
+            KEY status_updated_at (status, updated_at),
             KEY similarity_score (similarity_score),
             UNIQUE KEY source_target (source_post_id, target_post_id)
         ) $charset_collate;";


### PR DESCRIPTION
### Motivation
- Improve DB performance for high-frequency query patterns by adding composite indexes to schedule, sources_data, and internal_links tables to better support template-centric scheduling, source-scoped scanning/pagination, and link status/reporting queries. 
- Confirm that existing notification and schedule indexes already cover some requested patterns so no duplicate keys are introduced. 

### Description
- Added `template_active_next_run (template_id, is_active, next_run)` to `aips_schedule` to optimize template-centric lookups for active schedules due to run. 
- Added `source_id_id (source_id, id)` and `source_id_fetch_status_id (source_id, fetch_status, id)` to `aips_sources_data` to support efficient source-scoped scans and pagination by `id`. 
- Added `status_created_at (status, created_at)` and `status_updated_at (status, updated_at)` to `aips_internal_links` to support status/reporting queries while preserving the existing `UNIQUE KEY source_target (source_post_id, target_post_id)` for pair lookups. 
- Verified notifications already include `is_read_created_at (is_read, created_at)` and `dedupe_key_created_at (dedupe_key, created_at)` so no changes were made to `aips_notifications`. 
- Ensured index naming and definition style follow the repository convention (`KEY <name> (...)`) to remain compatible with `dbDelta` behavior. 
- Implementation location: `ai-post-scheduler/includes/class-aips-db-manager.php` and changes are applied via the existing upgrade path that calls `AIPS_DB_Migrations::check_and_run()` which in turn runs `AIPS_DB_Manager::install_tables()` (dbDelta) on upgrades. 

### Testing
- Attempted to check open PRs with `gh pr list`, but the environment does not have the GitHub CLI available (`gh: command not found`) so the pre-change PR check could not be performed. 
- Ran a PHP syntax check with `php -l ai-post-scheduler/includes/class-aips-db-manager.php` which succeeded with no syntax errors. 
- Confirmed that `AIPS_DB_Migrations::check_and_run()` invokes `AIPS_DB_Manager::install_tables()` (dbDelta) so the new index definitions will be applied during the normal upgrade flow and are idempotent; no further automated schema migration script was required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a5d5a691c8321a0b96e7c0fe4e886)