### PR TITLE
Add repository-specific Codex skills and skills README

### DIFF
--- a/.codex/skills/README.md
+++ b/.codex/skills/README.md
@@ -1,0 +1,12 @@
+# Codex Skills for wp-ai-scheduler
+
+This directory contains repository-specific Codex skills for common contribution patterns:
+
+- `db-changes`: safe schema/migration workflows.
+- `admin-ui-changes`: WordPress admin page/template/asset changes.
+- `ajax-controller-changes`: AJAX action routing and controller best practices.
+- `generation-changes`: generation/regeneration and prompt architecture changes.
+- `pr-triage`: overlap detection and review-risk triage.
+- `feature-slicing`: planning work into mergeable slices.
+
+Each skill is documented in a `SKILL.md` file within its folder.

--- a/.codex/skills/admin-ui-changes/SKILL.md
+++ b/.codex/skills/admin-ui-changes/SKILL.md
@@ -4,7 +4,7 @@ Use this skill when changing WordPress admin pages, menus, templates, and admin 
 
 ## Scope
 - Admin menus/routes and admin-facing rendering.
-- `templates/admin/`, `assets/js/`, `assets/css/`, and admin controllers.
+- `ai-post-scheduler/templates/admin/`, `ai-post-scheduler/assets/js/`, `ai-post-scheduler/assets/css/`, and admin controllers.
 
 ## Required workflow
 1. **Map page ownership**

--- a/.codex/skills/admin-ui-changes/SKILL.md
+++ b/.codex/skills/admin-ui-changes/SKILL.md
@@ -17,8 +17,8 @@ Use this skill when changing WordPress admin pages, menus, templates, and admin 
    - Escape all output (`esc_html`, `esc_attr`, `esc_url`, `wp_kses_post`).
    - Verify nonce/capability for state-changing actions.
 4. **Asset updates**
-   - Place admin interactions in `assets/js/`.
-   - Keep styles in `assets/css/` and reuse existing classes when possible.
+   - Place admin interactions in `ai-post-scheduler/assets/js/`.
+   - Keep styles in `ai-post-scheduler/assets/css/` and reuse existing classes when possible.
 5. **Validation**
    - Exercise affected admin pages.
    - Run relevant PHPUnit tests for touched controllers/services.

--- a/.codex/skills/admin-ui-changes/SKILL.md
+++ b/.codex/skills/admin-ui-changes/SKILL.md
@@ -1,0 +1,36 @@
+# Admin UI Changes Skill
+
+Use this skill when changing WordPress admin pages, menus, templates, and admin JS/CSS.
+
+## Scope
+- Admin menus/routes and admin-facing rendering.
+- `templates/admin/`, `assets/js/`, `assets/css/`, and admin controllers.
+
+## Required workflow
+1. **Map page ownership**
+   - Verify route/menu source in `AIPS_Admin_Menu::add_menu_pages()`.
+   - Identify the controller that provides data to the template.
+2. **Separate concerns**
+   - Put business logic in `includes/` service/controller classes.
+   - Keep templates in `ai-post-scheduler/templates/admin/` primarily for rendering.
+3. **Security + hygiene**
+   - Escape all output (`esc_html`, `esc_attr`, `esc_url`, `wp_kses_post`).
+   - Verify nonce/capability for state-changing actions.
+4. **Asset updates**
+   - Place admin interactions in `assets/js/`.
+   - Keep styles in `assets/css/` and reuse existing classes when possible.
+5. **Validation**
+   - Exercise affected admin pages.
+   - Run relevant PHPUnit tests for touched controllers/services.
+
+## Guardrails
+- Do not register menu pages in `AIPS_Settings`; use `AIPS_Admin_Menu`.
+- Avoid render-time controller reinstantiation patterns.
+- Follow plugin style conventions (tabs, `array()`).
+
+## Useful files
+- `ai-post-scheduler/includes/class-aips-admin-menu.php`
+- `ai-post-scheduler/includes/class-aips-admin-assets.php`
+- `ai-post-scheduler/templates/admin/`
+- `ai-post-scheduler/assets/js/`
+- `ai-post-scheduler/assets/css/`

--- a/.codex/skills/admin-ui-changes/SKILL.md
+++ b/.codex/skills/admin-ui-changes/SKILL.md
@@ -11,7 +11,7 @@ Use this skill when changing WordPress admin pages, menus, templates, and admin 
    - Verify route/menu source in `AIPS_Admin_Menu::add_menu_pages()`.
    - Identify the controller that provides data to the template.
 2. **Separate concerns**
-   - Put business logic in `includes/` service/controller classes.
+   - Put business logic in `ai-post-scheduler/includes/` service/controller classes.
    - Keep templates in `ai-post-scheduler/templates/admin/` primarily for rendering.
 3. **Security + hygiene**
    - Escape all output (`esc_html`, `esc_attr`, `esc_url`, `wp_kses_post`).

