### PR TITLE
🏗️ Atlas: Extract Analytics from History Repository (Lazy-Load + Query Guards)

### DIFF
--- a/.build/atlas-journal.md
+++ b/.build/atlas-journal.md
@@ -1438,3 +1438,9 @@ This refactoring resolves the "unexpected title prompts" issue by eliminating du
 **Decision:** Extracted post-execution cleanup, failure logging, success logging, and history container logic into a dedicated `AIPS_Schedule_Result_Handler` class.
 **Consequence:** `AIPS_Schedule_Processor` is now strictly focused on the execution logic. Reduced the class size significantly and decoupled the specific handling of success and error states.
 **Tests:** Created `test-schedule-result-handler.php` to verify result handling. Test execution skipped per user request.
+
+## 2024-05-29 - Extract Analytics from History Repository
+**Context:** The `AIPS_History_Repository` had become a "God Object" exceeding 1300 lines of code, violating the Single Responsibility Principle by mixing core CRUD operations with complex statistical aggregations and analytics.
+**Decision:** Extracted all statistical and analytical methods (e.g., `get_stats`, `get_daily_success_failure_trend`) into a new dedicated class `AIPS_History_Stats_Repository`.
+**Consequence:** Improves code cohesion and separation of concerns. To maintain strict backward compatibility, `AIPS_History_Repository` now instantiates the new stats repository and its legacy methods act as proxies, which are marked with `@deprecated` docblocks.
+**Tests:** Existing test suite provides coverage. Updated `tests/AIPS_Autoloader_Test.php` to include the new repository class ensuring it resolves correctly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,6 @@
 ### Changed
 - Admin History: Replaced full page reload with AJAX table reload when retrying failed generations to improve user flow.
 - Refactored multiple admin UI actions to update DOM tables dynamically without a full page reload for a smoother user experience.
+## [Unreleased]
+### Refactored
+- Extracted statistical and analytical methods from `AIPS_History_Repository` into a dedicated `AIPS_History_Stats_Repository` to resolve "God Object" anti-pattern and improve separation of concerns, maintaining strict backward compatibility.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
+## [Unreleased]
 ### Changed
 - Admin History: Replaced full page reload with AJAX table reload when retrying failed generations to improve user flow.
 - Refactored multiple admin UI actions to update DOM tables dynamically without a full page reload for a smoother user experience.
-## [Unreleased]
 ### Refactored
 - Extracted statistical and analytical methods from `AIPS_History_Repository` into a dedicated `AIPS_History_Stats_Repository` to resolve "God Object" anti-pattern and improve separation of concerns, maintaining strict backward compatibility.

--- a/ai-post-scheduler/includes/class-aips-history-repository.php
+++ b/ai-post-scheduler/includes/class-aips-history-repository.php
@@ -49,6 +49,11 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
      * @var wpdb WordPress database abstraction object
      */
     private $wpdb;
+
+    /**
+     * @var AIPS_History_Stats_Repository Stats repository
+     */
+    private $stats_repository;
     
     /**
      * Initialize the repository.
@@ -59,6 +64,7 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
         $this->table_name = $wpdb->prefix . 'aips_history';
         $this->table_name_log = $wpdb->prefix . 'aips_history_log';
         $this->schedule_table = $wpdb->prefix . 'aips_schedule';
+        $this->stats_repository = new AIPS_History_Stats_Repository();
     }
 
     /**
@@ -131,43 +137,32 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
         delete_transient('aips_schedule_completed_count_' . absint($schedule_id));
     }
 
+    /**
+     * @deprecated 2.4.0 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
+     */
     public function get_daily_success_failure_trend($days = 14) {
-        $days = max(1, absint($days));
-
-        return $this->wpdb->get_results($this->wpdb->prepare(
-            "SELECT DATE(FROM_UNIXTIME(created_at)) AS metric_date, SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS success_count, SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failure_count FROM {$this->table_name} WHERE created_at >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY metric_date ORDER BY metric_date ASC",
-            $days
-        ), ARRAY_A);
+        return $this->stats_repository->get_daily_success_failure_trend($days);
     }
 
+    /**
+     * @deprecated 2.4.0 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
+     */
     public function get_average_duration_by_flow($days = 14) {
-        $days = max(1, absint($days));
-
-        return $this->wpdb->get_results($this->wpdb->prepare(
-            "SELECT COALESCE(NULLIF(creation_method, ''), 'unknown') AS flow_type, AVG(completed_at - created_at) AS avg_duration_seconds, COUNT(*) AS sample_count FROM {$this->table_name} WHERE completed_at IS NOT NULL AND created_at >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY flow_type ORDER BY avg_duration_seconds DESC",
-            $days
-        ), ARRAY_A);
+        return $this->stats_repository->get_average_duration_by_flow($days);
     }
 
+    /**
+     * @deprecated 2.4.0 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
+     */
     public function get_retry_counts_by_service($days = 14) {
-        $days = max(1, absint($days));
-
-        return $this->wpdb->get_results($this->wpdb->prepare(
-            "SELECT COALESCE(NULLIF(JSON_UNQUOTE(JSON_EXTRACT(details, '$.context')), ''), 'unknown') AS service_key, COUNT(*) AS retry_count FROM {$this->table_name_log} WHERE log_type = %s AND timestamp >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY service_key ORDER BY retry_count DESC",
-            'retry',
-            $days
-        ), ARRAY_A);
+        return $this->stats_repository->get_retry_counts_by_service($days);
     }
 
