### PR TITLE
Add testing-workflow skill with PHPUnit guidance and pre-PR checklist

### DIFF
--- a/.codex/skills/README.md
+++ b/.codex/skills/README.md
@@ -1,0 +1,4 @@
+# Repository Skills
+
+## Available skills
+- `testing-workflow`: Standard testing workflow for AI Post Scheduler plugin PHPUnit coverage and pre-PR checks.

--- a/.codex/skills/testing-workflow/SKILL.md
+++ b/.codex/skills/testing-workflow/SKILL.md
@@ -1,0 +1,159 @@
+# Testing Workflow Skill — AI Post Scheduler
+
+## Purpose
+Use this workflow to create and maintain reliable PHPUnit coverage for the AI Post Scheduler WordPress plugin.
+
+## Required test execution location
+- Always run Composer and PHPUnit commands from `ai-post-scheduler/` only.
+- Do **not** run plugin test commands from the repository root.
+
+```bash
+cd ai-post-scheduler
+composer test
+```
+
+## Test file structure and class pattern
+- Place tests in `ai-post-scheduler/tests/`.
+- Use feature-level files with one primary class/feature target per file.
+- Test classes should extend `WP_UnitTestCase`.
+- Prefer file names that map to the feature/class under test, e.g.:
+	- `tests/test-aips-settings.php`
+	- `tests/test-aips-ajax-controller.php`
+	- `tests/test-aips-template-repository.php`
+
+Minimal structure:
+
+```php
+<?php
+
+class Test_AIPS_Example_Service extends WP_UnitTestCase {
+
+	public function setUp(): void {
+		parent::setUp();
+		// Arrange shared fixtures/mocks.
+	}
+
+	public function test_it_handles_success_path() {
+		// Arrange
+		// Act
+		// Assert
+	}
+
+	public function test_it_handles_failure_path() {
+		// Arrange
+		// Act
+		// Assert
+	}
+}
+```
+
+## When to update `tests/bootstrap.php`
+Update `ai-post-scheduler/tests/bootstrap.php` when either of these is true:
+- You add a new `ai-post-scheduler/includes/*.php` class that must be available in limited-mode/unit-like test runs where plugin bootstrapping does not autoload it.
+- A new test directly instantiates or references a class that is not currently required by bootstrap or loaded transitively.
+
+Practical rule:
+- If a test fails with missing class errors in limited-mode runs, add the explicit `require_once` entry in `tests/bootstrap.php` for that include file.
+
+## Coverage templates
+
+### 1) Success/failure path coverage template
+
+```php
+public function test_execute_returns_expected_result_on_success() {
+	// Arrange valid input and dependencies.
+
+	// Act
+	$result = $this->service->execute( $input );
+
+	// Assert output.
+	$this->assertTrue( $result['success'] );
+	$this->assertSame( 'expected', $result['data'] );
+
+	// Assert side effects (DB write, option update, hook, etc.).
+	$this->assertSame( 1, (int) get_option( 'aips_example_counter', 0 ) );
+}
+
+public function test_execute_returns_error_on_failure() {
+	// Arrange invalid input or forced dependency failure.
+
+	// Act
+	$result = $this->service->execute( $invalid_input );
+
+	// Assert output.
+	$this->assertFalse( $result['success'] );
+	$this->assertNotEmpty( $result['message'] );
+
+	// Assert side effects are absent or rolled back.
+	$this->assertSame( 0, (int) get_option( 'aips_example_counter', 0 ) );
+}
+```
+
+### 2) Capability/nonce failure tests for AJAX controllers
+
+```php
+public function test_ajax_fails_when_user_lacks_capability() {
+	// Arrange non-admin user.
+	wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+	$_POST['nonce'] = wp_create_nonce( 'aips_action_nonce' );
+
+	// Act
+	$response = $this->call_controller_action();
+
+	// Assert response and no side effect.
+	$this->assertFalse( $response['success'] );
+	$this->assertStringContainsString( 'permission', strtolower( $response['message'] ) );
+	$this->assertSame( 0, $this->repo->count_changes() );
+}
+
+public function test_ajax_fails_with_invalid_nonce() {
+	// Arrange admin user but invalid nonce.
+	wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+	$_POST['nonce'] = 'invalid';
+
+	// Act
+	$response = $this->call_controller_action();
+
+	// Assert response and no side effect.
+	$this->assertFalse( $response['success'] );
+	$this->assertStringContainsString( 'nonce', strtolower( $response['message'] ) );
+	$this->assertSame( 0, $this->repo->count_changes() );
+}
+```
+
+### 3) Repository/service boundary tests template
+
+```php
+public function test_service_delegates_persistence_to_repository() {
+	// Arrange repository spy/fake with call tracking.
+	$repo = new Test_AIPS_Example_Repository_Spy();
+	$service = new AIPS_Example_Service( $repo );
+
+	// Act
+	$service->save_item( array( 'title' => 'Sample' ) );
+
+	// Assert boundary contract.
+	$this->assertSame( 1, $repo->save_calls );
+	$this->assertSame( 'Sample', $repo->last_payload['title'] );
+}
+
+public function test_service_handles_repository_failure_contract() {
+	// Arrange repository fake that throws or returns WP_Error.
+	$repo = new Test_AIPS_Example_Repository_Failing_Fake();
+	$service = new AIPS_Example_Service( $repo );
+
+	// Act
+	$result = $service->save_item( array( 'title' => 'Sample' ) );
+
+	// Assert translated error contract.
+	$this->assertFalse( $result['success'] );
+	$this->assertStringContainsString( 'save', strtolower( $result['message'] ) );
+}
+```
+
+## Pre-PR checklist
+- [ ] Tests were executed from `ai-post-scheduler/`.
+- [ ] Any new required `includes/*.php` class is loaded in `tests/bootstrap.php` when needed for limited-mode tests.
+- [ ] Success and failure paths are both covered for changed behavior.
+- [ ] Assertions validate both returned output and side effects (DB/options/hooks/events/files).
+- [ ] AJAX controller tests include capability and nonce failure coverage for state-changing actions.


### PR DESCRIPTION
### Motivation
- Standardize how PHPUnit tests are written and executed for the AI Post Scheduler plugin so contributors follow a single, testable pattern.
- Clarify the `WP_UnitTestCase` feature-level file structure and when `tests/bootstrap.php` must be updated to support limited-mode runs.
- Provide concrete templates for success/failure paths, AJAX capability/nonce failures, and repository/service boundary tests to reduce reviewer friction.

### Description
- Add `.codex/skills/testing-workflow/SKILL.md` containing required test execution instructions, `WP_UnitTestCase` patterns, bootstrap update rules, coverage templates, and a pre-PR checklist.
- Add `.codex/skills/README.md` with an entry for the new `testing-workflow` repository skill.
- Include templates for success/failure path coverage, capability/nonce failure tests for AJAX controllers, and repository/service boundary tests, plus a checklist that requires loading new `includes/*.php` files in `tests/bootstrap.php` when needed.

### Testing
- No automated tests were run because this is a documentation-only change; developers should validate behavioral changes by running `composer test` from `ai-post-scheduler/` as documented.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10bcde599083218579a701aa104001)