--- a/.codex/skills/ajax-controller-changes/SKILL.md
+++ b/.codex/skills/ajax-controller-changes/SKILL.md
@@ -1,0 +1,33 @@
+# AJAX Controller Changes Skill
+
+Use this skill when adding or modifying plugin AJAX endpoints and handlers.
+
+## Scope
+- `wp_ajax_*` handlers, controller constructors, and action routing.
+- Registry mapping in `AIPS_Ajax_Registry`.
+
+## Required workflow
+1. **Route first**
+   - Add/confirm the action in `AIPS_Ajax_Registry::$map`.
+   - Ensure the action resolves to exactly one responsible controller class.
+2. **Controller responsibilities**
+   - Register hooks in the controller constructor.
+   - Handle nonce checks, capability checks, sanitization, and response formatting.
+3. **Repository boundary**
+   - Keep SQL/persistence in repository classes.
+   - Call repositories/services from controller methods.
+4. **Response consistency**
+   - Use `AIPS_Ajax_Response` for JSON replies.
+   - Return predictable error payloads for validation/capability failures.
+5. **Validation**
+   - Add/extend PHPUnit tests for both success and failure paths.
+
+## Guardrails
+- Never bypass `current_user_can('manage_options')` for admin-only actions.
+- Do not introduce anonymous ad hoc AJAX actions outside registry routing.
+
+## Useful files
+- `ai-post-scheduler/includes/class-aips-ajax-registry.php`
+- `ai-post-scheduler/includes/class-aips-ajax-response.php`
+- `ai-post-scheduler/includes/class-aips-settings-ajax.php`
+- `ai-post-scheduler/tests/Test_AIPS_Ajax_Registry_Response.php`

--- a/.codex/skills/db-changes/SKILL.md
+++ b/.codex/skills/db-changes/SKILL.md
@@ -1,0 +1,36 @@
+# DB Changes Skill
+
+Use this skill when implementing schema/table/index changes in the AI Post Scheduler plugin.
+
+## Scope
+- WordPress plugin DB schema and upgrade safety.
+- Tables managed by `AIPS_DB_Manager` and migrations managed by `AIPS_DB_Migrations`.
+
+## Required workflow
+1. **Locate ownership**
+   - Confirm the table or schema lives in `ai-post-scheduler/includes/class-aips-db-manager.php`.
+   - Confirm migration touchpoints in `ai-post-scheduler/includes/class-aips-db-migrations.php`.
+2. **Design for backward compatibility**
+   - Prefer additive changes.
+   - Never drop/rename columns without a compatibility bridge.
+3. **Implement through DB manager/migrations only**
+   - Update `AIPS_DB_Manager::get_schema()`.
+   - Ensure `AIPS_DB_Manager::install_tables()` + `dbDelta` can apply the change.
+   - If needed, add/extend migration logic in `AIPS_DB_Migrations::check_and_run()` flows.
+4. **Repository boundary check**
+   - Keep SQL in repository classes under `ai-post-scheduler/includes/`.
+   - Avoid SQL in controllers and templates.
+5. **Validation**
+   - Run targeted tests first, then broader suite when practical.
+   - Confirm plugin activation/upgrade path remains safe.
+
+## Guardrails
+- Target PHP 8.2+ and WP 5.8+.
+- Keep WordPress style: tabs, `array()` syntax.
+- Add/keep `if (!defined('ABSPATH')) { exit; }` in new PHP files.
+
+## Useful files
+- `ai-post-scheduler/includes/class-aips-db-manager.php`
+- `ai-post-scheduler/includes/class-aips-db-migrations.php`
+- `ai-post-scheduler/tests/Test_AIPS_DB_Schema.php`
+- `ai-post-scheduler/tests/Test_AIPS_DB_Migrations.php`

--- a/.codex/skills/feature-slicing/SKILL.md
+++ b/.codex/skills/feature-slicing/SKILL.md
@@ -1,0 +1,34 @@
+# Feature Slicing Skill
+
+Use this skill to break a feature into implementation slices that are independently testable and mergeable.
+
+## Scope
+- Planning and decomposition for plugin features across DB, backend, AJAX, UI, and tests.
+
+## Required workflow
+1. **Define outcomes first**
+   - Write user-visible outcomes and technical acceptance criteria.
+2. **Slice by dependency chain**
+   - Suggested order:
+     1) schema/repository,
+     2) services/business logic,
+     3) AJAX/controller wiring,
+     4) admin UI,
+     5) telemetry/observability polish.
+3. **Keep slices vertical when possible**
+   - Each slice should include minimal code + tests needed for confidence.
+4. **Set merge gates per slice**
+   - Explicit tests to pass.
+   - Rollback/fallback notes for risky changes.
+5. **Cross-check overlap**
+   - Confirm no open PR already owns the same slice before starting.
+
+## Guardrails
+- Avoid giant PRs mixing unrelated concerns.
+- Keep SQL in repositories and routing in `AIPS_Ajax_Registry`.
+- Ensure each slice can be reviewed in isolation.
+
+## Useful references
+- `docs/DEV_HANDBOOK.md`
+- `docs/DEVELOPMENT_GUIDELINES.md`
+- `ai-post-scheduler/tests/`

