### PR TITLE
Atlas: Refactored History Repository Stats

### DIFF
--- a/.build/atlas-journal.md
+++ b/.build/atlas-journal.md
@@ -1438,3 +1438,9 @@ This refactoring resolves the "unexpected title prompts" issue by eliminating du
 **Decision:** Extracted post-execution cleanup, failure logging, success logging, and history container logic into a dedicated `AIPS_Schedule_Result_Handler` class.
 **Consequence:** `AIPS_Schedule_Processor` is now strictly focused on the execution logic. Reduced the class size significantly and decoupled the specific handling of success and error states.
 **Tests:** Created `test-schedule-result-handler.php` to verify result handling. Test execution skipped per user request.
+
+## 2026-05-18 - [Extract History Stats Repository]
+**Context:** The `AIPS_History_Repository` had grown into a God Object (~1360 lines), mixing regular CRUD operations for the history table with complex analytical and statistical queries.
+**Decision:** Extracted all analytical and statistical methods (e.g., `get_estimated_generation_time`, `get_stats`, `get_daily_success_failure_trend`) into a dedicated `AIPS_History_Stats_Repository`. Instantiated the new stats repository within `AIPS_History_Repository` and converted the original methods into proxies to preserve backward compatibility.
+**Consequence:** High cohesion and loose coupling achieved. `AIPS_History_Repository` is now focused purely on standard data access and delegates analytics to `AIPS_History_Stats_Repository`. This creates a slight overhead of instantiating the helper class but maintains 100% backward compatibility.
+**Tests:** Ran existing autoloader test suite after adding `AIPS_History_Stats_Repository`. Verified the file syntax.

--- a/ai-post-scheduler/includes/class-aips-history-repository.php
+++ b/ai-post-scheduler/includes/class-aips-history-repository.php
@@ -49,6 +49,11 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
      * @var wpdb WordPress database abstraction object
      */
     private $wpdb;
+
+    /**
+     * @var AIPS_History_Stats_Repository
+     */
+    private $stats_repository;
     
     /**
      * Initialize the repository.
@@ -59,6 +64,12 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
         $this->table_name = $wpdb->prefix . 'aips_history';
         $this->table_name_log = $wpdb->prefix . 'aips_history_log';
         $this->schedule_table = $wpdb->prefix . 'aips_schedule';
+
+        $this->stats_repository = new AIPS_History_Stats_Repository(
+            $this->wpdb,
+            $this->table_name,
+            $this->table_name_log
+        );
     }
 
     /**
@@ -131,43 +142,49 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
         delete_transient('aips_schedule_completed_count_' . absint($schedule_id));
     }
 
+    /**
+     * Get the daily success and failure trend.
+     * Proxy method for backward compatibility.
+     *
+     * @param int $days Number of days to include.
+     * @return array
+     */
     public function get_daily_success_failure_trend($days = 14) {
-        $days = max(1, absint($days));
-
-        return $this->wpdb->get_results($this->wpdb->prepare(
-            "SELECT DATE(FROM_UNIXTIME(created_at)) AS metric_date, SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS success_count, SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failure_count FROM {$this->table_name} WHERE created_at >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY metric_date ORDER BY metric_date ASC",
-            $days
-        ), ARRAY_A);
+        return $this->stats_repository->get_daily_success_failure_trend($days);
     }
 
+    /**
+     * Get the average duration grouped by flow type.
+     * Proxy method for backward compatibility.
+     *
+     * @param int $days Number of days to include.
+     * @return array
+     */
     public function get_average_duration_by_flow($days = 14) {
-        $days = max(1, absint($days));
-
-        return $this->wpdb->get_results($this->wpdb->prepare(
-            "SELECT COALESCE(NULLIF(creation_method, ''), 'unknown') AS flow_type, AVG(completed_at - created_at) AS avg_duration_seconds, COUNT(*) AS sample_count FROM {$this->table_name} WHERE completed_at IS NOT NULL AND created_at >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY flow_type ORDER BY avg_duration_seconds DESC",
-            $days
-        ), ARRAY_A);
+        return $this->stats_repository->get_average_duration_by_flow($days);
     }
 
