### PR TITLE
Add admin utility classes, replace high-impact inline styles, and add inline-style QA guard

### DIFF
--- a/ai-post-scheduler/assets/css/admin.css
+++ b/ai-post-scheduler/assets/css/admin.css
@@ -3976,3 +3976,25 @@ float: none;
 .aips-ai-engine-download-wrap {
 margin-top: 10px;
 }
+
+/* ==========================================================================
+   Utility classes (admin templates)
+   ========================================================================== */
+.is-hidden { display: none !important; }
+.is-flex { display: flex !important; }
+.aips-display-block { display: block !important; }
+.aips-flex { display: flex; }
+.aips-items-center { align-items: center; }
+.aips-gap-1 { gap: var(--aips-space-1); }
+.aips-gap-2 { gap: var(--aips-space-2); }
+.aips-gap-3 { gap: var(--aips-space-3); }
+.aips-gap-4 { gap: var(--aips-space-4); }
+.aips-mt-2 { margin-top: var(--aips-space-2); }
+.aips-mb-1 { margin-bottom: var(--aips-space-1); }
+.aips-mb-4 { margin-bottom: var(--aips-space-4); }
+.aips-w-auto { width: auto; }
+.aips-text-xs { font-size: var(--aips-text-xs); }
+.aips-text-sm { font-size: var(--aips-text-sm); }
+.aips-font-semibold { font-weight: var(--aips-font-semibold); }
+.aips-font-bold { font-weight: var(--aips-font-bold); }
+.aips-spinner-reset { float: none; margin: 0; }

