### PR TITLE
Weekly automations (PR triage + docs drift)

### DIFF
--- a/.github/prompts/docs-drift-weekly.prompt.md
+++ b/.github/prompts/docs-drift-weekly.prompt.md
@@ -12,4 +12,4 @@ Task:
 3. Suggest the highest-priority docs to refresh.
 
 Output:
-- JSON with risk level, changed code/docs paths, and top documentation actions.
+- JSON with the following structure: {"risk_level": "high|medium|low", "code_paths": [], "docs_paths": [], "actions": [{"doc": "string", "reason": "string"}]}

--- a/.github/prompts/docs-drift-weekly.prompt.md
+++ b/.github/prompts/docs-drift-weekly.prompt.md
@@ -1,0 +1,15 @@
+---
+mode: ask
+model: GPT-5.3-Codex
+description: Weekly docs drift analysis prompt for wp-ai-scheduler.
+---
+
+You are the Docs Drift automation assistant.
+
+Task:
+1. Compare code paths changed in the last 7 days with docs paths changed in the same window.
+2. Flag high drift risk when code changed without docs updates.
+3. Suggest the highest-priority docs to refresh.
+
+Output:
+- JSON with risk level, changed code/docs paths, and top documentation actions.

--- a/.github/workflows/docs-drift-weekly.yml
+++ b/.github/workflows/docs-drift-weekly.yml
@@ -35,7 +35,7 @@ jobs:
             ).trim().split('\n').filter(Boolean);
 
             const changedDocs = execSync(
-              `git log --since="${sinceIso}" --name-only --pretty=format: -- docs README.md ai-post-scheduler/README.md ai-post-scheduler/readme.txt | sed '/^$/d' | sort -u`,
+              `git log --since="${sinceIso}" --name-only --pretty=format: -- docs README.md ai-post-scheduler/README.md ai-post-scheduler/readme.txt ai-post-scheduler/docs | sed '/^$/d' | sort -u`,
               { encoding: 'utf8' }
             ).trim().split('\n').filter(Boolean);
 

--- a/.github/workflows/docs-drift-weekly.yml
+++ b/.github/workflows/docs-drift-weekly.yml
@@ -1,0 +1,74 @@
+name: Docs Drift Weekly
+
+on:
+  schedule:
+    - cron: '30 13 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  docs-drift:
+    name: Generate docs drift report
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build docs drift report
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const { execSync } = require('child_process');
+
+            const now = new Date();
+            const since = new Date(now.getTime() - (7 * 24 * 60 * 60 * 1000));
+            const sinceIso = since.toISOString();
+
+            const changedCore = execSync(
+              `git log --since="${sinceIso}" --name-only --pretty=format: -- ai-post-scheduler/includes ai-post-scheduler/templates ai-post-scheduler/assets | sed '/^$/d' | sort -u`,
+              { encoding: 'utf8' }
+            ).trim().split('\n').filter(Boolean);
+
+            const changedDocs = execSync(
+              `git log --since="${sinceIso}" --name-only --pretty=format: -- docs README.md ai-post-scheduler/README.md ai-post-scheduler/readme.txt | sed '/^$/d' | sort -u`,
+              { encoding: 'utf8' }
+            ).trim().split('\n').filter(Boolean);
+
+            const report = {
+              schema_version: 'docs-drift.v1',
+              generated_at: now.toISOString(),
+              prompt_template: '.github/prompts/docs-drift-weekly.prompt.md',
+              window_days: 7,
+              changed_code_paths: changedCore,
+              changed_docs_paths: changedDocs,
+              docs_drift_risk: changedCore.length > 0 && changedDocs.length === 0 ? 'high' : 'normal',
+            };
+
+            fs.mkdirSync('artifacts', { recursive: true });
+            fs.writeFileSync('artifacts/docs-drift-report.json', JSON.stringify(report, null, 2));
+            fs.writeFileSync(
+              'artifacts/docs-drift-summary.md',
+              [
+                '# Docs Drift Weekly',
+                '',
+                `- Generated: ${report.generated_at}`,
+                `- Prompt template: ${report.prompt_template}`,
+                `- Changed code paths: ${report.changed_code_paths.length}`,
+                `- Changed docs paths: ${report.changed_docs_paths.length}`,
+                `- Drift risk: ${report.docs_drift_risk}`,
+              ].join('\n')
+            );
+
+      - name: Upload docs drift artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-drift-weekly
+          path: artifacts/
+
+      - name: Append summary to workflow run
+        run: cat artifacts/docs-drift-summary.md >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pr-triage-weekly.yml
+++ b/.github/workflows/pr-triage-weekly.yml
@@ -304,7 +304,7 @@ jobs:
       - name: Upload triage artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: pr-triage-daily