+    /**
+     * @deprecated 2.4.0 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
+     */
     public function get_top_failure_reasons($days = 14, $limit = 8) {
-        $days = max(1, absint($days));
-        $limit = max(1, absint($limit));
-
-        return $this->wpdb->get_results($this->wpdb->prepare(
-            "SELECT COALESCE(NULLIF(TRIM(error_message), ''), 'Unknown failure') AS reason, COUNT(*) AS failure_count FROM {$this->table_name} WHERE status = 'failed' AND created_at >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY reason ORDER BY failure_count DESC LIMIT %d",
-            $days,
-            $limit
-        ), ARRAY_A);
+        return $this->stats_repository->get_top_failure_reasons($days, $limit);
     }
     
     /**
@@ -658,6 +653,8 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
     /**
      * Get the estimated generation time based on recent successful generations.
      *
+     * @deprecated 2.4.0 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
+     *
      * Retrieves the average of the most recent recorded generation times
      * from post metadata to provide an estimate for bulk generation tasks.
      *
@@ -668,83 +665,20 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
      * }
      */
     public function get_estimated_generation_time($limit = 20) {
-        $default_seconds = 30;
-        $limit           = absint($limit);
-
-        // Retrieve the most recent recorded generation times.
-        $times = $this->wpdb->get_col(
-            $this->wpdb->prepare(
-                "SELECT meta_value FROM {$this->wpdb->postmeta}
-                 WHERE meta_key = %s
-                 ORDER BY meta_id DESC
-                 LIMIT %d",
-                '_aips_post_generation_total_time',
-                $limit
-            )
-        );
-
-        if (!empty($times)) {
-            $numeric_times = array_filter(array_map('floatval', $times), function($v) {
-                return $v > 0;
-            });
-
-            if (!empty($numeric_times)) {
-                $avg              = array_sum($numeric_times) / count($numeric_times);
-                $per_post_seconds = (int) ceil($avg);
-            } else {
-                $per_post_seconds = $default_seconds;
-            }
-
-            $sample_size = count($numeric_times);
-        } else {
-            $per_post_seconds = $default_seconds;
-            $sample_size      = 0;
-        }
-
-        return array(
-            'per_post_seconds' => $per_post_seconds,
-            'sample_size'      => $sample_size,
-        );
+        return $this->stats_repository->get_estimated_generation_time($limit);
     }
 
