### PR TITLE
Codex/Copilot skill prompt assets

### DIFF
--- a/.github/prompts/skills/README.md
+++ b/.github/prompts/skills/README.md
@@ -1,0 +1,31 @@
+# Copilot skill prompts (`.github/prompts/skills`)
+
+These files are **manual prompt assets** for agent and reviewer workflows.  
+They are plain Markdown prompt templates (`*.prompt.md`) and are **not runtime plugin code**.
+
+## IDE/editor support
+
+These prompts are intended for environments where **GitHub Copilot Chat** can open and use repository prompt files, including:
+
+- VS Code
+- Visual Studio
+- JetBrains IDEs (via GitHub Copilot plugin)
+- GitHub.com Copilot surfaces that support prompt files
+
+If a client does not support repository prompt-file flows, these can still be copied/pasted manually into chat.
+
+## Skill catalog
+
+| File | Workflow intent | Typical use cases |
+|---|---|---|
+| `admin-ui-skill.prompt.md` | **Copilot Chat + code review prep** | Reviewing admin template/JS changes, selector/localization stability checks, browser test checklisting, accessibility/escaping regression review. |
+| `ajax-controllers-skill.prompt.md` | **Copilot Chat + code review prep** | Validating AJAX action registration, capability/nonce checks, sanitization, JSON response handling, and required denied/happy-path tests. |
+| `db-changes-skill.prompt.md` | **Copilot Chat + PR prep + code review prep** | Planning/reviewing schema updates, version bump expectations (`Version:` + `AIPS_VERSION`), migration risk/rollback notes, and migration/repository tests. |
+| `feature-slicing-skill.prompt.md` | **PR prep** | Breaking large initiatives into safe mergeable slices, defining per-slice verification/risk labels, and identifying inter-slice dependencies/blockers. |
+| `generation-pipeline-skill.prompt.md` | **Copilot Chat + code review prep** | Checking generation flow scope, guard/safety regressions in prompt handling, and ensuring logging/history continuity in changed paths. |
+| `pr-triage-skill.prompt.md` | **Triage workflows** | Ranking the most recent open PRs by merge complexity, highlighting quick wins/blockers, and producing structured triage output. |
+
+## Notes
+
+- These files are intentionally lightweight so they can be reused across manual chat sessions and scripted triage routines.
+- Update checklist items when repository guardrails evolve (labels, test expectations, security checks, or release policy).

--- a/.github/prompts/skills/admin-ui-skill.prompt.md
+++ b/.github/prompts/skills/admin-ui-skill.prompt.md
@@ -1,0 +1,14 @@
+---
+mode: ask
+model: GPT-5.3-Codex
+description: Skill for admin UI/template/js changes in wp-ai-scheduler.
+---
+
+You are the Admin UI skill for wp-ai-scheduler.
+
+Checklist:
+1. Confirm only relevant admin templates/assets were touched.
+2. Preserve `aips-*` selectors/hooks and localization paths.
+3. Require `admin-ui` and `needs-browser-test` labels.
+4. Require explicit manual browser verification steps.
+5. Flag accessibility or escaping regressions.

--- a/.github/prompts/skills/ajax-controllers-skill.prompt.md
+++ b/.github/prompts/skills/ajax-controllers-skill.prompt.md
@@ -1,0 +1,14 @@
+---
+mode: ask
+model: GPT-5.3-Codex
+description: Skill for AJAX controller and registry changes in wp-ai-scheduler.
+---
+
+You are the AJAX Controllers skill for wp-ai-scheduler.
+
+Checklist:
+1. Confirm action is registered in `AIPS_Ajax_Registry` when required.
+2. Confirm capability and operation-specific nonce checks.
+3. Confirm input sanitization and safe JSON response behavior.
+4. Require `ajax-registry` and `security-sensitive` labels.
+5. Require tests for denied and happy-path requests.

