### PR TITLE
Agent lane instructions + Workflow documentation

### DIFF
--- a/.github/instructions/admin-ui.instructions.md
+++ b/.github/instructions/admin-ui.instructions.md
@@ -1,0 +1,11 @@
+---
+applyTo: "ai-post-scheduler/templates/admin/**/*.php,ai-post-scheduler/assets/js/admin*.js,ai-post-scheduler/assets/css/admin*.css"
+---
+
+Lane: **Admin UI changes** (`admin-ui`, `needs-browser-test`)
+
+- Keep templates presentation-only; move business logic to includes/.
+- Preserve existing `aips-*` hooks/classes used by JS.
+- Localize user-facing strings; escape output correctly in templates.
+- For behavior changes, include a manual browser verification checklist.
+- Apply both `admin-ui` and `needs-browser-test` labels on related PRs.

--- a/.github/instructions/ajax-controllers.instructions.md
+++ b/.github/instructions/ajax-controllers.instructions.md
@@ -1,0 +1,11 @@
+---
+applyTo: "ai-post-scheduler/includes/class-aips-ajax-registry.php,ai-post-scheduler/includes/class-aips-*-controller.php"
+---
+
+Lane: **AJAX controllers** (`ajax-registry`, `security-sensitive`)
+
+- Register AJAX action routing in `AIPS_Ajax_Registry` and keep handler ownership in controller classes.
+- Enforce capability checks and operation-specific nonces for each action.
+- Sanitize all inputs and return structured responses via existing response helpers.
+- Add/update tests for unauthorized requests, nonce failures, and success paths.
+- Apply `ajax-registry` and `security-sensitive` labels when this lane is touched.

--- a/.github/instructions/ajax-controllers.instructions.md
+++ b/.github/instructions/ajax-controllers.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "ai-post-scheduler/includes/class-aips-ajax-registry.php,ai-post-scheduler/includes/class-aips-*-controller.php"
+applyTo: "ai-post-scheduler/includes/class-aips-ajax-registry.php,ai-post-scheduler/includes/class-aips-*-controller.php,ai-post-scheduler/includes/class-aips-db-manager.php,ai-post-scheduler/includes/class-aips-history.php,ai-post-scheduler/includes/class-aips-voices.php,ai-post-scheduler/includes/class-aips-planner.php,ai-post-scheduler/includes/class-aips-post-review.php,ai-post-scheduler/includes/class-aips-settings-ajax.php"
 ---
 
 Lane: **AJAX controllers** (`ajax-registry`, `security-sensitive`)

--- a/.github/instructions/cron-generation.instructions.md
+++ b/.github/instructions/cron-generation.instructions.md
@@ -1,0 +1,11 @@
+---
+applyTo: "ai-post-scheduler/includes/class-aips-*scheduler*.php,ai-post-scheduler/includes/class-aips-*cron*.php,ai-post-scheduler/includes/class-aips-*generator*.php,ai-post-scheduler/includes/class-aips-*prompt*.php,ai-post-scheduler/includes/class-aips-generation-*.php"
+---
+
+Lane: **Cron + generation pipeline** (`cron`, `generation-pipeline`)
+
+- Keep scheduling/retry logic idempotent and safe for duplicate trigger execution.
+- Keep generation flow changes scoped and covered by targeted tests.
+- Record important lifecycle events using existing history/logging services.
+- Prefer repository/service boundaries; avoid direct SQL in scheduler/controller classes.
+- Apply `cron` and/or `generation-pipeline` labels for lane ownership.

--- a/.github/instructions/db-changes.instructions.md
+++ b/.github/instructions/db-changes.instructions.md
@@ -1,0 +1,11 @@
+---
+applyTo: "ai-post-scheduler/includes/class-aips-db-*.php,ai-post-scheduler/ai-post-scheduler.php"
+---
+
+Lane: **DB changes** (`schema-change`, `security-sensitive`)
+
+- Keep schema definitions and DB upgrades inside DB manager/migration classes only.
+- If schema changes, update both plugin header `Version:` and `AIPS_VERSION` in `ai-post-scheduler.php`.
+- Keep migrations backward-compatible and idempotent.
+- Add/update tests covering repository/query behavior and migration-safe paths.
+- Include rollback/compatibility notes in PR summary and apply `schema-change` label.