+    /**
+     * @deprecated 2.4.0 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
+     */
     public function get_stats() {
-        $cached_stats = get_transient('aips_history_stats');
-
-        if ($cached_stats !== false) {
-            return $cached_stats;
-        }
-
-        $results = $this->wpdb->get_row("
-            SELECT
-                COUNT(*) as total,
-                SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as completed,
-                SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) as failed,
-                SUM(CASE WHEN status = 'processing' THEN 1 ELSE 0 END) as processing,
-                SUM(CASE WHEN status = 'partial' THEN 1 ELSE 0 END) as partial
-            FROM {$this->table_name}
-            WHERE COALESCE(creation_method, '') <> 'schedule_lifecycle'
-                AND NOT (creation_method IS NULL AND template_id IS NULL AND topic_id IS NULL AND post_id IS NULL AND author_id IS NULL)
-        ");
-
-        $stats = array(
-            'total' => isset($results->total) ? (int) $results->total : 0,
-            'completed' => isset($results->completed) ? (int) $results->completed : 0,
-            'failed' => isset($results->failed) ? (int) $results->failed : 0,
-            'processing' => isset($results->processing) ? (int) $results->processing : 0,
-            'partial' => isset($results->partial) ? (int) $results->partial : 0,
-        );
-        
-        $stats['success_rate'] = $stats['total'] > 0 
-            ? round(($stats['completed'] / $stats['total']) * 100, 1) 
-            : 0;
-
-        set_transient('aips_history_stats', $stats, HOUR_IN_SECONDS);
-        
-        return $stats;
+        return $this->stats_repository->get_stats();
     }
 
     /**
      * Get per-day generation counts for the last N days.
+     *
+     * @deprecated 2.4.0 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
      *
      * Returns an array keyed by ISO date string (Y-m-d) where each value is an
      * associative array with 'completed', 'failed', and 'total' counts.
@@ -757,75 +691,36 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
      * @return array<string, array{completed: int, failed: int, total: int}>
      */
     public function get_daily_generation_counts( $days = 14 ) {
-        $days      = max( 1, absint( $days ) );
-        $start_day = AIPS_DateTime::now()->advance( '-' . ( $days - 1 ) . ' days' )->format( 'Y-m-d' );
-        $start     = AIPS_DateTime::fromDate( $start_day )->timestamp();
-
-        $results = $this->wpdb->get_results(
-            $this->wpdb->prepare(
-                "SELECT
-                    DATE(FROM_UNIXTIME(created_at)) AS day,
-                    SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS completed,
-                    SUM(CASE WHEN status = 'failed'    THEN 1 ELSE 0 END) AS failed,
-                    COUNT(*) AS total
-                 FROM {$this->table_name}
-                 WHERE created_at >= %d
-                   AND COALESCE(creation_method, '') <> 'schedule_lifecycle'
-                   AND NOT (creation_method IS NULL AND template_id IS NULL AND topic_id IS NULL AND post_id IS NULL AND author_id IS NULL)
-                 GROUP BY DATE(FROM_UNIXTIME(created_at))
-                 ORDER BY day ASC",
-                $start
-            )
-        );
-
-        $data = array();
-        foreach ( $results as $row ) {
-            $data[ $row->day ] = array(
-                'completed' => (int) $row->completed,
-                'failed'    => (int) $row->failed,
-                'total'     => (int) $row->total,
-            );
-        }
-
-        return $data;
+        return $this->stats_repository->get_daily_generation_counts($days);
     }
 
     /**
      * Get statistics for a specific template.
      *
+     * @deprecated 2.4.0 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
+     *
      * @param int $template_id Template ID.
      * @return int Number of completed posts for this template.
      */
     public function get_template_stats($template_id) {
-        return (int) $this->wpdb->get_var($this->wpdb->prepare(
-            "SELECT COUNT(*) FROM {$this->table_name} WHERE template_id = %d AND status = 'completed'",
-            $template_id
-        ));
+        return $this->stats_repository->get_template_stats($template_id);
     }
 
     /**
      * Get statistics for all templates.
      *
+     * @deprecated 2.4.0 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
+     *
      * @return array Associative array of template ID => count.
      */
     public function get_all_template_stats() {
-        $results = $this->wpdb->get_results("
-            SELECT template_id, COUNT(*) as count
-            FROM {$this->table_name}
-            WHERE status = 'completed'
-            GROUP BY template_id
-        ");
-
-        $stats = array();
-        foreach ($results as $row) {
-            $stats[$row->template_id] = (int) $row->count;
-        }
-
-        return $stats;
+        return $this->stats_repository->get_all_template_stats();
     }
 
     /**
      * Get generated-post counts for schedule history containers.
+     *
+     * @deprecated 2.4.0 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
      *
      * Counts activity/error logs that represent a generated post event.
      * The key is history_id (schedule_history_id on schedules table).
@@ -834,47 +729,13 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
      * @return array Associative array of history_id => generated count.
      */
     public function get_schedule_generated_post_counts($history_ids) {
-        $history_ids = array_map('absint', (array) $history_ids);
-        $history_ids = array_filter($history_ids);
-
-        if (empty($history_ids)) {
-            return array();
-        }
-
-        $placeholders = implode(',', array_fill(0, count($history_ids), '%d'));
-
-        $sql = "
-            SELECT history_id, COUNT(*) AS count
-            FROM {$this->table_name_log}
-            WHERE history_id IN ({$placeholders})
-                AND history_type_id IN (%d, %d)
-                AND (
-                    details LIKE %s
-                    OR details LIKE %s
-                    OR details LIKE %s
-                )
-            GROUP BY history_id
-        ";
-
-        $args = $history_ids;
-        $args[] = AIPS_History_Type::ACTIVITY;
-        $args[] = AIPS_History_Type::ERROR;
-        $args[] = '%"event_type":"post_published"%';
-        $args[] = '%"event_type":"post_draft"%';
-        $args[] = '%"event_type":"manual_schedule_completed"%';
-
-        $results = $this->wpdb->get_results($this->wpdb->prepare($sql, $args));
-
-        $counts = array();
-        foreach ($results as $row) {
-            $counts[(int) $row->history_id] = (int) $row->count;
-        }
-
-        return $counts;
+        return $this->stats_repository->get_schedule_generated_post_counts($history_ids);
     }
 
     /**
      * Get author schedule logs filtered by event types.
+     *
+     * @deprecated 2.4.0 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
      *
      * @param int   $author_id Author ID.
      * @param array $event_types Event types to include.
@@ -882,40 +743,7 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
      * @return array Raw log rows from aips_history_log.
      */
     public function get_author_schedule_logs_by_event_types($author_id, $event_types = array(), $limit = 100) {
-        $author_id = absint($author_id);
-        $limit = absint($limit);
-        $event_types = array_filter(array_map('sanitize_key', (array) $event_types));
-
-        if (!$author_id || $limit < 1 || empty($event_types)) {
-            return array();
-        }
-
-        $where_events = array();
-        $args = array(
-            $author_id,
-            AIPS_History_Type::ACTIVITY,
-            AIPS_History_Type::ERROR,
-        );
-
-        foreach ($event_types as $event_type) {
-            $where_events[] = 'hl.details LIKE %s';
-            $args[] = '%"event_type":"' . $this->wpdb->esc_like($event_type) . '"%';
-        }
-
-        $args[] = $limit;
-
-        $sql = "
-            SELECT hl.*
-            FROM {$this->table_name_log} hl
-            INNER JOIN {$this->table_name} h ON hl.history_id = h.id
-            WHERE h.author_id = %d
-                AND hl.history_type_id IN (%d, %d)
-                AND (" . implode(' OR ', $where_events) . ")
-            ORDER BY hl.timestamp DESC
-            LIMIT %d
-        ";
-
-        return $this->wpdb->get_results($this->wpdb->prepare($sql, $args));
+        return $this->stats_repository->get_author_schedule_logs_by_event_types($author_id, $event_types, $limit);
     }
     
     /**

--- a/ai-post-scheduler/includes/class-aips-history-repository.php
+++ b/ai-post-scheduler/includes/class-aips-history-repository.php
@@ -150,28 +150,28 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
     }
 
     /**
-     * @deprecated 2.4.0 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
+     * @deprecated 2.8.3 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
      */
     public function get_daily_success_failure_trend($days = 14) {
         return $this->get_stats_repository()->get_daily_success_failure_trend($days);
     }
 
     /**
-     * @deprecated 2.4.0 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
+     * @deprecated 2.8.3 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
      */
     public function get_average_duration_by_flow($days = 14) {
         return $this->get_stats_repository()->get_average_duration_by_flow($days);
     }
 
     /**
-     * @deprecated 2.4.0 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
+     * @deprecated 2.8.3 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
      */
     public function get_retry_counts_by_service($days = 14) {
         return $this->get_stats_repository()->get_retry_counts_by_service($days);
     }
 
     /**
-     * @deprecated 2.4.0 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
+     * @deprecated 2.8.3 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
      */
     public function get_top_failure_reasons($days = 14, $limit = 8) {
         return $this->get_stats_repository()->get_top_failure_reasons($days, $limit);
@@ -665,7 +665,7 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
     /**
      * Get the estimated generation time based on recent successful generations.
      *
-     * @deprecated 2.4.0 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
+     * @deprecated 2.8.3 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
      *
      * Retrieves the average of the most recent recorded generation times
      * from post metadata to provide an estimate for bulk generation tasks.
@@ -681,7 +681,7 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
     }
 
     /**
-     * @deprecated 2.4.0 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
+     * @deprecated 2.8.3 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
      */
     public function get_stats() {
         return $this->get_stats_repository()->get_stats();
@@ -690,7 +690,7 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
     /**
      * Get per-day generation counts for the last N days.
      *
-     * @deprecated 2.4.0 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
+     * @deprecated 2.8.3 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
      *
      * Returns an array keyed by ISO date string (Y-m-d) where each value is an
      * associative array with 'completed', 'failed', and 'total' counts.
@@ -709,7 +709,7 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
     /**
      * Get statistics for a specific template.
      *
-     * @deprecated 2.4.0 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
+     * @deprecated 2.8.3 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
      *
      * @param int $template_id Template ID.
      * @return int Number of completed posts for this template.
@@ -721,7 +721,7 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
     /**
      * Get statistics for all templates.
      *
-     * @deprecated 2.4.0 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
+     * @deprecated 2.8.3 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
      *
      * @return array Associative array of template ID => count.
      */
@@ -732,7 +732,7 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
     /**
      * Get generated-post counts for schedule history containers.
      *
-     * @deprecated 2.4.0 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
+     * @deprecated 2.8.3 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
      *
      * Counts activity/error logs that represent a generated post event.
      * The key is history_id (schedule_history_id on schedules table).
@@ -747,7 +747,7 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
     /**
      * Get author schedule logs filtered by event types.
      *
-     * @deprecated 2.4.0 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
+     * @deprecated 2.8.3 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
      *
      * @param int   $author_id Author ID.
      * @param array $event_types Event types to include.

--- a/ai-post-scheduler/includes/class-aips-history-repository.php
+++ b/ai-post-scheduler/includes/class-aips-history-repository.php
@@ -51,7 +51,7 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
     private $wpdb;
 
     /**
-     * @var AIPS_History_Stats_Repository Stats repository
+     * @var AIPS_History_Stats_Repository|null Stats repository.
      */
     private $stats_repository;
     
@@ -64,7 +64,19 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
         $this->table_name = $wpdb->prefix . 'aips_history';
         $this->table_name_log = $wpdb->prefix . 'aips_history_log';
         $this->schedule_table = $wpdb->prefix . 'aips_schedule';
-        $this->stats_repository = new AIPS_History_Stats_Repository();
+    }
+
+    /**
+     * Get the stats repository instance, lazy-loading it when needed.
+     *
+     * @return AIPS_History_Stats_Repository
+     */
+    private function get_stats_repository(): AIPS_History_Stats_Repository {
+        if ( $this->stats_repository === null ) {
+            $this->stats_repository = new AIPS_History_Stats_Repository();
+        }
+
+        return $this->stats_repository;
     }
 
     /**
@@ -141,28 +153,28 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
      * @deprecated 2.4.0 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
      */
     public function get_daily_success_failure_trend($days = 14) {
-        return $this->stats_repository->get_daily_success_failure_trend($days);
+        return $this->get_stats_repository()->get_daily_success_failure_trend($days);
     }
 
     /**
      * @deprecated 2.4.0 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
      */
     public function get_average_duration_by_flow($days = 14) {
-        return $this->stats_repository->get_average_duration_by_flow($days);
+        return $this->get_stats_repository()->get_average_duration_by_flow($days);
     }
 
     /**
      * @deprecated 2.4.0 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
      */
     public function get_retry_counts_by_service($days = 14) {
-        return $this->stats_repository->get_retry_counts_by_service($days);
+        return $this->get_stats_repository()->get_retry_counts_by_service($days);
     }
 
     /**
      * @deprecated 2.4.0 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
      */
     public function get_top_failure_reasons($days = 14, $limit = 8) {
-        return $this->stats_repository->get_top_failure_reasons($days, $limit);
+        return $this->get_stats_repository()->get_top_failure_reasons($days, $limit);
     }
     
     /**
@@ -665,14 +677,14 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
      * }
      */
     public function get_estimated_generation_time($limit = 20) {
-        return $this->stats_repository->get_estimated_generation_time($limit);
+        return $this->get_stats_repository()->get_estimated_generation_time($limit);
     }
 
     /**
      * @deprecated 2.4.0 This is a legacy proxy for backward compatibility. Use AIPS_History_Stats_Repository instead.
      */
     public function get_stats() {
-        return $this->stats_repository->get_stats();
+        return $this->get_stats_repository()->get_stats();
     }
 
     /**
@@ -691,7 +703,7 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
      * @return array<string, array{completed: int, failed: int, total: int}>
      */
     public function get_daily_generation_counts( $days = 14 ) {
-        return $this->stats_repository->get_daily_generation_counts($days);
+        return $this->get_stats_repository()->get_daily_generation_counts($days);
     }
 
     /**
@@ -703,7 +715,7 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
      * @return int Number of completed posts for this template.
      */
     public function get_template_stats($template_id) {
-        return $this->stats_repository->get_template_stats($template_id);
+        return $this->get_stats_repository()->get_template_stats($template_id);
     }
 
     /**
@@ -714,7 +726,7 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
      * @return array Associative array of template ID => count.
      */
     public function get_all_template_stats() {
-        return $this->stats_repository->get_all_template_stats();
+        return $this->get_stats_repository()->get_all_template_stats();
     }
 
     /**
@@ -729,7 +741,7 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
      * @return array Associative array of history_id => generated count.
      */
     public function get_schedule_generated_post_counts($history_ids) {
-        return $this->stats_repository->get_schedule_generated_post_counts($history_ids);
+        return $this->get_stats_repository()->get_schedule_generated_post_counts($history_ids);
     }
 
     /**
@@ -743,7 +755,7 @@ class AIPS_History_Repository implements AIPS_History_Repository_Interface {
      * @return array Raw log rows from aips_history_log.
      */
     public function get_author_schedule_logs_by_event_types($author_id, $event_types = array(), $limit = 100) {
-        return $this->stats_repository->get_author_schedule_logs_by_event_types($author_id, $event_types, $limit);
+        return $this->get_stats_repository()->get_author_schedule_logs_by_event_types($author_id, $event_types, $limit);
     }
     
     /**

--- a/ai-post-scheduler/includes/class-aips-history-stats-repository.php
+++ b/ai-post-scheduler/includes/class-aips-history-stats-repository.php
@@ -1,0 +1,373 @@
+<?php
+/**
+ * History Stats Repository
+ *
+ * Dedicated repository for analytical queries and stats methods
+ * extracted from AIPS_History_Repository to mitigate God Object anti-pattern.
+ *
+ * @package AI_Post_Scheduler
+ * @since 2.4.0
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Class AIPS_History_Stats_Repository
+ *
+ * Handles complex analytical queries and statistical aggregations for history records.
+ */
+class AIPS_History_Stats_Repository {
+
+    /**
+     * @var string The history table name (with prefix)
+     */
+    private $table_name;
+
+    /**
+     * @var string The history log table name
+     */
+    private $table_name_log;
+
+    /**
+     * @var wpdb WordPress database abstraction object
+     */
+    private $wpdb;
+
+    /**
+     * Initialize the repository.
+     */
+    public function __construct() {
+        global $wpdb;
+        $this->wpdb = $wpdb;
+        $this->table_name = $wpdb->prefix . 'aips_history';
+        $this->table_name_log = $wpdb->prefix . 'aips_history_log';
+    }
+
+    /**
+     * Get daily success and failure trend.
+     *
+     * @param int $days Number of days to include.
+     * @return array
+     */
+    public function get_daily_success_failure_trend($days = 14) {
+        $days = max(1, absint($days));
+
+        return $this->wpdb->get_results($this->wpdb->prepare(
+            "SELECT DATE(FROM_UNIXTIME(created_at)) AS metric_date, SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS success_count, SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failure_count FROM {$this->table_name} WHERE created_at >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY metric_date ORDER BY metric_date ASC",
+            $days
+        ), ARRAY_A);
+    }
+
+    /**
+     * Get average duration by flow type.
+     *
+     * @param int $days Number of days to include.
+     * @return array
+     */
+    public function get_average_duration_by_flow($days = 14) {
+        $days = max(1, absint($days));
+
+        return $this->wpdb->get_results($this->wpdb->prepare(
+            "SELECT COALESCE(NULLIF(creation_method, ''), 'unknown') AS flow_type, AVG(completed_at - created_at) AS avg_duration_seconds, COUNT(*) AS sample_count FROM {$this->table_name} WHERE completed_at IS NOT NULL AND created_at >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY flow_type ORDER BY avg_duration_seconds DESC",
+            $days
+        ), ARRAY_A);
+    }
+
+    /**
+     * Get retry counts by service key.
+     *
+     * @param int $days Number of days to include.
+     * @return array
+     */
+    public function get_retry_counts_by_service($days = 14) {
+        $days = max(1, absint($days));
+
+        return $this->wpdb->get_results($this->wpdb->prepare(
+            "SELECT COALESCE(NULLIF(JSON_UNQUOTE(JSON_EXTRACT(details, '$.context')), ''), 'unknown') AS service_key, COUNT(*) AS retry_count FROM {$this->table_name_log} WHERE log_type = %s AND timestamp >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY service_key ORDER BY retry_count DESC",
+            'retry',
+            $days
+        ), ARRAY_A);
+    }
+
+    /**
+     * Get top failure reasons.
+     *
+     * @param int $days Number of days to include.
+     * @param int $limit Maximum number of reasons to return.
+     * @return array
+     */
+    public function get_top_failure_reasons($days = 14, $limit = 8) {
+        $days = max(1, absint($days));
+        $limit = max(1, absint($limit));
+
+        return $this->wpdb->get_results($this->wpdb->prepare(
+            "SELECT COALESCE(NULLIF(TRIM(error_message), ''), 'Unknown failure') AS reason, COUNT(*) AS failure_count FROM {$this->table_name} WHERE status = 'failed' AND created_at >= UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL %d DAY)) GROUP BY reason ORDER BY failure_count DESC LIMIT %d",
+            $days,
+            $limit
+        ), ARRAY_A);
+    }
+
+    /**
+     * Return estimated generation timing stats.
+     *
+     * @param int $limit Number of rows to sample.
+     * @return array
+     */
+    public function get_estimated_generation_time($limit = 20) {
+        $default_seconds = 30;
+        $limit           = absint($limit);
+
+        // Retrieve the most recent recorded generation times.
+        $times = $this->wpdb->get_col(
+            $this->wpdb->prepare(
+                "SELECT meta_value FROM {$this->wpdb->postmeta}
+                 WHERE meta_key = %s
+                 ORDER BY meta_id DESC
+                 LIMIT %d",
+                '_aips_post_generation_total_time',
+                $limit
+            )
+        );
+
+        if (!empty($times)) {
+            $numeric_times = array_filter(array_map('floatval', $times), function($v) {
+                return $v > 0;
+            });
+
+            if (!empty($numeric_times)) {
+                $avg              = array_sum($numeric_times) / count($numeric_times);
+                $per_post_seconds = (int) ceil($avg);
+            } else {
+                $per_post_seconds = $default_seconds;
+            }
+
+            $sample_size = count($numeric_times);
+        } else {
+            $per_post_seconds = $default_seconds;
+            $sample_size      = 0;
+        }
+
+        return array(
+            'per_post_seconds' => $per_post_seconds,
+            'sample_size'      => $sample_size,
+        );
+    }
+
+    /**
+     * Get overall statistics.
+     *
+     * @return array
+     */
+    public function get_stats() {
+        $cached_stats = get_transient('aips_history_stats');
+
+        if ($cached_stats !== false) {
+            return $cached_stats;
+        }
+
+        $results = $this->wpdb->get_row("
+            SELECT
+                COUNT(*) as total,
+                SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as completed,
+                SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) as failed,
+                SUM(CASE WHEN status = 'processing' THEN 1 ELSE 0 END) as processing,
+                SUM(CASE WHEN status = 'partial' THEN 1 ELSE 0 END) as partial
+            FROM {$this->table_name}
+            WHERE COALESCE(creation_method, '') <> 'schedule_lifecycle'
+                AND NOT (creation_method IS NULL AND template_id IS NULL AND topic_id IS NULL AND post_id IS NULL AND author_id IS NULL)
+        ");
+
+        $stats = array(
+            'total' => isset($results->total) ? (int) $results->total : 0,
+            'completed' => isset($results->completed) ? (int) $results->completed : 0,
+            'failed' => isset($results->failed) ? (int) $results->failed : 0,
+            'processing' => isset($results->processing) ? (int) $results->processing : 0,
+            'partial' => isset($results->partial) ? (int) $results->partial : 0,
+        );
+
+        $stats['success_rate'] = $stats['total'] > 0
+            ? round(($stats['completed'] / $stats['total']) * 100, 1)
+            : 0;
+
+        set_transient('aips_history_stats', $stats, HOUR_IN_SECONDS);
+
+        return $stats;
+    }
+
+    /**
+     * Get per-day generation counts for the last N days.
+     *
+     * Returns an array keyed by ISO date string (Y-m-d) where each value is an
+     * associative array with 'completed', 'failed', and 'total' counts.
+     * Days with no records are omitted; callers should fill gaps as needed.
+     *
+     * Applies the same row-exclusion filters as get_stats() so that
+     * schedule-lifecycle rows and empty-shell records are not counted.
+     *
+     * @param int $days Number of calendar days to look back (inclusive today). Default 14.
+     * @return array<string, array{completed: int, failed: int, total: int}>
+     */
+    public function get_daily_generation_counts( $days = 14 ) {
+        $days      = max( 1, absint( $days ) );
+        $start_day = AIPS_DateTime::now()->advance( '-' . ( $days - 1 ) . ' days' )->format( 'Y-m-d' );
+        $start     = AIPS_DateTime::fromDate( $start_day )->timestamp();
+
+        $results = $this->wpdb->get_results(
+            $this->wpdb->prepare(
+                "SELECT
+                    DATE(FROM_UNIXTIME(created_at)) AS day,
+                    SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS completed,
+                    SUM(CASE WHEN status = 'failed'    THEN 1 ELSE 0 END) AS failed,
+                    COUNT(*) AS total
+                 FROM {$this->table_name}
+                 WHERE created_at >= %d
+                   AND COALESCE(creation_method, '') <> 'schedule_lifecycle'
+                   AND NOT (creation_method IS NULL AND template_id IS NULL AND topic_id IS NULL AND post_id IS NULL AND author_id IS NULL)
+                 GROUP BY DATE(FROM_UNIXTIME(created_at))
+                 ORDER BY day ASC",
+                $start
+            )
+        );
+
+        $data = array();
+        foreach ( $results as $row ) {
+            $data[ $row->day ] = array(
+                'completed' => (int) $row->completed,
+                'failed'    => (int) $row->failed,
+                'total'     => (int) $row->total,
+            );
+        }
+
+        return $data;
+    }
+
+    /**
+     * Get statistics for a specific template.
+     *
+     * @param int $template_id Template ID.
+     * @return int Number of completed posts for this template.
+     */
+    public function get_template_stats($template_id) {
+        return (int) $this->wpdb->get_var($this->wpdb->prepare(
+            "SELECT COUNT(*) FROM {$this->table_name} WHERE template_id = %d AND status = 'completed'",
+            $template_id
+        ));
+    }
+
+    /**
+     * Get statistics for all templates.
+     *
+     * @return array Associative array of template ID => count.
+     */
+    public function get_all_template_stats() {
+        $results = $this->wpdb->get_results("
+            SELECT template_id, COUNT(*) as count
+            FROM {$this->table_name}
+            WHERE status = 'completed'
+            GROUP BY template_id
+        ");
+
+        $stats = array();
+        foreach ($results as $row) {
+            $stats[$row->template_id] = (int) $row->count;
+        }
+
+        return $stats;
+    }
+
+    /**
+     * Get generated-post counts for schedule history containers.
+     *
+     * Counts activity/error logs that represent a generated post event.
+     * The key is history_id (schedule_history_id on schedules table).
+     *
+     * @param array $history_ids History container IDs.
+     * @return array Associative array of history_id => generated count.
+     */
+    public function get_schedule_generated_post_counts($history_ids) {
+        $history_ids = array_map('absint', (array) $history_ids);
+        $history_ids = array_filter($history_ids);
+
+        if (empty($history_ids)) {
+            return array();
+        }
+
+        $placeholders = implode(',', array_fill(0, count($history_ids), '%d'));
+
+        $sql = "
+            SELECT history_id, COUNT(*) AS count
+            FROM {$this->table_name_log}
+            WHERE history_id IN ({$placeholders})
+                AND history_type_id IN (%d, %d)
+                AND (
+                    details LIKE %s
+                    OR details LIKE %s
+                    OR details LIKE %s
+                )
+            GROUP BY history_id
+        ";
+
+        $args = $history_ids;
+        $args[] = AIPS_History_Type::ACTIVITY;
+        $args[] = AIPS_History_Type::ERROR;
+        $args[] = '%"event_type":"post_published"%';
+        $args[] = '%"event_type":"post_draft"%';
+        $args[] = '%"event_type":"manual_schedule_completed"%';
+
+        $results = $this->wpdb->get_results($this->wpdb->prepare($sql, $args));
+
+        $counts = array();
+        foreach ($results as $row) {
+            $counts[(int) $row->history_id] = (int) $row->count;
+        }
+
+        return $counts;
+    }
+
+    /**
+     * Get author schedule logs filtered by event types.
+     *
+     * @param int   $author_id Author ID.
+     * @param array $event_types Event types to include.
+     * @param int   $limit Max rows to return.
+     * @return array Raw log rows from aips_history_log.
+     */
+    public function get_author_schedule_logs_by_event_types($author_id, $event_types = array(), $limit = 100) {
+        $author_id = absint($author_id);
+        $limit = absint($limit);
+        $event_types = array_filter(array_map('sanitize_key', (array) $event_types));
+
+        if (!$author_id || $limit < 1 || empty($event_types)) {
+            return array();
+        }
+
+        $where_events = array();
+        $args = array(
+            $author_id,
+            AIPS_History_Type::ACTIVITY,
+            AIPS_History_Type::ERROR,
+        );
+
+        foreach ($event_types as $event_type) {
+            $where_events[] = 'hl.details LIKE %s';
+            $args[] = '%"event_type":"' . $this->wpdb->esc_like($event_type) . '"%';
+        }
+
+        $args[] = $limit;
+
+        $sql = "
+            SELECT hl.*
+            FROM {$this->table_name_log} hl
+            INNER JOIN {$this->table_name} h ON hl.history_id = h.id
+            WHERE h.author_id = %d
+                AND hl.history_type_id IN (%d, %d)
+                AND (" . implode(' OR ', $where_events) . ")
+            ORDER BY hl.timestamp DESC
+            LIMIT %d
+        ";
+
+        return $this->wpdb->get_results($this->wpdb->prepare($sql, $args));
+    }
+}

--- a/ai-post-scheduler/includes/class-aips-history-stats-repository.php
+++ b/ai-post-scheduler/includes/class-aips-history-stats-repository.php
@@ -6,7 +6,7 @@
  * extracted from AIPS_History_Repository to mitigate God Object anti-pattern.
  *
  * @package AI_Post_Scheduler
- * @since 2.4.0
+ * @since 2.8.3
  */
 
 if (!defined('ABSPATH')) {

--- a/ai-post-scheduler/includes/class-aips-history-stats-repository.php
+++ b/ai-post-scheduler/includes/class-aips-history-stats-repository.php
@@ -232,12 +232,14 @@ class AIPS_History_Stats_Repository {
         );
 
         $data = array();
-        foreach ( $results as $row ) {
-            $data[ $row->day ] = array(
-                'completed' => (int) $row->completed,
-                'failed'    => (int) $row->failed,
-                'total'     => (int) $row->total,
-            );
+        if ( is_array( $results ) ) {
+            foreach ( $results as $row ) {
+                $data[ $row->day ] = array(
+                    'completed' => (int) $row->completed,
+                    'failed'    => (int) $row->failed,
+                    'total'     => (int) $row->total,
+                );
+            }
         }
 
         return $data;
@@ -270,8 +272,10 @@ class AIPS_History_Stats_Repository {
         ");
 
         $stats = array();
-        foreach ($results as $row) {
-            $stats[$row->template_id] = (int) $row->count;
+        if ( is_array( $results ) ) {
+            foreach ( $results as $row ) {
+                $stats[ $row->template_id ] = (int) $row->count;
+            }
         }
 
         return $stats;
@@ -319,8 +323,10 @@ class AIPS_History_Stats_Repository {
         $results = $this->wpdb->get_results($this->wpdb->prepare($sql, $args));
 
         $counts = array();
-        foreach ($results as $row) {
-            $counts[(int) $row->history_id] = (int) $row->count;
+        if ( is_array( $results ) ) {
+            foreach ( $results as $row ) {
+                $counts[ (int) $row->history_id ] = (int) $row->count;
+            }
         }
 
         return $counts;

--- a/ai-post-scheduler/tests/AIPS_Autoloader_Test.php
+++ b/ai-post-scheduler/tests/AIPS_Autoloader_Test.php
@@ -171,6 +171,7 @@ class AIPS_Autoloader_Test extends WP_UnitTestCase {
 	public function test_autoloader_loads_repository_classes() {
 		$repositories = array(
 			'AIPS_History_Repository',
+			'AIPS_History_Stats_Repository',
 			'AIPS_Schedule_Repository',
 			'AIPS_Template_Repository',
 		);

--- a/ai-post-scheduler/tests/AIPS_History_Repository_Test.php
+++ b/ai-post-scheduler/tests/AIPS_History_Repository_Test.php
@@ -359,7 +359,7 @@ class AIPS_History_Repository_Test extends WP_UnitTestCase {
 					'generated_content'=> '',
 					'prompt'           => '',
 					'error_message'    => null,
-					'created_at'       => $today . ' 10:00:00',
+					'created_at'       => strtotime($today . ' 10:00:00'),
 				),
 				array('%d', '%d', '%s', '%s', '%s', '%s', '%s', '%s')
 			);
@@ -377,7 +377,7 @@ class AIPS_History_Repository_Test extends WP_UnitTestCase {
 				'generated_content'=> '',
 				'prompt'           => '',
 				'error_message'    => null,
-				'created_at'       => $yesterday . ' 08:00:00',
+				'created_at'       => strtotime($yesterday . ' 08:00:00'),
 			),
 			array('%d', '%d', '%s', '%s', '%s', '%s', '%s', '%s')
 		);


### PR DESCRIPTION
## Summary
- Extracted analytics/statistical query methods from `AIPS_History_Repository` into `AIPS_History_Stats_Repository` to reduce God-object responsibilities and preserve backward compatibility via deprecated proxy methods.
- Addressed follow-up Gemini review feedback by:
  - Lazy-loading the stats repository inside `AIPS_History_Repository` (instead of constructing it unconditionally).
  - Updating proxy methods to use the lazy-loading accessor.
  - Adding defensive `is_array()` guards before iterating `$wpdb->get_results()` outputs in stats methods to avoid foreach warnings on query failure.
- Why now? This keeps the refactor performant and safer under DB failure scenarios while maintaining the original compatibility guarantees.

## Verification
- [x] `composer test` (or targeted tests) run for changed behavior
- [ ] Manual verification completed for changed admin/runtime paths
- [ ] Documentation updated (if behavior or workflow changed)

## Risk Checklist
- [ ] Label `schema-change` applied when DB schema/version is touched
- [ ] Label `admin-ui` + `needs-browser-test` applied when admin UI is touched
- [ ] Label `ajax-registry` applied when AJAX handlers/registry are touched
- [ ] Label `cron` applied when cron/queue/retry paths are touched
- [ ] Label `generation-pipeline` applied when prompt/generation flow is touched
- [ ] Label `security-sensitive` applied when auth/nonce/capability/data-safety paths are touched
- [ ] Label duplicate-risk applied and addressed before merge