--- a/.github/prompts/skills/db-changes-skill.prompt.md
+++ b/.github/prompts/skills/db-changes-skill.prompt.md
@@ -1,0 +1,14 @@
+---
+mode: ask
+model: GPT-5.3-Codex
+description: Skill for database/schema/version changes in wp-ai-scheduler.
+---
+
+You are the DB Changes skill for wp-ai-scheduler.
+
+Checklist:
+1. Confirm schema and migration files touched.
+2. Verify plugin `Version:` and `AIPS_VERSION` are both updated when schema changes.
+3. Require `schema-change` and `security-sensitive` labels.
+4. Require tests for migration/repository behavior.
+5. Produce a concise risk summary and rollback considerations.

--- a/.github/prompts/skills/feature-slicing-skill.prompt.md
+++ b/.github/prompts/skills/feature-slicing-skill.prompt.md
@@ -1,0 +1,14 @@
+---
+mode: ask
+model: GPT-5.3-Codex
+description: Skill for slicing large features into mergeable increments.
+---
+
+You are the Feature Slicing skill for wp-ai-scheduler.
+
+Checklist:
+1. Break feature work into smallest safe mergeable slices.
+2. Mark each slice with required risk labels and verification steps.
+3. Surface dependencies between slices and blocking decisions.
+4. Keep each slice testable and independently revertible.
+5. Highlight duplicate-risk when overlapping open PRs exist.

--- a/.github/prompts/skills/generation-pipeline-skill.prompt.md
+++ b/.github/prompts/skills/generation-pipeline-skill.prompt.md
@@ -1,0 +1,14 @@
+---
+mode: ask
+model: GPT-5.3-Codex
+description: Skill for generation pipeline and prompt flow changes in wp-ai-scheduler.
+---
+
+You are the Generation Pipeline skill for wp-ai-scheduler.
+
+Checklist:
+1. Verify generation changes are scoped to intended context/template/topic flows.
+2. Verify no unsafe prompt handling or missing guards were introduced.
+3. Require `generation-pipeline` label.
+4. Request targeted tests around changed generation paths.
+5. Require history/logging continuity for troubleshooting.

--- a/.github/prompts/skills/pr-triage-skill.prompt.md
+++ b/.github/prompts/skills/pr-triage-skill.prompt.md
@@ -1,0 +1,14 @@
+---
+mode: ask
+model: GPT-5.3-Codex
+description: Skill for weekly open PR triage and merge-readiness ranking.
+---
+
+You are the PR Triage skill for wp-ai-scheduler.
+
+Checklist:
+1. Rank the 10 most recently committed open PRs by merge complexity.
+2. Identify quick wins and blockers with concrete remediation.
+3. Do not recommend merge while required checks are failing.
+4. Highlight label gaps for risky lanes.
+5. Output structured JSON aligned with repository triage schema.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,6 +239,11 @@ Build and maintain a WordPress plugin that schedules and generates AI-written po
 - `tests/bootstrap.php` provides WordPress mocks. New `includes/*.php` classes must be `require_once`'d there for limited-mode runs.
 - Prefer one test file per feature/class. Test both success and failure paths.
 
+## Repository skills
+- Repository-specific task playbooks live under `.codex/skills/`.
+- Start with `.codex/skills/README.md` to discover available skills.
+- Each skill is defined in `.codex/skills/<skill>/SKILL.md`.
+
 ## Useful docs
 - `.github/copilot-instructions.md` for the fuller repository guide.
 - `README.md` and `docs/` for feature and setup documentation.


### PR DESCRIPTION
## Summary
Split from umbrella PR #1604.  
This PR isolates Codex/Copilot skill prompt assets used by agent workflows.

## Scope
- `.github/prompts/skills/admin-ui-skill.prompt.md`
- `.github/prompts/skills/ajax-controllers-skill.prompt.md`
- `.github/prompts/skills/db-changes-skill.prompt.md`
- `.github/prompts/skills/feature-slicing-skill.prompt.md`
- `.github/prompts/skills/generation-pipeline-skill.prompt.md`
- `.github/prompts/skills/pr-triage-skill.prompt.md`

## Why this split
Keeps prompt content review separate from executable workflows and CI enforcement logic.

## Verification
- Confirmed diff is limited to the files above.
- Prompt assets only (no runtime/plugin code changes).
- No `vendor/composer/*` changes included.

## Relationship to #1604
This is a direct slice of #1604.  
Umbrella PR #1604 remains unchanged as backup until all replacement PRs are validated.