+          name: pr-triage-weekly
           path: artifacts/
 
       - name: Append summary to workflow run

--- a/.github/workflows/pr-triage-weekly.yml
+++ b/.github/workflows/pr-triage-weekly.yml
@@ -10,7 +10,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: pr-triage-daily-${{ github.ref }}
+  group: pr-triage-weekly-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pr-triage-weekly.yml
+++ b/.github/workflows/pr-triage-weekly.yml
@@ -297,7 +297,7 @@ jobs:
               summaryLines.push(`- ${pr.rank}. #${pr.number} [${pr.complexity.status}] score=${pr.complexity.score} ci=${pr.ci_status} mergeable=${pr.mergeable}`);
             }
             summaryLines.push('');
-            summaryLines.push('Prompt template: .github/prompts/pr-triage-daily.prompt.md');
+            summaryLines.push('Prompt template: configured for this workflow');
 
             fs.writeFileSync('artifacts/pr-triage-summary.md', summaryLines.join('\n'));
 

--- a/.github/workflows/pr-triage-weekly.yml
+++ b/.github/workflows/pr-triage-weekly.yml
@@ -32,10 +32,15 @@ jobs:
             const repo = context.repo.repo;
             const topN = 10;
 
+            const pageSize = 50;
             const query = `
-              query($owner: String!, $repo: String!, $first: Int!) {
+              query($owner: String!, $repo: String!, $first: Int!, $after: String) {
                 repository(owner: $owner, name: $repo) {
-                  pullRequests(states: OPEN, first: $first, orderBy: { field: UPDATED_AT, direction: DESC }) {
+                  pullRequests(states: OPEN, first: $first, after: $after, orderBy: { field: UPDATED_AT, direction: DESC }) {
+                    pageInfo {
+                      hasNextPage
+                      endCursor
+                    }
                     nodes {
                       number
                       title
@@ -68,13 +73,23 @@ jobs:
               }
             `;
 
-            const response = await github.graphql(query, {
-              owner,
-              repo,
-              first: 50,
-            });
+            const openPrs = [];
+            let after = null;
+            let hasNextPage = true;
 