--- a/ai-post-scheduler/composer.json
+++ b/ai-post-scheduler/composer.json
@@ -30,7 +30,8 @@
   "scripts": {
     "test": "vendor/bin/phpunit",
     "test:coverage": "vendor/bin/phpunit --coverage-html coverage",
-    "test:verbose": "vendor/bin/phpunit --verbose"
+    "test:verbose": "vendor/bin/phpunit --verbose",
+    "qa:inline-styles": "bash scripts/check-inline-styles.sh"
   },
   "config": {
     "allow-plugins": {

--- a/ai-post-scheduler/scripts/check-inline-styles.sh
+++ b/ai-post-scheduler/scripts/check-inline-styles.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+added_lines="$(git diff --unified=0 -- templates/admin/*.php | rg '^\+[^+].*style="' || true)"
+if [ -n "$added_lines" ]; then
+  echo "New inline style attributes were introduced in templates/admin/*.php:" 
+  echo "$added_lines"
+  exit 1
+fi
+
+echo "No new inline style attributes introduced in templates/admin/*.php"

--- a/ai-post-scheduler/templates/admin/authors.php
+++ b/ai-post-scheduler/templates/admin/authors.php
@@ -69,7 +69,7 @@ $site_ctx = AIPS_Site_Context::get();
                     <div class="aips-filter-right">
                         <label class="screen-reader-text" for="aips-author-search"><?php esc_html_e('Search Authors:', 'ai-post-scheduler'); ?></label>
                         <input type="search" id="aips-author-search" class="aips-form-input" placeholder="<?php esc_attr_e('Search authors...', 'ai-post-scheduler'); ?>">
-                        <button type="button" id="aips-author-search-clear" class="aips-btn aips-btn-sm aips-btn-ghost" style="display: none;"><?php esc_html_e('Clear', 'ai-post-scheduler'); ?></button>
+                        <button type="button" id="aips-author-search-clear" class="aips-btn aips-btn-sm aips-btn-ghost is-hidden"><?php esc_html_e('Clear', 'ai-post-scheduler'); ?></button>
                     </div>
                 </div>
 
@@ -77,7 +77,7 @@ $site_ctx = AIPS_Site_Context::get();
                 <div class="aips-panel-body no-padding">
                     <div class="aips-panel-toolbar">
                         <div class="aips-toolbar-left aips-btn-group aips-btn-group-inline">
-                            <select id="aips-authors-bulk-action-select" class="aips-form-select" style="width: auto;">
+                            <select id="aips-authors-bulk-action-select" class="aips-form-select aips-w-auto">
                                 <option value=""><?php esc_html_e('Bulk Actions', 'ai-post-scheduler'); ?></option>
                                 <option value="generate_topics"><?php esc_html_e('Generate Topics', 'ai-post-scheduler'); ?></option>
                                 <option value="delete"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></option>
@@ -313,7 +313,7 @@ $site_ctx = AIPS_Site_Context::get();
         </div>
 
         <!-- Generation Queue Tab Content -->
-        <div id="generation-queue-tab" class="aips-tab-content" style="display: none;" role="tabpanel" aria-hidden="true">
+        <div id="generation-queue-tab" class="aips-tab-content is-hidden" role="tabpanel" aria-hidden="true">
             <div class="aips-content-panel">
                 <div class="aips-filter-bar">
                     <div class="aips-filter-left">
@@ -331,7 +331,7 @@ $site_ctx = AIPS_Site_Context::get();
                     <div class="aips-filter-right">
                         <label class="screen-reader-text" for="aips-queue-search"><?php esc_html_e('Search Queue Topics:', 'ai-post-scheduler'); ?></label>
                         <input type="search" id="aips-queue-search" class="aips-form-input" placeholder="<?php esc_attr_e('Search queue topics...', 'ai-post-scheduler'); ?>">
-                        <button type="button" id="aips-queue-search-clear" class="aips-btn aips-btn-sm aips-btn-secondary" style="display: none;">
+                        <button type="button" id="aips-queue-search-clear" class="aips-btn aips-btn-sm aips-btn-secondary is-hidden">
                             <?php esc_html_e('Clear', 'ai-post-scheduler'); ?>
                         </button>
                     </div>
@@ -339,7 +339,7 @@ $site_ctx = AIPS_Site_Context::get();
 
                 <div class="aips-panel-toolbar">
                     <div class="aips-toolbar-left aips-btn-group aips-btn-group-inline">
-                        <select id="aips-queue-bulk-action-select" class="aips-form-select aips-queue-bulk-action-select" style="width: auto;">
+                        <select id="aips-queue-bulk-action-select" class="aips-form-select aips-queue-bulk-action-select aips-w-auto">
                             <option value=""><?php esc_html_e('Bulk Actions', 'ai-post-scheduler'); ?></option>
                             <option value="generate_now"><?php esc_html_e('Generate Now', 'ai-post-scheduler'); ?></option>
                         </select>
@@ -365,7 +365,7 @@ $site_ctx = AIPS_Site_Context::get();
                     </div>
                 </div>
 
-                <div class="tablenav" id="aips-queue-tablenav" style="display: none;">
+                <div class="tablenav" id="aips-queue-tablenav" class="is-hidden">
                     <span class="aips-table-footer-count" id="aips-queue-table-footer-count"></span>
                     <div class="aips-history-pagination-links" id="aips-queue-pagination-links"></div>
                 </div>
@@ -375,7 +375,7 @@ $site_ctx = AIPS_Site_Context::get();
 </div><!-- .wrap.aips-wrap -->
 
 <!-- Topic Logs Modal -->
-<div id="aips-topic-logs-modal" class="aips-modal" style="display: none;">
+<div id="aips-topic-logs-modal" class="aips-modal is-hidden">
     <div class="aips-modal-content aips-modal-large">
         <button type="button" class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
         <h2 id="aips-topic-logs-modal-title"><?php esc_html_e('Topic History Log', 'ai-post-scheduler'); ?></h2>
@@ -386,7 +386,7 @@ $site_ctx = AIPS_Site_Context::get();
 </div>
 
 <!-- Author Edit/Create Modal -->
-<div id="aips-author-modal" class="aips-modal" style="display: none;">
+<div id="aips-author-modal" class="aips-modal is-hidden">
     <div class="aips-modal-content">
         <button type="button" class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
         <h2 id="aips-author-modal-title"><?php esc_html_e('Add New Author', 'ai-post-scheduler'); ?></h2>
@@ -576,13 +576,13 @@ $site_ctx = AIPS_Site_Context::get();
                 <p class="description"><?php esc_html_e('When enabled, active sources from the selected Source Groups will be injected into the topic generation prompt for this author.', 'ai-post-scheduler'); ?></p>
             </div>
 
-            <div id="author-source-groups-selector" style="display:none;">
+            <div id="author-source-groups-selector" class="is-hidden">
                 <div class="form-group">
                     <label><?php esc_html_e('Source Groups', 'ai-post-scheduler'); ?></label>
                     <?php if (!empty($author_source_groups)): ?>
                         <div class="aips-checkbox-group">
                             <?php foreach ($author_source_groups as $asg): ?>
-                                <label style="display:block; margin-bottom:4px;">
+                                <label class="aips-display-block aips-mb-1">
                                     <input type="checkbox"
                                         name="source_group_ids[]"
                                         class="aips-author-source-group-cb"
@@ -610,7 +610,7 @@ $site_ctx = AIPS_Site_Context::get();
 </div>
 
 <!-- Author Suggestions Modal -->
-<div id="aips-suggest-authors-modal" class="aips-modal" style="display: none;" role="dialog" aria-modal="true" aria-labelledby="aips-suggest-authors-modal-title">
+<div id="aips-suggest-authors-modal" class="aips-modal is-hidden" role="dialog" aria-modal="true" aria-labelledby="aips-suggest-authors-modal-title">
     <div class="aips-modal-content aips-modal-large">
         <button type="button" class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
         <div class="aips-modal-header">
@@ -706,7 +706,7 @@ $site_ctx = AIPS_Site_Context::get();
             {{postCountBadge}}
             {{duplicateBadge}}
             {{feedbackBadge}}
-            <input type="text" class="topic-title-edit" style="display:none;" value="{{topicTitle}}">
+            <input type="text" class="topic-title-edit is-hidden" value="{{topicTitle}}">
         </div>
         {{detailContent}}
     </td>
@@ -718,7 +718,7 @@ $site_ctx = AIPS_Site_Context::get();
 </script>
 
 <script type="text/html" id="aips-tmpl-topic-detail-section">
-<div class="aips-topic-detail-content" id="aips-topic-details-{{id}}" style="display:none;">
+<div class="aips-topic-detail-content" id="aips-topic-details-{{id}}" class="is-hidden">
     {{content}}
 </div>
 </script>

--- a/ai-post-scheduler/templates/admin/history.php
+++ b/ai-post-scheduler/templates/admin/history.php
@@ -234,7 +234,7 @@ if (is_object($history)) {
 </div><!-- .wrap.aips-wrap -->
 
 <!-- History Logs Modal -->
-<div id="aips-history-logs-modal" class="aips-modal" style="display: none;">
+<div id="aips-history-logs-modal" class="aips-modal is-hidden">
     <div class="aips-modal-content aips-modal-large">
         <div class="aips-modal-header">
             <h3 id="aips-history-logs-modal-title"><?php esc_html_e('History Details', 'ai-post-scheduler'); ?></h3>

--- a/ai-post-scheduler/templates/admin/internal-links.php
+++ b/ai-post-scheduler/templates/admin/internal-links.php
@@ -111,7 +111,7 @@ $count_inserted = isset($link_counts['inserted']) ? (int) $link_counts['inserted
 					<div class="aips-filter-right">
 						<label class="screen-reader-text" for="aips-il-search"><?php esc_html_e('Search posts:', 'ai-post-scheduler'); ?></label>
 						<input type="search" id="aips-il-search" class="aips-form-input" placeholder="<?php esc_attr_e('Search by post title…', 'ai-post-scheduler'); ?>">
-						<button type="button" id="aips-il-search-clear" class="aips-btn aips-btn-sm aips-btn-secondary" style="display:none;"><?php esc_html_e('Clear', 'ai-post-scheduler'); ?></button>
+						<button type="button" id="aips-il-search-clear" class="aips-btn aips-btn-sm aips-btn-secondary is-hidden"><?php esc_html_e('Clear', 'ai-post-scheduler'); ?></button>
 					</div>
 				</div>
 
@@ -146,7 +146,7 @@ $count_inserted = isset($link_counts['inserted']) ? (int) $link_counts['inserted
 		</div><!-- /#suggestions-tab -->
 
 		<!-- Generate for Post Tab -->
-		<div id="generate-tab" class="aips-tab-content" role="tabpanel" aria-hidden="true" style="display:none;">
+		<div id="generate-tab" class="aips-tab-content" role="tabpanel" aria-hidden="true" class="is-hidden">
 			<div class="aips-content-panel">
 				<div class="aips-panel-body" style="padding:24px;">
 					<h2 style="margin-top:0;"><?php esc_html_e('Generate Suggestions for a Post', 'ai-post-scheduler'); ?></h2>
@@ -201,7 +201,7 @@ $count_inserted = isset($link_counts['inserted']) ? (int) $link_counts['inserted
 </div><!-- /.wrap -->
 
 <!-- Insert Link Modal -->
-<div id="aips-insert-modal" class="aips-modal" style="display:none;" role="dialog" aria-modal="true" aria-labelledby="aips-insert-modal-title">
+<div id="aips-insert-modal" class="aips-modal is-hidden" role="dialog" aria-modal="true" aria-labelledby="aips-insert-modal-title">
 	<div class="aips-modal-content" style="max-width:860px;width:94%;">
 		<div class="aips-modal-header">
 			<h2 id="aips-insert-modal-title"><?php esc_html_e('Insert Link', 'ai-post-scheduler'); ?></h2>
@@ -416,7 +416,7 @@ $count_inserted = isset($link_counts['inserted']) ? (int) $link_counts['inserted
 </script>
 
 <!-- Edit Anchor Text Modal -->
-<div id="aips-anchor-modal" class="aips-modal" style="display:none;" role="dialog" aria-modal="true" aria-labelledby="aips-anchor-modal-title">
+<div id="aips-anchor-modal" class="aips-modal is-hidden" role="dialog" aria-modal="true" aria-labelledby="aips-anchor-modal-title">
 	<div class="aips-modal-content">
 		<div class="aips-modal-header">
 			<h2 id="aips-anchor-modal-title"><?php esc_html_e('Edit Anchor Text', 'ai-post-scheduler'); ?></h2>

--- a/ai-post-scheduler/templates/admin/research.php
+++ b/ai-post-scheduler/templates/admin/research.php
@@ -114,12 +114,12 @@ if (!in_array($active_tab, $valid_tabs, true)) {
                     </tr>
                 </table>
                 
-                <div style="margin-top: 8px; display: flex; align-items: center; gap: 12px;">
+                <div class="aips-mt-2 aips-flex aips-items-center aips-gap-3">
                     <button type="submit" class="aips-btn aips-btn-primary" id="research-submit">
                         <span class="dashicons dashicons-search" aria-hidden="true"></span>
                         <?php esc_html_e('Research Trending Topics', 'ai-post-scheduler'); ?>
                     </button>
-                    <span class="spinner" style="float: none; margin: 0;"></span>
+                    <span class="spinner aips-spinner-reset"></span>
                 </div>
             </form>
 
@@ -160,7 +160,7 @@ if (!in_array($active_tab, $valid_tabs, true)) {
                         <td>
                             <div class="aips-checkbox-group">
                                 <?php foreach ($research_source_groups as $rsg): ?>
-                                    <label class="aips-checkbox-label" style="display:block; margin-bottom:4px;">
+                                    <label class="aips-checkbox-label aips-display-block aips-mb-1">
                                         <input type="checkbox" name="term_ids[]"
                                                value="<?php echo esc_attr($rsg->term_id); ?>">
                                         <?php echo esc_html($rsg->name); ?>
@@ -179,12 +179,12 @@ if (!in_array($active_tab, $valid_tabs, true)) {
                         </td>
                     </tr>
                 </table>
-                <div style="margin-top: 8px; display: flex; align-items: center; gap: 12px;">
+                <div class="aips-mt-2 aips-flex aips-items-center aips-gap-3">
                     <button type="submit" class="aips-btn aips-btn-secondary" id="source-research-submit">
                         <span class="dashicons dashicons-admin-links" aria-hidden="true"></span>
                         <?php esc_html_e('Research from Sources', 'ai-post-scheduler'); ?>
                     </button>
-                    <span class="spinner" id="source-research-spinner" style="float: none; margin: 0;"></span>
+                    <span class="spinner" id="source-research-spinner" class="aips-spinner-reset"></span>
                 </div>
             </form>
             <?php endif; ?>
@@ -240,7 +240,7 @@ if (!in_array($active_tab, $valid_tabs, true)) {
                 <div class="aips-filter-right">
                     <label class="screen-reader-text" for="filter-search"><?php esc_html_e('Search topics...', 'ai-post-scheduler'); ?></label>
                     <input type="search" id="filter-search" class="aips-form-input" placeholder="<?php esc_attr_e('Search topics...', 'ai-post-scheduler'); ?>">
-                    <button type="button" id="filter-search-clear" class="aips-btn aips-btn-sm aips-btn-ghost" style="display:none;" aria-label="<?php esc_attr_e('Clear search', 'ai-post-scheduler'); ?>"><?php esc_html_e('Clear', 'ai-post-scheduler'); ?></button>
+                    <button type="button" id="filter-search-clear" class="aips-btn aips-btn-sm aips-btn-ghost is-hidden" aria-label="<?php esc_attr_e('Clear search', 'ai-post-scheduler'); ?>"><?php esc_html_e('Clear', 'ai-post-scheduler'); ?></button>
                 </div>
             </div>
             
@@ -276,13 +276,13 @@ if (!in_array($active_tab, $valid_tabs, true)) {
             </div>
 
             <!-- Table Footer -->
-            <div class="tablenav" id="topics-tablenav" style="display: none;">
+            <div class="tablenav" id="topics-tablenav" class="is-hidden">
                 <span class="aips-table-footer-count" id="topics-count"></span>
             </div>
         </div><!-- .aips-content-panel (library) -->
 
         <!-- Schedule Selected Topics Panel -->
-        <div id="bulk-schedule-section" class="aips-content-panel" style="display: none;">
+        <div id="bulk-schedule-section" class="aips-content-panel is-hidden">
             <div class="aips-panel-header">
                 <h2 class="aips-panel-title"><?php esc_html_e('Schedule Selected Topics', 'ai-post-scheduler'); ?></h2>
             </div>
@@ -323,12 +323,12 @@ if (!in_array($active_tab, $valid_tabs, true)) {
                             </td>
                         </tr>
                     </table>
-                    <div style="margin-top: 8px; display: flex; align-items: center; gap: 12px;">
+                    <div class="aips-mt-2 aips-flex aips-items-center aips-gap-3">
                         <button type="submit" class="aips-btn aips-btn-primary">
                             <span class="dashicons dashicons-calendar-alt"></span>
                             <?php esc_html_e('Schedule Topics', 'ai-post-scheduler'); ?>
                         </button>
-                        <span class="spinner" style="float: none; margin: 0;"></span>
+                        <span class="spinner aips-spinner-reset"></span>
                     </div>
                 </form>
             </div><!-- .aips-panel-body -->
@@ -367,7 +367,7 @@ if (!in_array($active_tab, $valid_tabs, true)) {
     </div>
 
     <!-- Generate Now — Template Selection Modal -->
-    <div id="aips-generate-now-modal" class="aips-modal" style="display: none;">
+    <div id="aips-generate-now-modal" class="aips-modal is-hidden">
         <div class="aips-modal-content">
             <div class="aips-modal-header">
                 <h2><?php esc_html_e('Generate Posts Now', 'ai-post-scheduler'); ?></h2>
@@ -412,7 +412,7 @@ if (!in_array($active_tab, $valid_tabs, true)) {
     </div>
 
     <!-- Trending Topic Posts Modal -->
-    <div id="aips-trending-topic-posts-modal" class="aips-modal" style="display: none;">
+    <div id="aips-trending-topic-posts-modal" class="aips-modal is-hidden">
         <div class="aips-modal-content aips-modal-large">
             <button type="button" class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
             <h2 id="aips-trending-topic-posts-modal-title"><?php esc_html_e('Posts Generated from Topic', 'ai-post-scheduler'); ?></h2>

--- a/ai-post-scheduler/templates/admin/schedule.php
+++ b/ai-post-scheduler/templates/admin/schedule.php
@@ -169,7 +169,7 @@ if (!function_exists('aips_datetime_from_db_value')) {
 				<div class="aips-filter-right">
 					<label class="screen-reader-text" for="aips-unified-search"><?php esc_html_e('Search Schedules:', 'ai-post-scheduler'); ?></label>
 					<input type="search" id="aips-unified-search" class="aips-form-input" placeholder="<?php esc_attr_e('Search schedules…', 'ai-post-scheduler'); ?>">
-					<button type="button" id="aips-unified-search-clear" class="aips-btn aips-btn-sm aips-btn-ghost" style="display:none;"><?php esc_html_e('Clear', 'ai-post-scheduler'); ?></button>
+					<button type="button" id="aips-unified-search-clear" class="aips-btn aips-btn-sm aips-btn-ghost is-hidden"><?php esc_html_e('Clear', 'ai-post-scheduler'); ?></button>
 				</div>
 			</div>
 
@@ -192,7 +192,7 @@ if (!function_exists('aips_datetime_from_db_value')) {
 					<button type="button" id="aips-unified-bulk-apply" class="aips-btn aips-btn-primary aips-btn-sm" disabled>
 						<?php esc_html_e('Apply', 'ai-post-scheduler'); ?>
 					</button>
-					<span id="aips-unified-selected-count" class="aips-selected-count" style="display:none;"></span>
+					<span id="aips-unified-selected-count" class="aips-selected-count is-hidden"></span>
 				</div>
 			</div>
 
@@ -446,7 +446,7 @@ if (!function_exists('aips_datetime_from_db_value')) {
 <!-- ============================================================ -->
 <!-- Add / Edit Template Schedule Modal                           -->
 <!-- ============================================================ -->
-<div id="aips-schedule-modal" class="aips-modal" style="display:none;"
+<div id="aips-schedule-modal" class="aips-modal is-hidden"
 	data-preselect-template="<?php echo esc_attr($preselect_template_id); ?>"
 	data-preselect-structure="<?php echo esc_attr($preselect_structure_id); ?>">
 	<div class="aips-modal-content">
@@ -530,7 +530,7 @@ if (!function_exists('aips_datetime_from_db_value')) {
 <!-- ============================================================ -->
 <!-- Schedule History Modal                                       -->
 <!-- ============================================================ -->
-<div id="aips-schedule-history-modal" class="aips-modal" style="display:none;"
+<div id="aips-schedule-history-modal" class="aips-modal is-hidden"
 	role="dialog" aria-modal="true" aria-labelledby="aips-schedule-history-modal-title">
 	<div class="aips-modal-content aips-modal-large">
 		<div class="aips-modal-header">

--- a/ai-post-scheduler/templates/admin/sources.php
+++ b/ai-post-scheduler/templates/admin/sources.php
@@ -67,7 +67,7 @@ if (!isset($source_term_ids_map) || !is_array($source_term_ids_map)) {
 				<div class="aips-filter-right">
 					<label class="screen-reader-text" for="aips-source-search"><?php esc_html_e('Search Sources:', 'ai-post-scheduler'); ?></label>
 					<input type="search" id="aips-source-search" class="aips-form-input" placeholder="<?php esc_attr_e('Search sources…', 'ai-post-scheduler'); ?>">
-					<button type="button" id="aips-source-search-clear" class="aips-btn aips-btn-sm aips-btn-ghost" style="display:none;"><?php esc_html_e('Clear', 'ai-post-scheduler'); ?></button>
+					<button type="button" id="aips-source-search-clear" class="aips-btn aips-btn-sm aips-btn-ghost is-hidden"><?php esc_html_e('Clear', 'ai-post-scheduler'); ?></button>
 				</div>
 			</div>
 
@@ -221,7 +221,7 @@ if (!isset($source_term_ids_map) || !is_array($source_term_ids_map)) {
 				</span>
 			</div>
 
-			<div id="aips-source-search-no-results" class="aips-empty-state" style="display:none;">
+			<div id="aips-source-search-no-results" class="aips-empty-state is-hidden">
 				<div class="dashicons dashicons-search aips-empty-state-icon" aria-hidden="true"></div>
 				<h3 class="aips-empty-state-title"><?php esc_html_e('No Sources Found', 'ai-post-scheduler'); ?></h3>
 				<p class="aips-empty-state-description"><?php esc_html_e('No sources match your search criteria.', 'ai-post-scheduler'); ?></p>
@@ -250,7 +250,7 @@ if (!isset($source_term_ids_map) || !is_array($source_term_ids_map)) {
 </div><!-- .wrap -->
 
 <!-- Add / Edit Source Modal -->
-<div id="aips-source-modal" class="aips-modal" style="display:none;" role="dialog" aria-modal="true" aria-labelledby="aips-source-modal-title">
+<div id="aips-source-modal" class="aips-modal is-hidden" role="dialog" aria-modal="true" aria-labelledby="aips-source-modal-title">
 	<div class="aips-modal-content">
 		<div class="aips-modal-header">
 			<h2 id="aips-source-modal-title"><?php esc_html_e('Add New Source', 'ai-post-scheduler'); ?></h2>
@@ -305,7 +305,7 @@ if (!isset($source_term_ids_map) || !is_array($source_term_ids_map)) {
 					<div id="aips-source-groups-checkboxes" class="aips-checkbox-group">
 						<?php if (!empty($source_groups)): ?>
 							<?php foreach ($source_groups as $group): ?>
-								<label class="aips-checkbox-label" style="display:block; margin-bottom:4px;">
+								<label class="aips-checkbox-label aips-display-block aips-mb-1">
 									<input type="checkbox"
 										name="term_ids[]"
 										class="aips-source-group-checkbox"
@@ -340,7 +340,7 @@ if (!isset($source_term_ids_map) || !is_array($source_term_ids_map)) {
 </div>
 
 <!-- Manage Source Groups Modal -->
-<div id="aips-groups-modal" class="aips-modal" style="display:none;" role="dialog" aria-modal="true" aria-labelledby="aips-groups-modal-title">
+<div id="aips-groups-modal" class="aips-modal is-hidden" role="dialog" aria-modal="true" aria-labelledby="aips-groups-modal-title">
 	<div class="aips-modal-content">
 		<div class="aips-modal-header">
 			<h2 id="aips-groups-modal-title"><?php esc_html_e('Manage Source Groups', 'ai-post-scheduler'); ?></h2>

--- a/ai-post-scheduler/templates/admin/templates.php
+++ b/ai-post-scheduler/templates/admin/templates.php
@@ -29,7 +29,7 @@ if (!defined('ABSPATH')) {
                 <div class="aips-filter-right">
                     <label class="screen-reader-text" for="aips-template-search"><?php esc_html_e('Search Templates:', 'ai-post-scheduler'); ?></label>
                     <input type="search" id="aips-template-search" class="aips-form-input" placeholder="<?php esc_attr_e('Search templates...', 'ai-post-scheduler'); ?>">
-                    <button type="button" id="aips-template-search-clear" class="aips-btn aips-btn-sm aips-btn-ghost" style="display: none;"><?php esc_html_e('Clear', 'ai-post-scheduler'); ?></button>
+                    <button type="button" id="aips-template-search-clear" class="aips-btn aips-btn-sm aips-btn-ghost is-hidden"><?php esc_html_e('Clear', 'ai-post-scheduler'); ?></button>
                 </div>
             </div>
             
@@ -192,7 +192,7 @@ if (!defined('ABSPATH')) {
 </div>
 
 <!-- Keep the original modal markup below (not redesigned yet) -->
-    <div id="aips-template-modal" class="aips-modal aips-wizard-modal" style="display: none;" data-wizard-steps="4">
+    <div id="aips-template-modal" class="aips-modal aips-wizard-modal is-hidden" data-wizard-steps="4">
         <div class="aips-modal-content aips-modal-large">
             <div class="aips-modal-header">
                 <h2 id="aips-modal-title"><?php esc_html_e('Add New Template', 'ai-post-scheduler'); ?></h2>
@@ -269,7 +269,7 @@ if (!defined('ABSPATH')) {
                         </div>
 
                         <!-- AI Variables Panel -->
-                        <div class="aips-form-row aips-ai-variables-panel" style="display: none;">
+                        <div class="aips-form-row aips-ai-variables-panel is-hidden">
                             <div class="aips-ai-variables-header">
                                 <span class="dashicons dashicons-admin-generic"></span>
                                 <strong><?php esc_html_e('AI Variables Detected', 'ai-post-scheduler'); ?></strong>
@@ -312,7 +312,7 @@ if (!defined('ABSPATH')) {
                     </div>
                     
                     <!-- Step 2: Content -->
-                    <div class="aips-wizard-step-content" data-step="2" style="display: none;">
+                    <div class="aips-wizard-step-content" data-step="2" class="is-hidden">
                         <h3>
                             <?php esc_html_e('Content Settings', 'ai-post-scheduler'); ?>
                             <span class="aips-help-tooltip dashicons dashicons-editor-help" data-tooltip="<?php esc_attr_e('Define the main content prompt that guides AI to generate your blog post content.', 'ai-post-scheduler'); ?>"></span>
@@ -370,7 +370,7 @@ if (!defined('ABSPATH')) {
                                 <?php if (!empty($template_source_groups)): ?>
                                     <div class="aips-checkbox-group">
                                         <?php foreach ($template_source_groups as $sg): ?>
-                                            <label class="aips-checkbox-label" style="display:block; margin-bottom:4px;">
+                                            <label class="aips-checkbox-label aips-display-block aips-mb-1">
                                                 <input type="checkbox"
                                                     name="source_group_ids[]"
                                                     class="aips-template-source-group-cb"
@@ -391,7 +391,7 @@ if (!defined('ABSPATH')) {
                     </div>
                     
                     <!-- Step 3: Featured Image -->
-                    <div class="aips-wizard-step-content" data-step="3" style="display: none;">
+                    <div class="aips-wizard-step-content" data-step="3" class="is-hidden">
                         <h3><?php esc_html_e('Featured Image Options', 'ai-post-scheduler'); ?></h3>
                         <p class="description"><?php esc_html_e('Configure whether and how to generate featured images for your posts.', 'ai-post-scheduler'); ?></p>
                         
@@ -403,7 +403,7 @@ if (!defined('ABSPATH')) {
                             <p class="description"><?php esc_html_e('If checked, a featured image will be attached to the generated post.', 'ai-post-scheduler'); ?></p>
                         </div>
 
-                        <div class="aips-featured-image-settings" style="display: none;">
+                        <div class="aips-featured-image-settings is-hidden">
                             <div class="aips-form-row">
                                 <label for="featured_image_source"><?php esc_html_e('Featured Image Source', 'ai-post-scheduler'); ?></label>
                                 <select id="featured_image_source" name="featured_image_source">
@@ -420,13 +420,13 @@ if (!defined('ABSPATH')) {
                                 <p class="description"><?php esc_html_e('Used when generating the image with AI.', 'ai-post-scheduler'); ?></p>
                             </div>
 
-                            <div class="aips-form-row aips-image-source aips-image-source-unsplash" style="display: none;">
+                            <div class="aips-form-row aips-image-source aips-image-source-unsplash is-hidden">
                                 <label for="featured_image_unsplash_keywords"><?php esc_html_e('Unsplash Keywords', 'ai-post-scheduler'); ?></label>
                                 <input type="text" id="featured_image_unsplash_keywords" name="featured_image_unsplash_keywords" class="regular-text" placeholder="<?php esc_attr_e('e.g. sunrise, mountains, drone view', 'ai-post-scheduler'); ?>">
                                 <p class="description"><?php esc_html_e('Unsplash will return a random image that matches these keywords.', 'ai-post-scheduler'); ?></p>
                             </div>
 
-                            <div class="aips-form-row aips-image-source aips-image-source-media" style="display: none;">
+                            <div class="aips-form-row aips-image-source aips-image-source-media is-hidden">
                                 <label><?php esc_html_e('Media Library Images', 'ai-post-scheduler'); ?></label>
                                 <div class="aips-media-library-picker">
                                     <input type="hidden" id="featured_image_media_ids" name="featured_image_media_ids" value="">
@@ -440,7 +440,7 @@ if (!defined('ABSPATH')) {
                     </div>
                     
                     <!-- Step 4: Summary & Post Settings -->
-                    <div class="aips-wizard-step-content" data-step="4" style="display: none;">
+                    <div class="aips-wizard-step-content" data-step="4" class="is-hidden">
                         <h3><?php esc_html_e('Review & Post Settings', 'ai-post-scheduler'); ?></h3>
                         <p class="description"><?php esc_html_e('Review your template configuration and set post publishing options.', 'ai-post-scheduler'); ?></p>
                         
@@ -529,7 +529,7 @@ if (!defined('ABSPATH')) {
                     </div>
                     
                     <!-- Step 5: Post-Save Next Steps (shown after successful save) -->
-                    <div class="aips-wizard-step-content aips-post-save-step" data-step="5" style="display: none;">
+                    <div class="aips-wizard-step-content aips-post-save-step" data-step="5" class="is-hidden">
                         <div style="text-align: center; padding: 30px 20px;">
                             <span class="dashicons dashicons-yes-alt" style="font-size: 64px; color: #46b450; width: 64px; height: 64px;"></span>
                             <h3 style="margin-top: 16px; font-size: 20px;" id="aips-save-success-title"><?php esc_html_e('Template Saved Successfully!', 'ai-post-scheduler'); ?></h3>
@@ -555,7 +555,7 @@ if (!defined('ABSPATH')) {
             </div>
             <div class="aips-modal-footer aips-wizard-footer">
                 <div class="aips-footer-left">
-                    <button type="button" class="button aips-wizard-back" style="display: none;">
+                    <button type="button" class="button aips-wizard-back is-hidden">
                         <span class="dashicons dashicons-arrow-left-alt2"></span>
                         <?php esc_html_e('Back', 'ai-post-scheduler'); ?>
                     </button>
@@ -596,19 +596,19 @@ if (!defined('ABSPATH')) {
                         <span class="aips-preview-drawer-label"><?php esc_html_e('Prompt Preview', 'ai-post-scheduler'); ?></span>
                     </button>
                 </div>
-                <div class="aips-preview-drawer-content" style="display: none;">
-                    <div class="aips-preview-loading" style="display: none;">
+                <div class="aips-preview-drawer-content is-hidden">
+                    <div class="aips-preview-loading is-hidden">
                         <span class="spinner is-active"></span>
                         <span><?php esc_html_e('Generating preview...', 'ai-post-scheduler'); ?></span>
                     </div>
-                    <div class="aips-preview-error" style="display: none;"></div>
-                    <div class="aips-preview-sections" style="display: none;">
+                    <div class="aips-preview-error is-hidden"></div>
+                    <div class="aips-preview-sections is-hidden">
                         <div class="aips-preview-metadata">
-                            <div class="aips-preview-meta-item" id="aips-preview-voice" style="display: none;">
+                            <div class="aips-preview-meta-item" id="aips-preview-voice" class="is-hidden">
                                 <strong><?php esc_html_e('Voice:', 'ai-post-scheduler'); ?></strong>
                                 <span class="aips-preview-voice-name"></span>
                             </div>
-                            <div class="aips-preview-meta-item" id="aips-preview-structure" style="display: none;">
+                            <div class="aips-preview-meta-item" id="aips-preview-structure" class="is-hidden">
                                 <strong><?php esc_html_e('Article Structure:', 'ai-post-scheduler'); ?></strong>
                                 <span class="aips-preview-structure-name"></span>
                             </div>
@@ -633,7 +633,7 @@ if (!defined('ABSPATH')) {
                             <div class="aips-preview-prompt-text" id="aips-preview-excerpt-prompt"></div>
                         </div>
                         
-                        <div class="aips-preview-section" id="aips-preview-image-section" style="display: none;">
+                        <div class="aips-preview-section" id="aips-preview-image-section" class="is-hidden">
                             <h4><?php esc_html_e('Image Prompt', 'ai-post-scheduler'); ?></h4>
                             <div class="aips-preview-prompt-text" id="aips-preview-image-prompt"></div>
                         </div>
@@ -643,7 +643,7 @@ if (!defined('ABSPATH')) {
         </div>
     </div>
     
-    <div id="aips-test-result-modal" class="aips-modal" style="display: none;">
+    <div id="aips-test-result-modal" class="aips-modal is-hidden">
         <div class="aips-modal-content aips-modal-large">
             <div class="aips-modal-header">
                 <h2><?php esc_html_e('Test Generation Result', 'ai-post-scheduler'); ?></h2>
@@ -661,7 +661,7 @@ if (!defined('ABSPATH')) {
                         <div id="aips-test-excerpt" class="aips-preview-box" style="background: #f0f0f1; padding: 10px; border: 1px solid #c3c4c7;"></div>
                     </div>
 
-                    <div class="aips-form-row" id="aips-test-image-row" style="display: none;">
+                    <div class="aips-form-row" id="aips-test-image-row" class="is-hidden">
                         <label><strong><?php esc_html_e('Image Preview (Prompt/Keywords):', 'ai-post-scheduler'); ?></strong></label>
                         <div id="aips-test-image" class="aips-preview-box" style="background: #f0f0f1; padding: 10px; border: 1px solid #c3c4c7;"></div>
                     </div>
@@ -678,7 +678,7 @@ if (!defined('ABSPATH')) {
         </div>
     </div>
 
-    <div id="aips-post-success-modal" class="aips-modal" style="display: none;">
+    <div id="aips-post-success-modal" class="aips-modal is-hidden">
         <div class="aips-modal-content aips-modal-large">
             <div class="aips-modal-header">
                 <h2
@@ -692,7 +692,7 @@ if (!defined('ABSPATH')) {
                 <div class="aips-post-success-summary">
                     <span class="dashicons dashicons-yes-alt aips-post-success-icon"></span>
                     <p class="aips-post-success-message" id="aips-success-message"><?php esc_html_e('1 post has been generated.', 'ai-post-scheduler'); ?></p>
-                    <p id="aips-success-note" class="description aips-post-success-note" style="display: none;"></p>
+                    <p id="aips-success-note" class="description aips-post-success-note is-hidden"></p>
                 </div>
                 <div id="aips-post-results-container" class="aips-post-results-container"></div>
             </div>
@@ -741,7 +741,7 @@ if (!defined('ABSPATH')) {
         </tr>
     </script>
 
-    <div id="aips-post-quick-preview-modal" class="aips-modal" style="display: none;">
+    <div id="aips-post-quick-preview-modal" class="aips-modal is-hidden">
         <div class="aips-modal-content aips-modal-large">
             <div class="aips-modal-header">
                 <h2><?php esc_html_e('Post Quick Preview', 'ai-post-scheduler'); ?></h2>


### PR DESCRIPTION
### Motivation
- Reduce repeated inline `style="..."` usage across admin templates by introducing reusable utility classes and a tokenized spacing/typography scale.
- Replace high-impact inline styles first to make runtime visibility toggles and layout controlled by classes (so JS toggles classes, not inline style strings).
- Prevent regressions by adding a QA check that fails if new inline style attributes are introduced into admin templates.

### Description
- Added a design-token-friendly utility block to `assets/css/admin.css` with visibility, layout, spacing, width, and typography helpers such as `.is-hidden`, `.is-flex`, `.aips-mt-2`, `.aips-mb-4`, `.aips-w-auto`, `.aips-gap-*`, `.aips-text-sm`, and spinner reset helpers.
- Replaced repeated inline `style` attributes in a focused set of high-impact admin templates by applying the new utility classes in `templates/admin/templates.php`, `templates/admin/authors.php`, `templates/admin/history.php`, `templates/admin/internal-links.php`, `templates/admin/research.php`, `templates/admin/schedule.php`, and `templates/admin/sources.php`.
- Added `scripts/check-inline-styles.sh`, a diff-based QA script that fails CI if new inline `style="..."` attributes are introduced under `templates/admin/*.php`.
- Wired the QA check into `composer.json` as the `qa:inline-styles` script (`composer qa:inline-styles`).

### Testing
- Ran the inline-style guard script (`bash scripts/check-inline-styles.sh`) and it passed (no *new* inline `style` attributes detected in `templates/admin/*.php`).
- Generated a focused inline-style inventory with `rg` to capture file-by-file counts of existing `style="` occurrences and validated the counts (inventory run succeeded).
- Attempted the required PR de-dup check via `gh pr list`, but the GitHub CLI is not available in the environment (`gh: command not found`), so an open-PR check could not be performed before making changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a5d8770dc83218b90dc794d451997)