--- a/docs/AGENT_WORKFLOW.md
+++ b/docs/AGENT_WORKFLOW.md
@@ -1,0 +1,85 @@
+# Agent Workflow
+
+This document defines how Codex, Copilot, Gemini, and other agents should work in this repository.
+
+## 1) Intake labels
+
+Use and maintain these labels:
+
+- `agent-ready`
+- `needs-spec`
+- `duplicate-risk`
+- `schema-change`
+- `admin-ui`
+- `ajax-registry`
+- `cron`
+- `generation-pipeline`
+- `security-sensitive`
+- `needs-browser-test`
+
+Workflow: `.github/workflows/standardize-agent-labels.yml` standardizes these labels.
+
+## 2) Agent-ready issue format
+
+Use `.github/ISSUE_TEMPLATE/agent-ready-feature.yml` for implementation-ready feature work.
+
+Required sections:
+- Goal
+- In scope
+- Acceptance criteria
+- Verification plan
+- Risk labels
+
+If details are missing, replace `agent-ready` with `needs-spec`.
+
+## 3) PR risk checklist
+
+All PRs use `.github/pull_request_template.md`.
+
+The checklist requires:
+- verification notes
+- risk labels aligned to touched lanes
+- duplicate-risk confirmation
+
+## 4) Lane-specific instructions
+
+Path-specific Copilot instructions:
+
+- `.github/instructions/db-changes.instructions.md`
+- `.github/instructions/admin-ui.instructions.md`
+- `.github/instructions/ajax-controllers.instructions.md`
+- `.github/instructions/cron-generation.instructions.md`
+
+## 5) Codex skills
+
+Codex skill prompts:
+
+- `.github/prompts/skills/db-changes-skill.prompt.md`
+- `.github/prompts/skills/admin-ui-skill.prompt.md`
+- `.github/prompts/skills/ajax-controllers-skill.prompt.md`
+- `.github/prompts/skills/generation-pipeline-skill.prompt.md`
+- `.github/prompts/skills/pr-triage-skill.prompt.md`
+- `.github/prompts/skills/feature-slicing-skill.prompt.md`
+
+## 6) Weekly automations
+
+- Open PR triage: `.github/workflows/pr-triage-weekly.yml`
+- Docs drift report: `.github/workflows/docs-drift-weekly.yml`
+
+Prompt references:
+
+- `.github/prompts/pr-triage-daily.prompt.md`
+- `.github/prompts/docs-drift-weekly.prompt.md`
+
+## 7) CI risk guards
+
+Workflow: `.github/workflows/ci-pr.yml`
+
+`Risk Guardrails` now checks:
+- lane label presence based on changed paths
+- schema/version guard:
+  - schema-impacting changes require `schema-change`
+  - schema-impacting changes require a plugin version bump
+  - plugin header `Version:` and `AIPS_VERSION` must match
+
+This keeps risky changes reviewable and easier to merge safely.


### PR DESCRIPTION
## Summary
Split from umbrella PR #1604.  
This PR contains lane-specific guidance docs and the consolidated agent workflow documentation.

## Scope
- `.github/instructions/admin-ui.instructions.md`
- `.github/instructions/ajax-controllers.instructions.md`
- `.github/instructions/cron-generation.instructions.md`
- `.github/instructions/db-changes.instructions.md`
- `docs/AGENT_WORKFLOW.md`

## Why this split
Separates process/documentation guidance from executable automation and CI enforcement so docs can be reviewed and merged independently.

## Verification
- Confirmed diff is limited to the files above.
- Documentation/instructions only (no runtime code changes).
- No `vendor/composer/*` changes included.

## Relationship to #1604
This is a direct slice of #1604.  
Umbrella PR #1604 remains unchanged as backup until all replacement PRs are validated.