-            const openPrs = response.repository.pullRequests.nodes || [];
+            while (hasNextPage) {
+              const response = await github.graphql(query, {
+                owner,
+                repo,
+                first: pageSize,
+                after,
+              });
+
+              const pullRequests = response.repository.pullRequests;
+              openPrs.push(...(pullRequests.nodes || []));
+              hasNextPage = pullRequests.pageInfo?.hasNextPage || false;
+              after = pullRequests.pageInfo?.endCursor || null;
+            }
 
             const prsByCommitRecency = openPrs
               .map((pr) => {

--- a/.github/workflows/pr-triage-weekly.yml
+++ b/.github/workflows/pr-triage-weekly.yml
@@ -1,0 +1,311 @@
+name: PR Triage Weekly
+
+on:
+  schedule:
+    - cron: '0 13 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: pr-triage-daily-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  triage:
+    name: Generate PR triage report
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Generate fixed-schema triage JSON
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const topN = 10;
+
+            const query = `
+              query($owner: String!, $repo: String!, $first: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequests(states: OPEN, first: $first, orderBy: { field: UPDATED_AT, direction: DESC }) {
+                    nodes {
+                      number
+                      title
+                      url
+                      isDraft
+                      updatedAt
+                      mergeable
+                      reviewDecision
+                      additions
+                      deletions
+                      changedFiles
+                      baseRefName
+                      headRefName
+                      author {
+                        login
+                      }
+                      commits(last: 1) {
+                        nodes {
+                          commit {
+                            committedDate
+                            statusCheckRollup {
+                              state
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            const response = await github.graphql(query, {
+              owner,
+              repo,
+              first: 50,
+            });
+
+            const openPrs = response.repository.pullRequests.nodes || [];
+
+            const prsByCommitRecency = openPrs
+              .map((pr) => {
+                const latestCommit = pr.commits?.nodes?.[0]?.commit || null;
+                const lastCommitAt = latestCommit?.committedDate || pr.updatedAt;
+                const ciRaw = latestCommit?.statusCheckRollup?.state || 'UNKNOWN';
+
+                let ciStatus = 'UNKNOWN';
+                if (ciRaw === 'SUCCESS') {
+                  ciStatus = 'SUCCESS';
+                } else if (ciRaw === 'FAILURE' || ciRaw === 'ERROR') {
+                  ciStatus = 'FAILED';
+                } else if (ciRaw === 'PENDING' || ciRaw === 'EXPECTED') {
+                  ciStatus = 'PENDING';
+                }
+
+                return {
+                  ...pr,
+                  _lastCommitAt: lastCommitAt,
+                  _ciStatus: ciStatus,
+                };
+              })
+              .sort((a, b) => new Date(b._lastCommitAt) - new Date(a._lastCommitAt))
+              .slice(0, topN);
+
+            const buildRoadmap = (pr, complexityDrivers) => {
+              const roadmap = [];
+
+              if (pr._ciStatus === 'FAILED') {
+                roadmap.push('Fix failing CI/lint/test checks and re-run required status checks.');
+              }
+              if (pr._ciStatus === 'PENDING') {
+                roadmap.push('Wait for pending checks to complete and address any failures.');
+              }
+              if (pr.mergeable === 'CONFLICTING') {
+                roadmap.push('Rebase or merge main to resolve merge conflicts.');
+              }
+              if (pr.reviewDecision === 'CHANGES_REQUESTED') {
+                roadmap.push('Address requested review changes and request re-review.');
+              }
+              if (pr.reviewDecision === 'REVIEW_REQUIRED') {
+                roadmap.push('Request reviewer approval and ensure all review threads are resolved.');
+              }
+              if (pr.changedFiles > 25 || (pr.additions + pr.deletions) > 2000) {
+                roadmap.push('Reduce blast radius by splitting high-risk changes into smaller follow-up PRs where practical.');
+              }
+
+              roadmap.push('Confirm docblocks, tests, and repository conventions in AGENTS.md are satisfied.');
+              roadmap.push('Validate alignment with architectural decisions in .build/atlas-journal.md.');
+
+              if (complexityDrivers.length === 0) {
+                roadmap.push('Perform final review and merge once all required checks are green.');
+              }
+
+              return roadmap;
+            };
+
+            const scorePr = (pr) => {
+              let score = 1;
+              const drivers = [];
+
+              const changedLines = (pr.additions || 0) + (pr.deletions || 0);
+
+              if ((pr.changedFiles || 0) >= 8) {
+                score += 1;
+                drivers.push('broad-file-scope');
+              }
+              if ((pr.changedFiles || 0) >= 20) {
+                score += 1;
+              }
+
+              if (changedLines >= 700) {
+                score += 1;
+                drivers.push('large-diff');
+              }
+              if (changedLines >= 1800) {
+                score += 1;
+              }
+
+              if (pr.isDraft) {
+                score += 1;
+                drivers.push('draft-pr');
+              }
+
+              if (pr.reviewDecision === 'REVIEW_REQUIRED') {
+                score += 1;
+                drivers.push('needs-review');
+              }
+              if (pr.reviewDecision === 'CHANGES_REQUESTED') {
+                score += 2;
+                drivers.push('changes-requested');
+              }
+
+              if (pr._ciStatus === 'PENDING') {
+                score += 1;
+                drivers.push('ci-pending');
+              }
+              if (pr._ciStatus === 'FAILED') {
+                score += 2;
+                drivers.push('ci-failing');
+              }
+
+              if (pr.mergeable === 'CONFLICTING') {
+                score += 2;
+                drivers.push('merge-conflicts');
+              }
+
+              if (score < 1) {
+                score = 1;
+              }
+              if (score > 10) {
+                score = 10;
+              }
+
+              let status = 'Moderate';
+              if (score <= 3) {
+                status = 'Fastest';
+              } else if (score >= 8) {
+                status = 'Complex';
+              }
+
+              return { score, status, drivers };
+            };
+
+            const ranked = prsByCommitRecency
+              .map((pr) => {
+                const complexity = scorePr(pr);
+                return {
+                  number: pr.number,
+                  title: pr.title,
+                  url: pr.url,
+                  author: pr.author?.login || 'unknown',
+                  base: pr.baseRefName,
+                  head: pr.headRefName,
+                  last_commit_at: pr._lastCommitAt,
+                  updated_at: pr.updatedAt,
+                  is_draft: !!pr.isDraft,
+                  mergeable: pr.mergeable || 'UNKNOWN',
+                  review_decision: pr.reviewDecision || 'UNKNOWN',
+                  ci_status: pr._ciStatus,
+                  changes: {
+                    files: pr.changedFiles || 0,
+                    additions: pr.additions || 0,
+                    deletions: pr.deletions || 0,
+                  },
+                  complexity,
+                  roadmap: buildRoadmap(pr, complexity.drivers),
+                };
+              })
+              .sort((a, b) => {
+                if (a.complexity.score !== b.complexity.score) {
+                  return a.complexity.score - b.complexity.score;
+                }
+                return new Date(b.last_commit_at) - new Date(a.last_commit_at);
+              })
+              .map((pr, index) => ({
+                rank: index + 1,
+                ...pr,
+              }));
+
+            const quickWins = ranked
+              .filter((pr) => pr.complexity.status === 'Fastest' && pr.ci_status === 'SUCCESS' && pr.mergeable === 'MERGEABLE' && pr.review_decision !== 'CHANGES_REQUESTED')
+              .slice(0, 3)
+              .map((pr) => ({
+                number: pr.number,
+                title: pr.title,
+                url: pr.url,
+                reason: 'Low complexity with passing CI and no hard blockers.',
+              }));
+
+            const blockers = ranked
+              .filter((pr) => pr.ci_status === 'FAILED' || pr.mergeable === 'CONFLICTING' || pr.review_decision === 'CHANGES_REQUESTED')
+              .slice(0, 5)
+              .map((pr) => ({
+                number: pr.number,
+                title: pr.title,
+                url: pr.url,
+                reason: pr.roadmap[0] || 'Requires merge-readiness remediation.',
+              }));
+
+            const nowIso = new Date().toISOString();
+            const dayStamp = nowIso.slice(0, 10);
+
+            const report = {
+              schema_version: 'pr-triage.v1',
+              generated_at: nowIso,
+              repository: `${owner}/${repo}`,
+              source: {
+                top_n: topN,
+                order: 'most-recently-committed',
+                branch: 'main',
+              },
+              report_title: `Oracle: PR Prioritization and Roadmap ${dayStamp}`,
+              quick_wins: quickWins,
+              blockers,
+              ranked_prs: ranked,
+            };
+
+            fs.mkdirSync('artifacts', { recursive: true });
+            fs.writeFileSync('artifacts/pr-triage-report.json', JSON.stringify(report, null, 2));
+
+            const summaryLines = [];
+            summaryLines.push(`# ${report.report_title}`);
+            summaryLines.push('');
+            summaryLines.push(`- Schema: ${report.schema_version}`);
+            summaryLines.push(`- Repository: ${report.repository}`);
+            summaryLines.push(`- Generated: ${report.generated_at}`);
+            summaryLines.push('');
+            summaryLines.push('## Quick Wins');
+            if (report.quick_wins.length === 0) {
+              summaryLines.push('- None');
+            } else {
+              for (const item of report.quick_wins) {
+                summaryLines.push(`- #${item.number} ${item.title}`);
+              }
+            }
+            summaryLines.push('');
+            summaryLines.push('## Ranked PRs');
+            for (const pr of report.ranked_prs) {
+              summaryLines.push(`- ${pr.rank}. #${pr.number} [${pr.complexity.status}] score=${pr.complexity.score} ci=${pr.ci_status} mergeable=${pr.mergeable}`);
+            }
+            summaryLines.push('');
+            summaryLines.push('Prompt template: .github/prompts/pr-triage-daily.prompt.md');
+
+            fs.writeFileSync('artifacts/pr-triage-summary.md', summaryLines.join('\n'));
+
+      - name: Upload triage artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-triage-daily
+          path: artifacts/
+
+      - name: Append summary to workflow run
+        run: cat artifacts/pr-triage-summary.md >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
Split from umbrella PR #1604.  
This PR isolates weekly automation workflows for PR triage and docs drift, including the docs drift prompt asset.

## Scope
- `.github/workflows/pr-triage-weekly.yml`
- `.github/workflows/docs-drift-weekly.yml`
- `.github/prompts/docs-drift-weekly.prompt.md`

## Why this split
Keeps scheduled automation changes independent from templates, CI guardrails, and lane instruction docs.

## Verification
- Confirmed diff is limited to the files above.
- Workflow/prompt automation only (no plugin runtime code changes).
- No `vendor/composer/*` changes included.

## Relationship to #1604
This is a direct slice of #1604.  
Umbrella PR #1604 remains unchanged as backup until all replacement PRs are validated.