### PR TITLE
🐞 Hunter: Mock wp_date and esc_sql in limited mode tests

### DIFF
--- a/.jules/hunter.md
+++ b/.jules/hunter.md
@@ -1,3 +1,7 @@
 ## 2026-04-27 - Handle Template Data Object Type Error
 **Learning:** Legacy template variables might receive class instances instead of expected associative arrays, causing fatal `Cannot use object of type class as array` errors in PHP 8+.
 **Action:** Always check `is_object($data)` before accessing elements via `$data['key']` in templates. If it is an object, use getter methods (e.g. `$handler->get_data()`) to retrieve an array context.
+
+## 2026-05-23 - Mocking WP Core Functions in Limited Testing Mode
+**Learning:** When PHPUnit tests fail in limited mode with "Call to undefined function" for WordPress core functions (e.g., `esc_sql`, `wp_date`), it's because the full WP environment isn't loaded.
+**Action:** Ensure these functions are safely mocked with conditional checks (e.g. `if (!function_exists('wp_date'))`) within `tests/bootstrap.php` to prevent fatal test execution errors.

--- a/ai-post-scheduler/tests/bootstrap.php
+++ b/ai-post-scheduler/tests/bootstrap.php
@@ -1714,6 +1714,20 @@ if (file_exists(WP_TESTS_DIR . '/includes/functions.php')) {
             return false;
         }
     }
+    if (!function_exists('wp_date')) {
+        function wp_date($format, $timestamp = null, $timezone = null) {
+            if ($timestamp === null) {
+                $timestamp = time();
+            }
+            return date($format, $timestamp);
+        }
+    }
+
+    if (!function_exists('esc_sql')) {
+        function esc_sql($data) {
+            return $data;
+        }
+    }
 }
 
 if (!function_exists('wp_is_writable')) {


### PR DESCRIPTION
**🐛 Bug:** Tests like `Test_History_Template` were failing with fatal "Call to undefined function wp_date()" or `esc_sql()` when running in limited testing mode.
**🔍 Root Cause:** `tests/bootstrap.php` lacked proper stubs for these WordPress core functions when the WP testing suite environment is missing.
**🛠️ Fix:** Added conditionally defined `wp_date` and `esc_sql` fallback functions at the end of `tests/bootstrap.php`.
**🧪 Verification:** Ran `phpunit tests/Test_History_Template.php` successfully and ran the full suite to verify no regressions were caused. Also ensured autogenerated composer files were excluded from the commit.

---
*PR created automatically by Jules for task [6481474815518364521](https://jules.google.com/task/6481474815518364521) started by @rpnunez*