+    /**
+     * Get retry counts grouped by service.
+     * Proxy method for backward compatibility.
+     *
+     * @param int $days Number of days to include.
+     * @return array
+     */
     public function get_retry_counts_by_service($days = 14) {
-        $days = max(1, absint($days));
-
-        return $this->wpdb->get_results($this->wpdb->prepare(
-            "SELECT COALESCE(NULLIF(JSON_UNQUOTE(JSON_EXTRACT(details, '$.context')), ''), 'unknown') AS service_key, COUNT(*) AS retry_count FROM {$this->table_name_log} WHERE log_type = %s AND timestamp >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY service_key ORDER BY retry_count DESC",
-            'retry',
-            $days
-        ), ARRAY_A);
+        return $this->stats_repository->get_retry_counts_by_service($days);
     }
 
+    /**
+     * Get top failure reasons.
+     * Proxy method for backward compatibility.
+     *
+     * @param int $days  Number of days to include.
+     * @param int $limit Number of reasons to return.
+     * @return array
+     */
     public function get_top_failure_reasons($days = 14, $limit = 8) {
-        $days = max(1, absint($days));
-        $limit = max(1, absint($limit));
-
-        return $this->wpdb->get_results($this->wpdb->prepare(
-            "SELECT COALESCE(NULLIF(TRIM(error_message), ''), 'Unknown failure') AS reason, COUNT(*) AS failure_count FROM {$this->table_name} WHERE status = 'failed' AND created_at >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY reason ORDER BY failure_count DESC LIMIT %d",
-            $days,
-            $limit
-        ), ARRAY_A);
+        return $this->stats_repository->get_top_failure_reasons($days, $limit);
     }
     
     /**
@@ -654,85 +671,29 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
      *     @type int $per_post_seconds Estimated seconds per post.
      *     @type int $sample_size      Number of valid samples used for the estimate.
      * }
+     *
+     * Proxy method for backward compatibility.
+     *
+     * @param int $limit Number of rows to sample.
+     * @return array
      */
     public function get_estimated_generation_time($limit = 20) {
-        $default_seconds = 30;
-        $limit           = absint($limit);
-
-        // Retrieve the most recent recorded generation times.
-        $times = $this->wpdb->get_col(
-            $this->wpdb->prepare(
-                "SELECT meta_value FROM {$this->wpdb->postmeta}
-                 WHERE meta_key = %s
-                 ORDER BY meta_id DESC
-                 LIMIT %d",
-                '_aips_post_generation_total_time',
-                $limit
-            )
-        );
-
-        if (!empty($times)) {
-            $numeric_times = array_filter(array_map('floatval', $times), function($v) {
-                return $v > 0;
-            });
-
-            if (!empty($numeric_times)) {
-                $avg              = array_sum($numeric_times) / count($numeric_times);
-                $per_post_seconds = (int) ceil($avg);
-            } else {
-                $per_post_seconds = $default_seconds;
-            }
-
-            $sample_size = count($numeric_times);
-        } else {
-            $per_post_seconds = $default_seconds;
-            $sample_size      = 0;
-        }
-
-        return array(
-            'per_post_seconds' => $per_post_seconds,
-            'sample_size'      => $sample_size,
-        );
+        return $this->stats_repository->get_estimated_generation_time($limit);
     }
 