--- a/.codex/skills/generation-changes/SKILL.md
+++ b/.codex/skills/generation-changes/SKILL.md
@@ -1,0 +1,34 @@
+# Generation Changes Skill
+
+Use this skill for post generation/regeneration workflows, prompts, and scheduling execution logic.
+
+## Scope
+- Generation context architecture, prompt builders, generation orchestration, and recovery flows.
+
+## Required workflow
+1. **Use context-based generation**
+   - Prefer `AIPS_Generation_Context` + factory (`AIPS_Generation_Context_Factory`).
+   - Avoid introducing new raw-template-only paths when context abstractions apply.
+2. **Prompt assembly discipline**
+   - Reuse shared/specialized builders (`AIPS_Prompt_Builder*`).
+   - Keep prompt composition isolated from transport/execution code.
+3. **Lifecycle observability**
+   - Record meaningful operations via `AIPS_History_Service` and generation logging.
+   - Use structured logs and correlation IDs where relevant.
+4. **Resilience and cron safety**
+   - Use `AIPS_Resilience_Service::retry_with_backoff()` for retryable operations.
+   - Ensure cron handlers remain idempotent for slice/batch retries.
+5. **Validation**
+   - Cover happy path + failure/retry + partial-generation recovery where affected.
+
+## Guardrails
+- Keep scheduling orchestration in services/schedulers.
+- Keep SQL in repositories.
+- Respect existing batch queue/job slicing patterns.
+
+## Useful files
+- `ai-post-scheduler/includes/class-aips-generation-context-factory.php`
+- `ai-post-scheduler/includes/class-aips-generator.php`
+- `ai-post-scheduler/includes/class-aips-author-post-generator.php`
+- `ai-post-scheduler/includes/class-aips-resilience-service.php`
+- `ai-post-scheduler/includes/class-aips-partial-generation-state-reconciler.php`

--- a/.codex/skills/pr-triage/SKILL.md
+++ b/.codex/skills/pr-triage/SKILL.md
@@ -1,0 +1,31 @@
+# PR Triage Skill
+
+Use this skill to evaluate overlap risk, readiness, and review posture for incoming work.
+
+## Scope
+- Duplicate/overlapping work detection.
+- Risk triage and review checklist preparation.
+
+## Required workflow
+1. **Check current open PRs/issues**
+   - Pull open PRs before implementation planning.
+   - Identify overlap by feature area, files, and acceptance criteria.
+2. **Classify PR risk**
+   - Mark changes as low/medium/high risk based on schema changes, cron behavior, AJAX surface, and user-impacting UI changes.
+3. **Review checklist**
+   - Security: nonce/capability/sanitization/escaping.
+   - Architecture: registry usage, repository boundaries, context patterns.
+   - Reliability: retries, idempotency, batch behavior.
+   - Tests: required coverage additions.
+4. **Decision output**
+   - Recommend: proceed, split, defer, or close as duplicate.
+   - Provide concise rationale and next steps.
+
+## Guardrails
+- De-duplication is mandatory unless explicitly overridden.
+- Prefer small, sliceable PRs over broad mixed-scope changes.
+
+## Useful references
+- `AGENTS.md`
+- `docs/DEVELOPMENT_GUIDELINES.md`
+- `.github/agents/PR Oracle v2.agent.md`


### PR DESCRIPTION
### Motivation
- Provide a set of repository-specific Codex skills to standardize common contribution patterns and guardrails across the plugin codebase.
- Capture guidance for high-risk areas such as DB migrations, AJAX handlers, generation workflows, and admin UI changes to reduce review friction and regressions.
- Add a central index so agents and contributors can discover the skills for planning and PR triage.

### Description
- Add a top-level skills index at `.codex/skills/README.md` that enumerates available skills and where each is documented.
- Add `SKILL.md` guidance files for `admin-ui-changes`, `ajax-controller-changes`, `db-changes`, `generation-changes`, `pr-triage`, and `feature-slicing` under `.codex/skills/`, each documenting scope, required workflow, guardrails, and useful file references.
- All new files are documentation only and live under the `.codex/skills/` directory to be consumed by agents and developer workflows.

### Testing
- No automated tests were run because these are documentation-only changes and do not affect runtime code or tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a105d18cbf8832186e8cca46ec21de7)