### PR TITLE
Preserve disabled retry default on upgrade

### DIFF
--- a/ai-post-scheduler/ai-post-scheduler.php
+++ b/ai-post-scheduler/ai-post-scheduler.php
@@ -137,6 +137,7 @@ final class AI_Post_Scheduler {
             'aips_default_post_status' => 'draft',
             'aips_default_category' => 0,
             'aips_enable_logging' => 1,
+            'aips_enable_retry' => 0,
             'aips_retry_max_attempts' => 3,
             'aips_ai_model' => '',
             'aips_unsplash_access_key' => '',

--- a/ai-post-scheduler/includes/class-aips-settings.php
+++ b/ai-post-scheduler/includes/class-aips-settings.php
@@ -254,7 +254,7 @@ class AIPS_Settings {
         ));
         register_setting('aips_settings', 'aips_enable_retry', array(
             'sanitize_callback' => 'absint',
-            'default' => 1
+            'default' => 0
         ));
         register_setting('aips_settings', 'aips_retry_max_attempts', array(
             'sanitize_callback' => 'absint',
@@ -711,7 +711,7 @@ class AIPS_Settings {
      * Render the enable retry setting field.
      */
     public function enable_retry_field_callback() {
-        $value = get_option('aips_enable_retry', 1);
+        $value = get_option('aips_enable_retry', 0);
         ?>
         <input type="hidden" name="aips_enable_retry" value="0">
         <input type="checkbox" name="aips_enable_retry" value="1" <?php checked(1, $value); ?>>

--- a/ai-post-scheduler/mcp-bridge.php
+++ b/ai-post-scheduler/mcp-bridge.php
@@ -1659,7 +1659,7 @@ class AIPS_MCP_Bridge {
 		// Resilience Settings
 		if ($category === 'all' || $category === 'resilience') {
 			$settings['resilience'] = array(
-				'enable_retry' => (bool) get_option('aips_enable_retry', true),
+				'enable_retry' => (bool) get_option('aips_enable_retry', false),
 				'retry_max_attempts' => (int) get_option('aips_retry_max_attempts', 3),
 				'retry_initial_delay' => (int) get_option('aips_retry_initial_delay', 1),
 				'enable_rate_limiting' => (bool) get_option('aips_enable_rate_limiting', false),


### PR DESCRIPTION
### Motivation
- Upgraded sites that never stored `aips_enable_retry` must keep the prior behavior (retries off) instead of silently enabling retry logic and causing extra AI calls and costs.  
- The Settings API default and MCP export needed to match the preserved disabled default to avoid inconsistent runtime behavior.

### Description
- Seed `aips_enable_retry` as disabled in `AI_Post_Scheduler::set_default_options()` by adding `'aips_enable_retry' => 0` so upgrades keep retry opt-in.  
- Change the Settings API registration for `aips_enable_retry` to use `'default' => 0` and update the settings checkbox fallback to `get_option('aips_enable_retry', 0)` in `includes/class-aips-settings.php`.  
- Align the MCP settings export to use `get_option('aips_enable_retry', false)` so remote/tooling sees retries disabled by default in `mcp-bridge.php`.

### Testing
- Ran syntax checks with `php -l` against `ai-post-scheduler/includes/class-aips-config.php`, `ai-post-scheduler/includes/class-aips-settings.php`, `ai-post-scheduler/ai-post-scheduler.php`, and `ai-post-scheduler/mcp-bridge.php`, which reported no syntax errors.  
- Ran `composer install` to populate dev dependencies successfully.  
- Ran the test suite via `composer test` (PHPUnit); the suite executed but failed in this environment because the WordPress test library is not available at `/tmp/wordpress-tests-lib`, producing many database and WP-environment dependent errors that are unrelated to this small default-value change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ba6f996a08321b75b86ce89f33d10)