### PR TITLE
⚡ Bolt: Optimize N+1 queries in generated posts controller

### DIFF
--- a/.build/bolt.md
+++ b/.build/bolt.md
@@ -26,3 +26,6 @@
 ## 2026-03-24 - [Optimize Dashboard History Retrieval]
 **Learning:** Replacing `SELECT *` with hardcoded columns in a core repository method (like `get_history`) as a default fallback is an anti-pattern in this architecture. It creates high regression risks by starving callers of expected data (like `longtext` fields) and breaks forward compatibility when new columns are added. The safest performance optimization is to update the call sites (like list views or dashboard widgets) to explicitly request a lighter payload (e.g. `fields => 'list'`) when heavy data is unnecessary.
 **Action:** When optimizing database queries, prefer passing explicit optimization parameters from the caller rather than blindly altering default fallback behaviors in the underlying repository.
+## 2026-06-01 - Optimize N+1 queries using _prime_post_caches
+**Learning:** In loops fetching multiple posts in WordPress via `get_post()`, a common bottleneck is executing an individual query for every item (N+1 query problem).
+**Action:** Extract all `post_id`s before the loop, uniquely filter them, and bulk load them into WordPress's object cache using `_prime_post_caches(array_unique($post_ids), false, true)`. This turns N queries into 1 batch query, drastically speeding up admin rendering flows.

--- a/ai-post-scheduler/includes/class-aips-generated-posts-controller.php
+++ b/ai-post-scheduler/includes/class-aips-generated-posts-controller.php
@@ -90,6 +90,17 @@ class AIPS_Generated_Posts_Controller {
 			'fields' => 'list', // Explicitly use lightweight list fields for UI listing
 		));
 		
+		// Pre-fetch posts to prevent N+1 queries
+		$post_ids = array();
+		foreach ($history['items'] as $item) {
+			if ($item->post_id) {
+				$post_ids[] = $item->post_id;
+			}
+		}
+		if (!empty($post_ids) && function_exists('_prime_post_caches')) {
+			_prime_post_caches(array_unique($post_ids), false, true);
+		}
+
 		// Get schedule data for each post
 		$posts_data = array();
 		foreach ($history['items'] as $item) {
@@ -149,6 +160,17 @@ class AIPS_Generated_Posts_Controller {
 			'author_id' => $author_id,
 			'template_id' => $template_id,
 		));
+
+		// Pre-fetch partial generation posts to prevent N+1 queries
+		$partial_post_ids = array();
+		foreach ($partial_generations['items'] as $item) {
+			if ($item->post_id) {
+				$partial_post_ids[] = $item->post_id;
+			}
+		}
+		if (!empty($partial_post_ids) && function_exists('_prime_post_caches')) {
+			_prime_post_caches(array_unique($partial_post_ids), false, true);
+		}
 
 		$partial_posts_data = array();
 		foreach ($partial_generations['items'] as $item) {


### PR DESCRIPTION
💡 **What:** Batched database cache loading for WordPress posts in `class-aips-generated-posts-controller.php`.
🎯 **Why:** The controller was looping over history logs and fetching `get_post($item->post_id)` one-by-one. In WordPress, this can trigger individual database queries for each post not in memory (the N+1 query problem).
📊 **Impact:** Reduces database query count significantly (from O(N) to O(1) batched query per list). This speeds up admin page rendering on the Generated Posts tab, especially when dealing with lists of 20 items. 
🔬 **Measurement:** Use the Query Monitor plugin or `SAVEQUERIES` / `timer_stop()` to verify reduced query counts when visiting the Generated Posts tab.
🛡️ **Safety:** The optimization is wrapped in `function_exists('_prime_post_caches')` to safely fallback on WordPress 5.8-6.0 since this core batch function was introduced in WP 6.1.

---
*PR created automatically by Jules for task [15450162233442303366](https://jules.google.com/task/15450162233442303366) started by @rpnunez*