### PR TITLE
🐞 Hunter: Fix undefined function `esc_sql` in tests

### DIFF
--- a/.jules/hunter.md
+++ b/.jules/hunter.md
@@ -1,3 +1,6 @@
 ## 2026-04-27 - Handle Template Data Object Type Error
 **Learning:** Legacy template variables might receive class instances instead of expected associative arrays, causing fatal `Cannot use object of type class as array` errors in PHP 8+.
 **Action:** Always check `is_object($data)` before accessing elements via `$data['key']` in templates. If it is an object, use getter methods (e.g. `$handler->get_data()`) to retrieve an array context.
+## 2024-05-22 - Missing WordPress Mock Function in Tests
+**Learning:** In the limited unit testing environment (when WordPress is not loaded), WordPress escaping functions are not naturally available. Missing functions, such as `esc_sql`, lead to fatal PHP errors (`Call to undefined function`) during test execution when those functions are invoked by the classes under test.
+**Action:** When tests fail with missing WordPress functions in isolated environments, proactively mock the necessary WordPress functions (like `esc_sql`) in `tests/bootstrap.php` to replicate the required behavior safely.

--- a/ai-post-scheduler/tests/bootstrap.php
+++ b/ai-post-scheduler/tests/bootstrap.php
@@ -163,6 +163,15 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
         }
     }
 
+    if (!function_exists('esc_sql')) {
+        function esc_sql($data) {
+            if (is_array($data)) {
+                return array_map('esc_sql', $data);
+            }
+            return addslashes($data);
+        }
+    }
+
     
     if (!function_exists('plugin_dir_path')) {
         function plugin_dir_path($file) {


### PR DESCRIPTION
🐛 **Bug:** Tests relying on `esc_sql` were failing with "Call to undefined function" in the limited testing environment because the WordPress function wasn't mocked.
🔍 **Root Cause:** In the limited/isolated test runner (`bootstrap.php`), WordPress is not loaded, and the `esc_sql` function was not previously provided in the mock stubs.
🛠️ **Fix:** Added a mocked version of `esc_sql` in `tests/bootstrap.php` that correctly handles recursive arrays and uses `addslashes` as a testing fallback.
🧪 **Verification:** Executed `cd ai-post-scheduler && vendor/bin/phpunit tests/Test_History_Template.php` which now passes successfully without the missing function error.

---
*PR created automatically by Jules for task [3069189599816672020](https://jules.google.com/task/3069189599816672020) started by @rpnunez*