### PR TITLE
Add SQL extraction backlog and repository-boundary lint guard

### DIFF
--- a/ai-post-scheduler/composer.json
+++ b/ai-post-scheduler/composer.json
@@ -30,7 +30,8 @@
   "scripts": {
     "test": "vendor/bin/phpunit",
     "test:coverage": "vendor/bin/phpunit --coverage-html coverage",
-    "test:verbose": "vendor/bin/phpunit --verbose"
+    "test:verbose": "vendor/bin/phpunit --verbose",
+    "lint:repository-boundary": "php tools/check-repository-boundary.php"
   },
   "config": {
     "allow-plugins": {

--- a/ai-post-scheduler/config/repository-boundary-whitelist.txt
+++ b/ai-post-scheduler/config/repository-boundary-whitelist.txt
@@ -1,0 +1,4 @@
+# Paths relative to ai-post-scheduler/ allowed to use direct wpdb in non-repository layers.
+# Keep this list short and temporary; include rationale in PRs for new entries.
+includes/class-aips-telemetry.php
+includes/class-aips-db-migrations.php

--- a/ai-post-scheduler/tools/check-repository-boundary.php
+++ b/ai-post-scheduler/tools/check-repository-boundary.php
@@ -1,0 +1,49 @@
+<?php
+$root = dirname(__DIR__);
+$whitelistFile = $root . '/config/repository-boundary-whitelist.txt';
+$whitelist = array();
+if (file_exists($whitelistFile)) {
+	$lines = file($whitelistFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+	foreach ($lines as $line) {
+		$line = trim($line);
+		if ('' === $line || '#' === $line[0]) {
+			continue;
+		}
+		$whitelist[$line] = true;
+	}
+}
+
+$iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root . '/includes'));
+$violations = array();
+
+foreach ($iterator as $fileInfo) {
+	if (!$fileInfo->isFile()) {
+		continue;
+	}
+	$filename = $fileInfo->getFilename();
+	if (!preg_match('/^class-aips-.*-(controller|service)\.php$/', $filename)) {
+		continue;
+	}
+	$relative = ltrim(str_replace($root, '', $fileInfo->getPathname()), '/');
+	if (isset($whitelist[$relative])) {
+		continue;
+	}
+	$content = file_get_contents($fileInfo->getPathname());
+	if (false === $content) {
+		continue;
+	}
+	if (preg_match('/\$wpdb\s*->|global\s+\$wpdb/', $content)) {
+		$violations[] = $relative;
+	}
+}
+
+if (!empty($violations)) {
+	echo "Repository boundary violations detected in controller/service classes:\n";
+	foreach ($violations as $path) {
+		echo " - {$path}\n";
+	}
+	echo "Move SQL into repositories or add a temporary whitelist entry with rationale.\n";
+	exit(1);
+}
+
+echo "Repository boundary check passed: no direct wpdb usage in controllers/services.\n";

--- a/docs/sql-extraction-backlog.md
+++ b/docs/sql-extraction-backlog.md
@@ -1,0 +1,20 @@
+## SQL Extraction Backlog (Repository Boundary Enforcement)
+
+This backlog is derived from `docs/feature-report-feature-profiles.md` findings and focuses on non-repository classes still using direct `wpdb` access.
+
+| Priority | Class | Current method(s) using SQL | Extract to repository method(s) |
+|---|---|---|---|
+| P1 | `AIPS_Scheduler` | constructor table setup + schedule fetch/update helpers that query schedule/template tables | `AIPS_Schedule_Repository::get_due_schedules()`, `::mark_schedule_result()`, `::count_due_schedules()` |
+| P1 | `AIPS_Schedule_Entry` | schedule state reads/writes in entry runtime paths | `AIPS_Schedule_Repository::get_entry_state()`, `::update_entry_state()` |
+| P1 | `AIPS_Post_Manager` | duplicate-check and post lookup helpers using posts table | `AIPS_Post_Repository::find_existing_generated_post()`, `::get_post_id_by_title_or_meta()` |
+| P2 | `AIPS_Templates` | template table bootstrap/list operations | `AIPS_Template_Repository::get_all()`, `::find_by_*()` (expand existing repo where needed) |
+| P2 | `AIPS_Bulk_Batch_Job_Store` | job insert/update/select/cleanup queries | Move to `AIPS_Bulk_Batch_Jobs_Repository` (or rename current store to repository and inject) |
+| P2 | `AIPS_Cache_DB_Driver` | cache row CRUD/cleanup SQL | Isolate as `AIPS_Cache_Repository` and keep driver interface DB-agnostic |
+| P3 | `AIPS_Data_Management_Import_MySQL` | import-time table existence/read/insert checks | `AIPS_Data_Management_Repository::table_exists()`, `::insert_rows()`, `::truncate_table()` |
+| P3 | `AIPS_DB_Migrations` | migration-time schema introspection/ALTER statements | `AIPS_DB_Schema_Repository::column_exists()`, `::run_alter_statement()` |
+| P3 | `AIPS_Date_Time_DB_Repair` | datetime-repair scans/updates | `AIPS_History_Repository::find_invalid_datetimes()`, `::repair_invalid_datetimes()` |
+| P3 | `AIPS_Telemetry` | request-level query counters and direct DB object inspection | keep read-only query metrics in `AIPS_Telemetry`; move persistence SQL to `AIPS_Telemetry_Repository` only |
+
+### Prioritization rationale
+
+Start with classes that combine **direct SQL + high coupling** (`AIPS_Scheduler`, `AIPS_Schedule_Entry`, `AIPS_Post_Manager`) to reduce change-surface and improve testability fastest.


### PR DESCRIPTION
### Motivation

- Enforce repository-centric architecture by preventing new direct `$wpdb` usage in controller/service classes.  
- Create a prioritized, actionable backlog of classes that currently mix SQL and business logic to guide extraction work.  
- Provide a lightweight, CI/local runnable guard with an explicit allowlist for temporary exceptions to avoid regressions.

### Description

- Added `docs/sql-extraction-backlog.md` documenting a P1/P2/P3 backlog mapping classes and methods to proposed repository methods and a prioritization rationale.  
- Added a repository-boundary lint script at `ai-post-scheduler/tools/check-repository-boundary.php` that scans `includes/` controller/service files for `global $wpdb` or `$wpdb->` and fails unless the file is listed in the allowlist.  
- Added an allowlist at `ai-post-scheduler/config/repository-boundary-whitelist.txt` for temporary exceptions and wired a Composer script `lint:repository-boundary` in `ai-post-scheduler/composer.json` to run the guard via `php tools/check-repository-boundary.php`.

### Testing

- Ran `cd ai-post-scheduler && composer lint:repository-boundary` which executed the new guard and it passed.  
- No other automated test suites were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bcd54e26883218d3131b3df9747f1)