### PR TITLE
🐞 Hunter: Fix Interval Calculator Start Time Fallback

### DIFF
--- a/.jules/hunter.md
+++ b/.jules/hunter.md
@@ -1,3 +1,7 @@
 ## 2026-04-27 - Handle Template Data Object Type Error
 **Learning:** Legacy template variables might receive class instances instead of expected associative arrays, causing fatal `Cannot use object of type class as array` errors in PHP 8+.
 **Action:** Always check `is_object($data)` before accessing elements via `$data['key']` in templates. If it is an object, use getter methods (e.g. `$handler->get_data()`) to retrieve an array context.
+
+## 2024-05-21 - Interval Calculator Start Time Fallback
+**Learning:** `calculate_next_run` methods expecting Unix timestamps must safely fallback using `strtotime()` when string date representations are provided instead of strictly rejecting non-numeric inputs.
+**Action:** When method signatures expect numeric timestamps but might receive string dates (e.g. `$start_time`), implement type guards that gracefully fallback using `strtotime($var) !== false`. Corresponding tests must assert against strict numeric values rather than comparing timestamps to formatted date strings.

--- a/ai-post-scheduler/includes/class-aips-interval-calculator.php
+++ b/ai-post-scheduler/includes/class-aips-interval-calculator.php
@@ -129,9 +129,13 @@ class AIPS_Interval_Calculator {
      * @return int UTC Unix timestamp for the next run.
      */
     public function calculate_next_run($frequency, $start_time = null) {
-        $base_time = is_numeric($start_time) && (int) $start_time > 0
-            ? (int) $start_time
-            : AIPS_DateTime::now()->timestamp();
+        if (is_numeric($start_time) && (int) $start_time > 0) {
+            $base_time = (int) $start_time;
+        } elseif (is_string($start_time) && strtotime($start_time) !== false) {
+            $base_time = strtotime($start_time);
+        } else {
+            $base_time = AIPS_DateTime::now()->timestamp();
+        }
         $now = AIPS_DateTime::now()->timestamp();
         
         // If start time is in the past, add intervals until future (Catch-up logic)

--- a/ai-post-scheduler/includes/class-aips-interval-calculator.php
+++ b/ai-post-scheduler/includes/class-aips-interval-calculator.php
@@ -131,8 +131,8 @@ class AIPS_Interval_Calculator {
     public function calculate_next_run($frequency, $start_time = null) {
         if (is_numeric($start_time) && (int) $start_time > 0) {
             $base_time = (int) $start_time;
-        } elseif (is_string($start_time) && strtotime($start_time) !== false) {
-            $base_time = strtotime($start_time);
+        } elseif (is_string($start_time) && ($parsed = strtotime($start_time)) !== false) {
+            $base_time = $parsed;
         } else {
             $base_time = AIPS_DateTime::now()->timestamp();
         }

--- a/ai-post-scheduler/tests/Test_AIPS_Interval_Calculator.php
+++ b/ai-post-scheduler/tests/Test_AIPS_Interval_Calculator.php
@@ -65,7 +65,7 @@ class Test_AIPS_Interval_Calculator extends WP_UnitTestCase {
         $start = '2030-06-15 10:00:00';
         $next = $this->calculator->calculate_next_run('hourly', $start);
         
-        $expected = '2030-06-15 11:00:00';
+        $expected = strtotime('2030-06-15 11:00:00');
         $this->assertEquals($expected, $next);
     }
 
@@ -76,7 +76,7 @@ class Test_AIPS_Interval_Calculator extends WP_UnitTestCase {
         $start = '2030-06-15 10:00:00';
         $next = $this->calculator->calculate_next_run('daily', $start);
         
-        $expected = '2030-06-16 10:00:00';
+        $expected = strtotime('2030-06-16 10:00:00');
         $this->assertEquals($expected, $next);
     }
 
@@ -87,7 +87,7 @@ class Test_AIPS_Interval_Calculator extends WP_UnitTestCase {
         $start = '2030-06-15 10:00:00';
         $next = $this->calculator->calculate_next_run('weekly', $start);
         
-        $expected = '2030-06-22 10:00:00';
+        $expected = strtotime('2030-06-22 10:00:00');
         $this->assertEquals($expected, $next);
     }
 
@@ -98,7 +98,7 @@ class Test_AIPS_Interval_Calculator extends WP_UnitTestCase {
         $start = '2030-06-15 10:00:00';
         $next = $this->calculator->calculate_next_run('monthly', $start);
         
-        $expected = '2030-07-15 10:00:00';
+        $expected = strtotime('2030-07-15 10:00:00');
         $this->assertEquals($expected, $next);
     }
 
@@ -109,7 +109,7 @@ class Test_AIPS_Interval_Calculator extends WP_UnitTestCase {
         $start = '2030-06-15 10:00:00';
         $next = $this->calculator->calculate_next_run('every_4_hours', $start);
         
-        $expected = '2030-06-15 14:00:00';
+        $expected = strtotime('2030-06-15 14:00:00');
         $this->assertEquals($expected, $next);
     }
 
@@ -120,7 +120,7 @@ class Test_AIPS_Interval_Calculator extends WP_UnitTestCase {
         $start = '2030-06-15 10:00:00';
         $next = $this->calculator->calculate_next_run('every_6_hours', $start);
         
-        $expected = '2030-06-15 16:00:00';
+        $expected = strtotime('2030-06-15 16:00:00');
         $this->assertEquals($expected, $next);
     }
 
@@ -131,7 +131,7 @@ class Test_AIPS_Interval_Calculator extends WP_UnitTestCase {
         $start = '2030-06-15 10:00:00';
         $next = $this->calculator->calculate_next_run('every_12_hours', $start);
         
-        $expected = '2030-06-15 22:00:00';
+        $expected = strtotime('2030-06-15 22:00:00');
         $this->assertEquals($expected, $next);
     }
 
@@ -142,7 +142,7 @@ class Test_AIPS_Interval_Calculator extends WP_UnitTestCase {
         $start = '2030-06-15 10:00:00';
         $next = $this->calculator->calculate_next_run('bi_weekly', $start);
         
-        $expected = '2030-06-29 10:00:00';
+        $expected = strtotime('2030-06-29 10:00:00');
         $this->assertEquals($expected, $next);
     }
 
@@ -156,7 +156,7 @@ class Test_AIPS_Interval_Calculator extends WP_UnitTestCase {
         $next = $this->calculator->calculate_next_run('every_monday', $start);
         
         // For every_monday from a Monday start, next should be 7 days later
-        $expected = '2030-06-17 10:00:00';
+        $expected = strtotime('2030-06-17 10:00:00');
         $this->assertEquals($expected, $next);
     }
 
@@ -171,7 +171,7 @@ class Test_AIPS_Interval_Calculator extends WP_UnitTestCase {
         $next = $this->calculator->calculate_next_run('every_wednesday', $start);
         
         // Next Wednesday after Monday June 10 should be Wednesday June 12, preserving time
-        $expected = '2030-06-12 14:30:00';
+        $expected = strtotime('2030-06-12 14:30:00');
         $this->assertEquals($expected, $next);
     }
 
@@ -181,11 +181,11 @@ class Test_AIPS_Interval_Calculator extends WP_UnitTestCase {
     public function test_calculate_next_run_without_start_time() {
         $next = $this->calculator->calculate_next_run('daily');
         
-        // Should return a datetime string
-        $this->assertMatchesRegularExpression('/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/', $next);
+        // Should return a numeric timestamp
+        $this->assertIsInt($next);
         
         // Should be in the future
-        $this->assertGreaterThan(current_time('mysql'), $next);
+        $this->assertGreaterThan(time(), $next);
     }
 
     /**
@@ -196,10 +196,8 @@ class Test_AIPS_Interval_Calculator extends WP_UnitTestCase {
         $next = $this->calculator->calculate_next_run('daily', $start);
         
         // Should be in the future, not based on 2020
-        $next_timestamp = strtotime($next);
-        $current_timestamp = current_time('timestamp');
-        
-        $this->assertGreaterThan($current_timestamp, $next_timestamp);
+        $this->assertIsInt($next);
+        $this->assertGreaterThan(time(), $next);
     }
 
     /**
@@ -287,7 +285,7 @@ class Test_AIPS_Interval_Calculator extends WP_UnitTestCase {
         $next = $this->calculator->calculate_next_run('invalid_frequency', $start);
         
         // Should default to +1 day
-        $expected = date('Y-m-d 10:00:00', strtotime('+1 day', strtotime($start)));
+        $expected = strtotime('+1 day', strtotime($start));
         $this->assertEquals($expected, $next);
     }
 }

--- a/ai-post-scheduler/tests/bootstrap.php
+++ b/ai-post-scheduler/tests/bootstrap.php
@@ -1592,6 +1592,6 @@ if (!function_exists('esc_sql')) {
 }
 if (!function_exists('wp_date')) {
     function wp_date($format, $timestamp = null, $timezone = null) {
-        return date($format, $timestamp ?: time());
+        return gmdate($format, $timestamp ?? time());
     }
 }

--- a/ai-post-scheduler/tests/bootstrap.php
+++ b/ai-post-scheduler/tests/bootstrap.php
@@ -1581,3 +1581,17 @@ if (!function_exists('_get_cron_array')) {
             : array();
     }
 }
+
+if (!function_exists('esc_sql')) {
+    function esc_sql($data) {
+        if (is_array($data)) {
+            return array_map('esc_sql', $data);
+        }
+        return addslashes($data);
+    }
+}
+if (!function_exists('wp_date')) {
+    function wp_date($format, $timestamp = null, $timezone = null) {
+        return date($format, $timestamp ?: time());
+    }
+}

--- a/ai-post-scheduler/vendor/composer/autoload_classmap.php
+++ b/ai-post-scheduler/vendor/composer/autoload_classmap.php
@@ -46,6 +46,8 @@ return array(
     'AIPS_Cache_Db_Driver' => $baseDir . '/includes/class-aips-cache-db-driver.php',
     'AIPS_Cache_Driver' => $baseDir . '/includes/interface-aips-cache-driver.php',
     'AIPS_Cache_Factory' => $baseDir . '/includes/class-aips-cache-factory.php',
+    'AIPS_Cache_Invalidation_Bus' => $baseDir . '/includes/class-aips-cache-invalidation-bus.php',
+    'AIPS_Cache_Policy' => $baseDir . '/includes/class-aips-cache-policy.php',
     'AIPS_Cache_Redis_Driver' => $baseDir . '/includes/class-aips-cache-redis-driver.php',
     'AIPS_Cache_Session_Driver' => $baseDir . '/includes/class-aips-cache-session-driver.php',
     'AIPS_Cache_Wp_Object_Cache_Driver' => $baseDir . '/includes/class-aips-cache-wp-object-cache-driver.php',

--- a/ai-post-scheduler/vendor/composer/autoload_static.php
+++ b/ai-post-scheduler/vendor/composer/autoload_static.php
@@ -76,6 +76,8 @@ class ComposerStaticInit35ade7d9f044c669e934e5a8a32e7934
         'AIPS_Cache_Db_Driver' => __DIR__ . '/../..' . '/includes/class-aips-cache-db-driver.php',
         'AIPS_Cache_Driver' => __DIR__ . '/../..' . '/includes/interface-aips-cache-driver.php',
         'AIPS_Cache_Factory' => __DIR__ . '/../..' . '/includes/class-aips-cache-factory.php',
+        'AIPS_Cache_Invalidation_Bus' => __DIR__ . '/../..' . '/includes/class-aips-cache-invalidation-bus.php',
+        'AIPS_Cache_Policy' => __DIR__ . '/../..' . '/includes/class-aips-cache-policy.php',
         'AIPS_Cache_Redis_Driver' => __DIR__ . '/../..' . '/includes/class-aips-cache-redis-driver.php',
         'AIPS_Cache_Session_Driver' => __DIR__ . '/../..' . '/includes/class-aips-cache-session-driver.php',
         'AIPS_Cache_Wp_Object_Cache_Driver' => __DIR__ . '/../..' . '/includes/class-aips-cache-wp-object-cache-driver.php',

--- a/ai-post-scheduler/vendor/composer/installed.php
+++ b/ai-post-scheduler/vendor/composer/installed.php
@@ -1,9 +1,9 @@
 <?php return array(
     'root' => array(
         'name' => 'rpnunez/wp-ai-scheduler',
-        'pretty_version' => 'dev-codex/add-history-button-to-post-actions-pqbnkl',
-        'version' => 'dev-codex/add-history-button-to-post-actions-pqbnkl',
-        'reference' => 'ad2b843139271e08a2a43b35e9057eaa7c313a1d',
+        'pretty_version' => 'dev-bug-hunter-interval-calculator-fix-17953350815519394961',
+        'version' => 'dev-bug-hunter-interval-calculator-fix-17953350815519394961',
+        'reference' => '57b0fb5ba98d865b8833f81ba5b310d11a9c1814',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -101,9 +101,9 @@
             'dev_requirement' => true,
         ),
         'rpnunez/wp-ai-scheduler' => array(
-            'pretty_version' => 'dev-codex/add-history-button-to-post-actions-pqbnkl',
-            'version' => 'dev-codex/add-history-button-to-post-actions-pqbnkl',
-            'reference' => 'ad2b843139271e08a2a43b35e9057eaa7c313a1d',
+            'pretty_version' => 'dev-bug-hunter-interval-calculator-fix-17953350815519394961',
+            'version' => 'dev-bug-hunter-interval-calculator-fix-17953350815519394961',
+            'reference' => '57b0fb5ba98d865b8833f81ba5b310d11a9c1814',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
🐛 Bug: The `calculate_next_run` method in `AIPS_Interval_Calculator` strictly required an integer timestamp and silently fell back to the current time if a string date was provided, breaking schedule phases.
🔍 Root Cause: The method checked `is_numeric($start_time)`. Since tests and possibly callers passed string dates like '2030-06-15 10:00:00', the check failed and used `now()`. Furthermore, tests were asserting string dates against numeric returns. Additionally, missing WP functions (`esc_sql`, `wp_date`) in `tests/bootstrap.php` caused limited mode test errors.
🛠️ Fix: Added a type guard for strings using `strtotime()` to gracefully parse dates. Updated corresponding tests to strictly assert numeric Unix timestamps. Mocked `esc_sql` in test bootstrap.
🧪 Verification: Ran the full test suite (`Test_AIPS_Interval_Calculator.php` and `Test_History_Template.php` now pass).

---
*PR created automatically by Jules for task [17953350815519394961](https://jules.google.com/task/17953350815519394961) started by @rpnunez*