### PR TITLE
🐞 Hunter: Mocked WP core functions in bootstrap.php for limited mode

### DIFF
--- a/.jules/hunter.md
+++ b/.jules/hunter.md
@@ -1,3 +1,6 @@
 ## 2026-04-27 - Handle Template Data Object Type Error
 **Learning:** Legacy template variables might receive class instances instead of expected associative arrays, causing fatal `Cannot use object of type class as array` errors in PHP 8+.
 **Action:** Always check `is_object($data)` before accessing elements via `$data['key']` in templates. If it is an object, use getter methods (e.g. `$handler->get_data()`) to retrieve an array context.
+## 2026-05-19 - [Fixing WP Core Mocks for PHPUnit]
+**Learning:** PHPUnit tests run in limited mode and throw `Call to undefined function` errors (like `esc_sql`, `wp_date`, `wp_timezone`) when WP core functions aren't mocked in `tests/bootstrap.php`.
+**Action:** Always add WP core function mocks to `tests/bootstrap.php` if they are used by the components being tested and the test environment runs in limited mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+### Fixed
+- Tests: Mocked WP core functions in bootstrap.php (`esc_sql`, `wp_date`, `wp_timezone`) to fix fatal errors in PHPUnit tests running in limited mode.
+
 ### Changed
 - Admin History: Replaced full page reload with AJAX table reload when retrying failed generations to improve user flow.
 - Refactored multiple admin UI actions to update DOM tables dynamically without a full page reload for a smoother user experience.

--- a/ai-post-scheduler/tests/bootstrap.php
+++ b/ai-post-scheduler/tests/bootstrap.php
@@ -116,6 +116,25 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
         }
     }
 
+    if (!function_exists('wp_date')) {
+        function wp_date($format, $timestamp = null, $timezone = null) {
+            if ($timestamp === null) $timestamp = time();
+            return date($format, $timestamp);
+        }
+    }
+
+    if (!function_exists('wp_timezone')) {
+        function wp_timezone() {
+            return new DateTimeZone('UTC');
+        }
+    }
+
+    if (!function_exists('esc_sql')) {
+        function esc_sql($data) {
+            return $data;
+        }
+    }
+
     if (!function_exists('esc_html')) {
         function esc_html($text) {
             return $text;


### PR DESCRIPTION
🐛 Bug: PHPUnit tests run in limited mode without the WordPress environment loaded. This resulted in fatal "Call to undefined function" errors for functions like `esc_sql`, `wp_date`, and `wp_timezone` (specifically failing `Test_History_Template`).
🔍 Root Cause: The WordPress testing environment was not properly loaded, meaning these native WP core functions were undefined.
🛠️ Fix: Mocked these WP core functions safely inside `ai-post-scheduler/tests/bootstrap.php` to prevent the errors and allow tests to run correctly in isolation.
🧪 Verification: Ran `vendor/bin/phpunit` tests and verified that the `Test_History_Template` test now passes without fatal "undefined function" errors, and the general test suite also has fewer warnings.

---
*PR created automatically by Jules for task [15180067488933547934](https://jules.google.com/task/15180067488933547934) started by @rpnunez*