+    /**
+     * Get general generation statistics.
+     * Proxy method for backward compatibility.
+     *
+     * @return array
+     */
     public function get_stats() {
-        $cached_stats = get_transient('aips_history_stats');
-
-        if ($cached_stats !== false) {
-            return $cached_stats;
-        }
-
-        $results = $this->wpdb->get_row("
-            SELECT
-                COUNT(*) as total,
-                SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as completed,
-                SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) as failed,
-                SUM(CASE WHEN status = 'processing' THEN 1 ELSE 0 END) as processing,
-                SUM(CASE WHEN status = 'partial' THEN 1 ELSE 0 END) as partial
-            FROM {$this->table_name}
-            WHERE COALESCE(creation_method, '') <> 'schedule_lifecycle'
-                AND NOT (creation_method IS NULL AND template_id IS NULL AND topic_id IS NULL AND post_id IS NULL AND author_id IS NULL)
-        ");
-
-        $stats = array(
-            'total' => isset($results->total) ? (int) $results->total : 0,
-            'completed' => isset($results->completed) ? (int) $results->completed : 0,
-            'failed' => isset($results->failed) ? (int) $results->failed : 0,
-            'processing' => isset($results->processing) ? (int) $results->processing : 0,
-            'partial' => isset($results->partial) ? (int) $results->partial : 0,
-        );
-        
-        $stats['success_rate'] = $stats['total'] > 0 
-            ? round(($stats['completed'] / $stats['total']) * 100, 1) 
-            : 0;
-
-        set_transient('aips_history_stats', $stats, HOUR_IN_SECONDS);
-        
-        return $stats;
+        return $this->stats_repository->get_stats();
     }
 
     /**
      * Get per-day generation counts for the last N days.
+     * Proxy method for backward compatibility.
      *
      * Returns an array keyed by ISO date string (Y-m-d) where each value is an
      * associative array with 'completed', 'failed', and 'total' counts.
@@ -745,74 +706,33 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
      * @return array<string, array{completed: int, failed: int, total: int}>
      */
     public function get_daily_generation_counts( $days = 14 ) {
-        $days  = max( 1, absint( $days ) );
-        $start = wp_date( 'Y-m-d', current_time( 'timestamp', true ) - ( ( $days - 1 ) * DAY_IN_SECONDS ), wp_timezone() );
-
-        $results = $this->wpdb->get_results(
-            $this->wpdb->prepare(
-                "SELECT
-                    DATE(created_at) AS day,
-                    SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS completed,
-                    SUM(CASE WHEN status = 'failed'    THEN 1 ELSE 0 END) AS failed,
-                    COUNT(*) AS total
-                 FROM {$this->table_name}
-                 WHERE created_at >= %s
-                   AND COALESCE(creation_method, '') <> 'schedule_lifecycle'
-                   AND NOT (creation_method IS NULL AND template_id IS NULL AND topic_id IS NULL AND post_id IS NULL AND author_id IS NULL)
-                 GROUP BY DATE(created_at)
-                 ORDER BY day ASC",
-                $start
-            )
-        );
-
-        $data = array();
-        foreach ( $results as $row ) {
-            $data[ $row->day ] = array(
-                'completed' => (int) $row->completed,
-                'failed'    => (int) $row->failed,
-                'total'     => (int) $row->total,
-            );
-        }
-
-        return $data;
+        return $this->stats_repository->get_daily_generation_counts($days);
     }
 
     /**
      * Get statistics for a specific template.
+     * Proxy method for backward compatibility.
      *
      * @param int $template_id Template ID.
      * @return int Number of completed posts for this template.
      */
     public function get_template_stats($template_id) {
-        return (int) $this->wpdb->get_var($this->wpdb->prepare(
-            "SELECT COUNT(*) FROM {$this->table_name} WHERE template_id = %d AND status = 'completed'",
-            $template_id
-        ));
+        return $this->stats_repository->get_template_stats($template_id);
     }
 
     /**
      * Get statistics for all templates.
+     * Proxy method for backward compatibility.
      *
      * @return array Associative array of template ID => count.
      */
     public function get_all_template_stats() {
-        $results = $this->wpdb->get_results("
-            SELECT template_id, COUNT(*) as count
-            FROM {$this->table_name}
-            WHERE status = 'completed'
-            GROUP BY template_id
-        ");
-
-        $stats = array();
-        foreach ($results as $row) {
-            $stats[$row->template_id] = (int) $row->count;
-        }
-
-        return $stats;
+        return $this->stats_repository->get_all_template_stats();
     }
 
     /**
      * Get generated-post counts for schedule history containers.
+     * Proxy method for backward compatibility.
      *
      * Counts activity/error logs that represent a generated post event.
      * The key is history_id (schedule_history_id on schedules table).
@@ -821,43 +741,7 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
      * @return array Associative array of history_id => generated count.
      */
     public function get_schedule_generated_post_counts($history_ids) {
-        $history_ids = array_map('absint', (array) $history_ids);
-        $history_ids = array_filter($history_ids);
-
-        if (empty($history_ids)) {
-            return array();
-        }
-
-        $placeholders = implode(',', array_fill(0, count($history_ids), '%d'));
-
-        $sql = "
-            SELECT history_id, COUNT(*) AS count
-            FROM {$this->table_name_log}
-            WHERE history_id IN ({$placeholders})
-                AND history_type_id IN (%d, %d)
-                AND (
-                    details LIKE %s
-                    OR details LIKE %s
-                    OR details LIKE %s
-                )
-            GROUP BY history_id
-        ";
-
-        $args = $history_ids;
-        $args[] = AIPS_History_Type::ACTIVITY;
-        $args[] = AIPS_History_Type::ERROR;
-        $args[] = '%"event_type":"post_published"%';
-        $args[] = '%"event_type":"post_draft"%';
-        $args[] = '%"event_type":"manual_schedule_completed"%';
-
-        $results = $this->wpdb->get_results($this->wpdb->prepare($sql, $args));
-
-        $counts = array();
-        foreach ($results as $row) {
-            $counts[(int) $row->history_id] = (int) $row->count;
-        }
-
-        return $counts;
+        return $this->stats_repository->get_schedule_generated_post_counts($history_ids);
     }
 
     /**

--- a/ai-post-scheduler/includes/class-aips-history-stats-repository.php
+++ b/ai-post-scheduler/includes/class-aips-history-stats-repository.php
@@ -1,0 +1,331 @@
+<?php
+/**
+ * History Stats Repository
+ *
+ * Handles analytical queries and stats methods for generation history.
+ * Extracted from AIPS_History_Repository to maintain Separation of Concerns.
+ *
+ * @package AI_Post_Scheduler
+ * @since 2.5.0
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Class AIPS_History_Stats_Repository
+ *
+ * Encapsulates analytical queries for the history system.
+ */
+class AIPS_History_Stats_Repository {
+
+    /**
+     * @var wpdb WordPress database abstraction object
+     */
+    private $wpdb;
+
+    /**
+     * @var string The history table name (with prefix)
+     */
+    private $table_name;
+
+    /**
+     * @var string The history log table name (with prefix)
+     */
+    private $table_name_log;
+
+    /**
+     * Initialize the stats repository.
+     *
+     * @param wpdb   $wpdb       Database abstraction object.
+     * @param string $table_name Main history table name.
+     * @param string $table_log  History log table name.
+     */
+    public function __construct($wpdb, $table_name, $table_log) {
+        $this->wpdb           = $wpdb;
+        $this->table_name     = $table_name;
+        $this->table_name_log = $table_log;
+    }
+
+    /**
+     * Get the daily success and failure trend.
+     *
+     * @param int $days Number of days to include.
+     * @return array
+     */
+    public function get_daily_success_failure_trend($days = 14) {
+        $days = max(1, absint($days));
+
+        return $this->wpdb->get_results($this->wpdb->prepare(
+            "SELECT DATE(FROM_UNIXTIME(created_at)) AS metric_date, SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS success_count, SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failure_count FROM {$this->table_name} WHERE created_at >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY metric_date ORDER BY metric_date ASC",
+            $days
+        ), ARRAY_A);
+    }
+
+    /**
+     * Get the average duration grouped by flow type.
+     *
+     * @param int $days Number of days to include.
+     * @return array
+     */
+    public function get_average_duration_by_flow($days = 14) {
+        $days = max(1, absint($days));
+
+        return $this->wpdb->get_results($this->wpdb->prepare(
+            "SELECT COALESCE(NULLIF(creation_method, ''), 'unknown') AS flow_type, AVG(completed_at - created_at) AS avg_duration_seconds, COUNT(*) AS sample_count FROM {$this->table_name} WHERE completed_at IS NOT NULL AND created_at >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY flow_type ORDER BY avg_duration_seconds DESC",
+            $days
+        ), ARRAY_A);
+    }
+
+    /**
+     * Get retry counts grouped by service.
+     *
+     * @param int $days Number of days to include.
+     * @return array
+     */
+    public function get_retry_counts_by_service($days = 14) {
+        $days = max(1, absint($days));
+
+        return $this->wpdb->get_results($this->wpdb->prepare(
+            "SELECT COALESCE(NULLIF(JSON_UNQUOTE(JSON_EXTRACT(details, '$.context')), ''), 'unknown') AS service_key, COUNT(*) AS retry_count FROM {$this->table_name_log} WHERE log_type = %s AND timestamp >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY service_key ORDER BY retry_count DESC",
+            'retry',
+            $days
+        ), ARRAY_A);
+    }
+
+    /**
+     * Get top failure reasons.
+     *
+     * @param int $days  Number of days to include.
+     * @param int $limit Number of reasons to return.
+     * @return array
+     */
+    public function get_top_failure_reasons($days = 14, $limit = 8) {
+        $days = max(1, absint($days));
+        $limit = max(1, absint($limit));
+
+        return $this->wpdb->get_results($this->wpdb->prepare(
+            "SELECT COALESCE(NULLIF(TRIM(error_message), ''), 'Unknown failure') AS reason, COUNT(*) AS failure_count FROM {$this->table_name} WHERE status = 'failed' AND created_at >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY reason ORDER BY failure_count DESC LIMIT %d",
+            $days,
+            $limit
+        ), ARRAY_A);
+    }
+
+    /**
+     * Return estimated generation timing stats.
+     *
+     * @param int $limit Number of rows to sample.
+     * @return array
+     */
+    public function get_estimated_generation_time($limit = 20) {
+        $default_seconds = 30;
+        $limit           = absint($limit);
+
+        // Retrieve the most recent recorded generation times.
+        $times = $this->wpdb->get_col(
+            $this->wpdb->prepare(
+                "SELECT meta_value FROM {$this->wpdb->postmeta}
+                 WHERE meta_key = %s
+                 ORDER BY meta_id DESC
+                 LIMIT %d",
+                '_aips_post_generation_total_time',
+                $limit
+            )
+        );
+
+        if (!empty($times)) {
+            $numeric_times = array_filter(array_map('floatval', $times), function($v) {
+                return $v > 0;
+            });
+
+            if (!empty($numeric_times)) {
+                $avg              = array_sum($numeric_times) / count($numeric_times);
+                $per_post_seconds = (int) ceil($avg);
+            } else {
+                $per_post_seconds = $default_seconds;
+            }
+
+            $sample_size = count($numeric_times);
+        } else {
+            $per_post_seconds = $default_seconds;
+            $sample_size      = 0;
+        }
+
+        return array(
+            'per_post_seconds' => $per_post_seconds,
+            'sample_size'      => $sample_size,
+        );
+    }
+
+    /**
+     * Get general generation statistics.
+     *
+     * @return array
+     */
+    public function get_stats() {
+        $cached_stats = get_transient('aips_history_stats');
+
+        if ($cached_stats !== false) {
+            return $cached_stats;
+        }
+
+        $results = $this->wpdb->get_row("
+            SELECT
+                COUNT(*) as total,
+                SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as completed,
+                SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) as failed,
+                SUM(CASE WHEN status = 'processing' THEN 1 ELSE 0 END) as processing,
+                SUM(CASE WHEN status = 'partial' THEN 1 ELSE 0 END) as partial
+            FROM {$this->table_name}
+            WHERE COALESCE(creation_method, '') <> 'schedule_lifecycle'
+                AND NOT (creation_method IS NULL AND template_id IS NULL AND topic_id IS NULL AND post_id IS NULL AND author_id IS NULL)
+        ");
+
+        $stats = array(
+            'total' => isset($results->total) ? (int) $results->total : 0,
+            'completed' => isset($results->completed) ? (int) $results->completed : 0,
+            'failed' => isset($results->failed) ? (int) $results->failed : 0,
+            'processing' => isset($results->processing) ? (int) $results->processing : 0,
+            'partial' => isset($results->partial) ? (int) $results->partial : 0,
+        );
+
+        $stats['success_rate'] = $stats['total'] > 0
+            ? round(($stats['completed'] / $stats['total']) * 100, 1)
+            : 0;
+
+        set_transient('aips_history_stats', $stats, HOUR_IN_SECONDS);
+
+        return $stats;
+    }
+
+    /**
+     * Get per-day generation counts for the last N days.
+     *
+     * Returns an array keyed by ISO date string (Y-m-d) where each value is an
+     * associative array with 'completed', 'failed', and 'total' counts.
+     * Days with no records are omitted; callers should fill gaps as needed.
+     *
+     * Applies the same row-exclusion filters as get_stats() so that
+     * schedule-lifecycle rows and empty-shell records are not counted.
+     *
+     * @param int $days Number of calendar days to look back (inclusive today). Default 14.
+     * @return array<string, array{completed: int, failed: int, total: int}>
+     */
+    public function get_daily_generation_counts( $days = 14 ) {
+        $days  = max( 1, absint( $days ) );
+        $start = wp_date( 'Y-m-d', current_time( 'timestamp', true ) - ( ( $days - 1 ) * DAY_IN_SECONDS ), wp_timezone() );
+
+        $results = $this->wpdb->get_results(
+            $this->wpdb->prepare(
+                "SELECT
+                    DATE(created_at) AS day,
+                    SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS completed,
+                    SUM(CASE WHEN status = 'failed'    THEN 1 ELSE 0 END) AS failed,
+                    COUNT(*) AS total
+                 FROM {$this->table_name}
+                 WHERE created_at >= %s
+                   AND COALESCE(creation_method, '') <> 'schedule_lifecycle'
+                   AND NOT (creation_method IS NULL AND template_id IS NULL AND topic_id IS NULL AND post_id IS NULL AND author_id IS NULL)
+                 GROUP BY DATE(created_at)
+                 ORDER BY day ASC",
+                $start
+            )
+        );
+
+        $data = array();
+        foreach ( $results as $row ) {
+            $data[ $row->day ] = array(
+                'completed' => (int) $row->completed,
+                'failed'    => (int) $row->failed,
+                'total'     => (int) $row->total,
+            );
+        }
+
+        return $data;
+    }
+
+    /**
+     * Get statistics for a specific template.
+     *
+     * @param int $template_id Template ID.
+     * @return int Number of completed posts for this template.
+     */
+    public function get_template_stats($template_id) {
+        return (int) $this->wpdb->get_var($this->wpdb->prepare(
+            "SELECT COUNT(*) FROM {$this->table_name} WHERE template_id = %d AND status = 'completed'",
+            $template_id
+        ));
+    }
+
+    /**
+     * Get statistics for all templates.
+     *
+     * @return array Associative array of template ID => count.
+     */
+    public function get_all_template_stats() {
+        $results = $this->wpdb->get_results("
+            SELECT template_id, COUNT(*) as count
+            FROM {$this->table_name}
+            WHERE status = 'completed'
+            GROUP BY template_id
+        ");
+
+        $stats = array();
+        foreach ($results as $row) {
+            $stats[$row->template_id] = (int) $row->count;
+        }
+
+        return $stats;
+    }
+
+    /**
+     * Get generated-post counts for schedule history containers.
+     *
+     * Counts activity/error logs that represent a generated post event.
+     * The key is history_id (schedule_history_id on schedules table).
+     *
+     * @param array $history_ids History container IDs.
+     * @return array Associative array of history_id => generated count.
+     */
+    public function get_schedule_generated_post_counts($history_ids) {
+        $history_ids = array_map('absint', (array) $history_ids);
+        $history_ids = array_filter($history_ids);
+
+        if (empty($history_ids)) {
+            return array();
+        }
+
+        $placeholders = implode(',', array_fill(0, count($history_ids), '%d'));
+
+        $sql = "
+            SELECT history_id, COUNT(*) AS count
+            FROM {$this->table_name_log}
+            WHERE history_id IN ({$placeholders})
+                AND history_type_id IN (%d, %d)
+                AND (
+                    details LIKE %s
+                    OR details LIKE %s
+                    OR details LIKE %s
+                )
+            GROUP BY history_id
+        ";
+
+        $args = $history_ids;
+        $args[] = AIPS_History_Type::ACTIVITY;
+        $args[] = AIPS_History_Type::ERROR;
+        $args[] = '%"event_type":"post_published"%';
+        $args[] = '%"event_type":"post_draft"%';
+        $args[] = '%"event_type":"manual_schedule_completed"%';
+
+        $results = $this->wpdb->get_results($this->wpdb->prepare($sql, $args));
+
+        $counts = array();
+        foreach ($results as $row) {
+            $counts[(int) $row->history_id] = (int) $row->count;
+        }
+
+        return $counts;
+    }
+
+}

--- a/ai-post-scheduler/tests/AIPS_Autoloader_Test.php
+++ b/ai-post-scheduler/tests/AIPS_Autoloader_Test.php
@@ -78,6 +78,7 @@ class AIPS_Autoloader_Test extends WP_UnitTestCase {
 	public function test_autoloader_converts_class_names_correctly() {
 		$test_cases = array(
 			'AIPS_History_Repository' => 'class-aips-history-repository.php',
+			'AIPS_History_Stats_Repository' => 'class-aips-history-stats-repository.php',
 			'AIPS_Template_Processor' => 'class-aips-template-processor.php',
 			'AIPS_AI_Service' => 'class-aips-ai-service.php',
 			'AIPS_Config' => 'class-aips-config.php',
@@ -171,6 +172,7 @@ class AIPS_Autoloader_Test extends WP_UnitTestCase {
 	public function test_autoloader_loads_repository_classes() {
 		$repositories = array(
 			'AIPS_History_Repository',
+			'AIPS_History_Stats_Repository',
 			'AIPS_Schedule_Repository',
 			'AIPS_Template_Repository',
 		);

--- a/ai-post-scheduler/tests/Test_AIPS_History_Stats_Repository.php
+++ b/ai-post-scheduler/tests/Test_AIPS_History_Stats_Repository.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Tests for AIPS_History_Stats_Repository.
+ */
+require_once dirname(dirname(__FILE__)) . "/includes/class-aips-history-stats-repository.php";
+
+// Simple mock for wpdb
+if (!class_exists('wpdb')) {
+	class wpdb {
+		public $prefix = 'wp_';
+		public $postmeta = 'wp_postmeta';
+		public function prepare($query, ...$args) { return $query; }
+		public function get_results($query, $output = 'OBJECT') { return []; }
+		public function get_col($query, $x = 0) { return []; }
+		public function get_row($query, $output = 'OBJECT', $y = 0) { return null; }
+		public function get_var($query, $x = 0, $y = 0) { return null; }
+	}
+}
+
+class Test_AIPS_History_Stats_Repository extends WP_UnitTestCase {
+
+	private $wpdb_mock;
+	private $repository;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->wpdb_mock = $this->createMock(wpdb::class);
+		$this->repository = new AIPS_History_Stats_Repository(
+			$this->wpdb_mock,
+			'wp_aips_history',
+			'wp_aips_history_log'
+		);
+	}
+
+	public function test_get_daily_success_failure_trend() {
+		$this->wpdb_mock->method('prepare')->willReturn('prepared_query');
+		$this->wpdb_mock->expects($this->once())
+			->method('get_results')
+			->with('prepared_query', ARRAY_A)
+			->willReturn([['metric_date' => '2023-01-01', 'success_count' => 10, 'failure_count' => 2]]);
+
+		$result = $this->repository->get_daily_success_failure_trend(14);
+		$this->assertIsArray($result);
+		$this->assertCount(1, $result);
+		$this->assertEquals(10, $result[0]['success_count']);
+	}
+
+	public function test_get_average_duration_by_flow() {
+		$this->wpdb_mock->method('prepare')->willReturn('prepared_query');
+		$this->wpdb_mock->expects($this->once())
+			->method('get_results')
+			->with('prepared_query', ARRAY_A)
+			->willReturn([['flow_type' => 'manual', 'avg_duration_seconds' => 30.5, 'sample_count' => 5]]);
+
+		$result = $this->repository->get_average_duration_by_flow(14);
+		$this->assertIsArray($result);
+		$this->assertEquals('manual', $result[0]['flow_type']);
+	}
+
+	public function test_get_retry_counts_by_service() {
+		$this->wpdb_mock->method('prepare')->willReturn('prepared_query');
+		$this->wpdb_mock->expects($this->once())
+			->method('get_results')
+			->with('prepared_query', ARRAY_A)
+			->willReturn([['service_key' => 'openai', 'retry_count' => 3]]);
+
+		$result = $this->repository->get_retry_counts_by_service(14);
+		$this->assertIsArray($result);
+		$this->assertEquals('openai', $result[0]['service_key']);
+	}
+
+	public function test_get_top_failure_reasons() {
+		$this->wpdb_mock->method('prepare')->willReturn('prepared_query');
+		$this->wpdb_mock->expects($this->once())
+			->method('get_results')
+			->with('prepared_query', ARRAY_A)
+			->willReturn([['reason' => 'Timeout', 'failure_count' => 10]]);
+
+		$result = $this->repository->get_top_failure_reasons(14, 8);
+		$this->assertIsArray($result);
+		$this->assertEquals('Timeout', $result[0]['reason']);
+	}
+
+	public function test_get_estimated_generation_time_with_no_data() {
+		// wpdb->postmeta property is accessed
+		$this->wpdb_mock->postmeta = 'wp_postmeta';
+		$this->wpdb_mock->method('prepare')->willReturn('prepared_query');
+		$this->wpdb_mock->expects($this->once())
+			->method('get_col')
+			->with('prepared_query')
+			->willReturn([]);
+
+		$result = $this->repository->get_estimated_generation_time(20);
+		$this->assertIsArray($result);
+		$this->assertEquals(30, $result['per_post_seconds']);
+		$this->assertEquals(0, $result['sample_size']);
+	}
+
+	public function test_get_estimated_generation_time_with_data() {
+		$this->wpdb_mock->postmeta = 'wp_postmeta';
+		$this->wpdb_mock->method('prepare')->willReturn('prepared_query');
+		$this->wpdb_mock->expects($this->once())
+			->method('get_col')
+			->with('prepared_query')
+			->willReturn(['15', '25', '20']);
+
+		$result = $this->repository->get_estimated_generation_time(20);
+		$this->assertIsArray($result);
+		$this->assertEquals(20, $result['per_post_seconds']);
+		$this->assertEquals(3, $result['sample_size']);
+	}
+
+	public function test_get_stats_without_cache() {
+		$mock_row = (object)[
+			'total' => 100,
+			'completed' => 90,
+			'failed' => 5,
+			'processing' => 3,
+			'partial' => 2
+		];
+
+		$this->wpdb_mock->expects($this->once())
+			->method('get_row')
+			->willReturn($mock_row);
+
+		$result = $this->repository->get_stats();
+
+		$this->assertIsArray($result);
+		$this->assertEquals(100, $result['total']);
+		$this->assertEquals(90.0, $result['success_rate']);
+	}
+
+	public function test_get_template_stats() {
+		$this->wpdb_mock->method('prepare')->willReturn('prepared_query');
+		$this->wpdb_mock->expects($this->once())
+			->method('get_var')
+			->with('prepared_query')
+			->willReturn(42);
+
+		$result = $this->repository->get_template_stats(1);
+		$this->assertEquals(42, $result);
+	}
+
+	public function test_get_all_template_stats() {
+		$this->wpdb_mock->expects($this->once())
+			->method('get_results')
+			->willReturn([
+				(object)['template_id' => 1, 'count' => 10],
+				(object)['template_id' => 2, 'count' => 20]
+			]);
+
+		$result = $this->repository->get_all_template_stats();
+		$this->assertIsArray($result);
+		$this->assertEquals(10, $result[1]);
+		$this->assertEquals(20, $result[2]);
+	}
+
+	public function test_get_schedule_generated_post_counts_empty() {
+		$result = $this->repository->get_schedule_generated_post_counts([]);
+		$this->assertIsArray($result);
+		$this->assertEmpty($result);
+	}
+
+	public function test_get_schedule_generated_post_counts_with_data() {
+		$this->wpdb_mock->method('prepare')->willReturn('prepared_query');
+		$this->wpdb_mock->expects($this->once())
+			->method('get_results')
+			->with('prepared_query')
+			->willReturn([
+				(object)['history_id' => 10, 'count' => 5],
+				(object)['history_id' => 20, 'count' => 8]
+			]);
+
+		$result = $this->repository->get_schedule_generated_post_counts([10, 20]);
+		$this->assertIsArray($result);
+		$this->assertEquals(5, $result[10]);
+		$this->assertEquals(8, $result[20]);
+	}
+}


### PR DESCRIPTION
**Tangle:**
The `AIPS_History_Repository` had grown into a massive "God Object" (1360+ lines), handling both regular database CRUD operations and highly complex analytical/statistical queries, thereby violating the Single Responsibility Principle.

**Detangle:**
Extracted all analytical queries (e.g., `get_estimated_generation_time`, `get_stats`, `get_daily_success_failure_trend`) into a dedicated `AIPS_History_Stats_Repository` class. I injected this new class into the `AIPS_History_Repository` constructor. The original methods in `AIPS_History_Repository` have been retained as proxy methods to ensure 100% backward compatibility, and have been explicitly documented with DocBlocks. Additionally, I added unit tests to approach better code coverage.

**Journal:**
Appended the decision to `.build/atlas-journal.md`.

**Tests:**
Ran the autoloader tests, created new unit tests for `AIPS_History_Stats_Repository`, and validated file syntax to ensure no regressions.

---
*PR created automatically by Jules for task [17958541262518112970](https://jules.google.com/task/17958541262518112970) started by @rpnunez*