### PR TITLE
Add observability standardization skill prompt

### DIFF
--- a/.github/prompts/skills/README.md
+++ b/.github/prompts/skills/README.md
@@ -23,6 +23,7 @@ If a client does not support repository prompt-file flows, these can still be co
 | `db-changes-skill.prompt.md` | **Copilot Chat + PR prep + code review prep** | Planning/reviewing schema updates, version bump expectations (`Version:` + `AIPS_VERSION`), migration risk/rollback notes, and migration/repository tests. |
 | `feature-slicing-skill.prompt.md` | **PR prep** | Breaking large initiatives into safe mergeable slices, defining per-slice verification/risk labels, and identifying inter-slice dependencies/blockers. |
 | `generation-pipeline-skill.prompt.md` | **Copilot Chat + code review prep** | Checking generation flow scope, guard/safety regressions in prompt handling, and ensuring logging/history continuity in changed paths. |
+| `observability-skill.prompt.md` | **Copilot Chat + PR prep + code review prep** | Standardizing lifecycle logging, correlation-id propagation, generation-history events, and telemetry-aware performance checks. |
 | `pr-triage-skill.prompt.md` | **Triage workflows** | Ranking the most recent open PRs by merge complexity, highlighting quick wins/blockers, and producing structured triage output. |
 
 ## Notes

--- a/.github/prompts/skills/observability-skill.prompt.md
+++ b/.github/prompts/skills/observability-skill.prompt.md
@@ -1,0 +1,60 @@
+# Observability Standardization Skill
+
+Use this skill when implementing or reviewing multi-step generation, scheduling, cron, AJAX, or admin workflows that require consistent tracing, lifecycle logging, and performance visibility.
+
+## Objectives
+
+- Standardize observability across major operations.
+- Ensure failures are diagnosable end-to-end.
+- Make performance tradeoffs explicit for sensitive paths.
+
+## Required observability rules
+
+1. **Lifecycle logging is required** for each major operation and must include:
+   - `start`
+   - `retry` (when applicable)
+   - `fail`
+   - `success`
+
+2. **Use `AIPS_Logger` and `AIPS_Correlation_Id`** for multi-step flows:
+   - Create or retrieve a correlation id at flow entry.
+   - Propagate the same id through all nested/subsequent steps.
+   - Include correlation id in all log contexts.
+
+3. **Record generation events via `AIPS_Generation_Logger` + history container**:
+   - Use `AIPS_History_Container` for structured history continuity.
+   - Emit meaningful generation events at component/step boundaries.
+   - Ensure generated-content workflows capture enough context for later diagnostics.
+
+4. **For performance-sensitive features, include telemetry considerations**:
+   - Reference slow query threshold: `AIPS_TELEMETRY_SLOW_QUERY_MS` (100 ms).
+   - Reference slow request threshold: `AIPS_TELEMETRY_SLOW_REQUEST_MS` (1500 ms).
+   - Respect telemetry opt-in (`aips_enable_telemetry`) and avoid assuming telemetry is always enabled.
+
+## Implementation checklist (must pass)
+
+- [ ] Correlation ID is created/retrieved once and propagated through the full flow.
+- [ ] Event names are meaningful, consistent, and scoped to operation/step.
+- [ ] Failure logs include actionable metadata (error type/code, step, retries, affected entity ids when safe).
+- [ ] No sensitive data in logs/events (no secrets, raw auth tokens, unnecessary PII, or full prompt payloads unless explicitly safe).
+- [ ] Lifecycle coverage exists for start/retry/fail/success at the operation level.
+- [ ] Generation workflows write structured entries through `AIPS_Generation_Logger` and history container.
+- [ ] Telemetry behavior is opt-in aware and thresholds are considered for performance-sensitive paths.
+
+## Suggested event naming pattern
+
+- `operation.start`
+- `operation.step_name.retry`
+- `operation.step_name.fail`
+- `operation.success`
+
+Keep names stable for filtering and incident review.
+
+## Review output expectations
+
+When using this skill in PR prep/review, produce:
+
+- A lifecycle coverage matrix (operation → start/retry/fail/success).
+- Correlation id propagation notes.
+- Telemetry impact summary (threshold relevance + opt-in handling).
+- A brief risk section listing any observability gaps and follow-up tasks.

--- a/.github/prompts/skills/observability-skill.prompt.md
+++ b/.github/prompts/skills/observability-skill.prompt.md
@@ -16,7 +16,7 @@ Use this skill when implementing or reviewing multi-step generation, scheduling,
    - `fail`
    - `success`
 
-2. **Use `AIPS_Logger` and `AIPS_Correlation_Id`** for multi-step flows:
+2. **Use `AIPS_Logger` and `AIPS_Correlation_ID`** for multi-step flows:
    - Create or retrieve a correlation id at flow entry.
    - Propagate the same id through all nested/subsequent steps.
    - Include correlation id in all log contexts.


### PR DESCRIPTION
### Motivation
- Introduce a shared observability policy and checklist so multi-step generation, scheduling, cron, AJAX, and admin flows consistently emit lifecycle logs, propagate correlation IDs, record generation events, and respect telemetry opt-in and thresholds.

### Description
- Add `.github/prompts/skills/observability-skill.prompt.md` containing lifecycle logging rules (`start`/`retry`/`fail`/`success`), `AIPS_Logger` + `AIPS_Correlation_Id` guidance, `AIPS_Generation_Logger` + history container recommendations, telemetry thresholds (`AIPS_TELEMETRY_SLOW_QUERY_MS` / `AIPS_TELEMETRY_SLOW_REQUEST_MS`) and an implementation checklist, and update `.github/prompts/skills/README.md` to register the new skill.

### Testing
- No automated tests were executed because this is a documentation-only change; validation was limited to local file creation and inspection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10bcdd90b8832181286350f10f13d0)