### PR TITLE
Labels automation + Issue/PR templates 

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-ready-feature.yml
+++ b/.github/ISSUE_TEMPLATE/agent-ready-feature.yml
@@ -1,0 +1,61 @@
+name: Agent-ready feature spec
+description: Structured feature request ready for Codex/Copilot/Gemini implementation.
+title: "[agent-ready] "
+labels:
+  - agent-ready
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template when the issue is implementation-ready for AI agents.
+  - type: input
+    id: goal
+    attributes:
+      label: Goal
+      description: What outcome should be achieved?
+      placeholder: Add export progress indicators to history page.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: In scope
+      description: Explicitly list touched files/systems and non-goals.
+      placeholder: |
+        - Includes: ai-post-scheduler/includes/class-aips-...
+        - Templates: ai-post-scheduler/templates/admin/...
+        - Not in scope: unrelated refactors
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Concrete pass/fail checks.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification plan
+      description: Tests + manual checks required before merge.
+      placeholder: |
+        - `composer test -- tests/Test_...php`
+        - Manual browser check on wp-admin page ...
+    validations:
+      required: true
+  - type: checkboxes
+    id: risk_labels
+    attributes:
+      label: Risk labels
+      options:
+        - label: Add `schema-change` when DB schema/version is touched
+        - label: Add `admin-ui` and `needs-browser-test` when admin UI is touched
+        - label: Add `ajax-registry` for AJAX map/controller wiring changes
+        - label: Add `cron` for scheduling/queue/retry flow changes
+        - label: Add `generation-pipeline` for prompt/generation path changes
+        - label: Add `security-sensitive` for auth/nonce/capability/data-safety changes
+        - label: Mark `needs-spec` instead of `agent-ready` if details are incomplete

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,4 +14,4 @@
 - [ ] Label `cron` applied when cron/queue/retry paths are touched
 - [ ] Label `generation-pipeline` applied when prompt/generation flow is touched
 - [ ] Label `security-sensitive` applied when auth/nonce/capability/data-safety paths are touched
-- [ ] `duplicate-risk` checked and addressed before merge
+- [ ] Label duplicate-risk applied and addressed before merge

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+- What changed?
+- Why now?
+
+## Verification
+- [ ] `composer test` (or targeted tests) run for changed behavior
+- [ ] Manual verification completed for changed admin/runtime paths
+- [ ] Documentation updated (if behavior or workflow changed)
+
+## Risk Checklist
+- [ ] Label `schema-change` applied when DB schema/version is touched
+- [ ] Label `admin-ui` + `needs-browser-test` applied when admin UI is touched
+- [ ] Label `ajax-registry` applied when AJAX handlers/registry are touched
+- [ ] Label `cron` applied when cron/queue/retry paths are touched
+- [ ] Label `generation-pipeline` applied when prompt/generation flow is touched
+- [ ] Label `security-sensitive` applied when auth/nonce/capability/data-safety paths are touched
+- [ ] `duplicate-risk` checked and addressed before merge

--- a/.github/workflows/standardize-agent-labels.yml
+++ b/.github/workflows/standardize-agent-labels.yml
@@ -1,0 +1,65 @@
+name: Standardize Agent Labels
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  sync-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create or update required labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const labels = [
+              { name: 'agent-ready', color: '0e8a16', description: 'Spec is complete and ready for an agent to implement.' },
+              { name: 'needs-spec', color: 'fbca04', description: 'Needs a complete implementation spec before agent work.' },
+              { name: 'duplicate-risk', color: 'd4c5f9', description: 'Likely overlaps with existing PR/work.' },
+              { name: 'schema-change', color: 'b60205', description: 'Changes database schema, migrations, or versioning.' },
+              { name: 'admin-ui', color: '1d76db', description: 'Touches wp-admin UI templates, CSS, or JS.' },
+              { name: 'ajax-registry', color: '5319e7', description: 'Touches AJAX registry, handlers, or controller wiring.' },
+              { name: 'cron', color: '0052cc', description: 'Touches cron schedules, jobs, queues, or retry logic.' },
+              { name: 'generation-pipeline', color: '006b75', description: 'Touches prompts, generation flow, or AI pipeline.' },
+              { name: 'security-sensitive', color: 'b60205', description: 'Touches nonces, capabilities, auth, or data safety boundaries.' },
+              { name: 'needs-browser-test', color: 'c2e0c6', description: 'Requires browser/manual verification before merge.' },
+            ];
+
+            for (const label of labels) {
+              try {
+                await github.rest.issues.getLabel({
+                  owner,
+                  repo,
+                  name: label.name,
+                });
+
+                await github.rest.issues.updateLabel({
+                  owner,
+                  repo,
+                  name: label.name,
+                  new_name: label.name,
+                  color: label.color,
+                  description: label.description,
+                });
+                core.info(`Updated label: ${label.name}`);
+              } catch (error) {
+                if (error.status === 404) {
+                  await github.rest.issues.createLabel({
+                    owner,
+                    repo,
+                    name: label.name,
+                    color: label.color,
+                    description: label.description,
+                  });
+                  core.info(`Created label: ${label.name}`);
+                } else {
+                  throw error;
+                }
+              }
+            }


### PR DESCRIPTION
## Summary
Split from umbrella PR #1604.  
This PR isolates repository intake/labeling assets:
- label standardization workflow
- agent-ready issue template
- PR template

## Scope
- `.github/workflows/standardize-agent-labels.yml`
- `.github/ISSUE_TEMPLATE/agent-ready-feature.yml`
- `.github/ISSUE_TEMPLATE/config.yml`
- `.github/pull_request_template.md`

## Why this split
Keeps labeling and contribution templates independently reviewable and mergeable, without coupling to CI guardrails or workflow docs.

## Verification
- Confirmed diff is limited to the files above.
- No plugin/runtime PHP code changes.
- No `vendor/composer/*` changes included.

## Relationship to #1604
This is a direct slice of #1604.  
Umbrella PR #1604 remains unchanged as backup until all replacement PRs are validated.