### PR TITLE
🎨 Palette: Improve accessibility of calendar navigation buttons

### DIFF
--- a/ai-post-scheduler/.build/palette.md
+++ b/ai-post-scheduler/.build/palette.md
@@ -1,0 +1,4 @@
+
+## 2026-06-03 - Accessible Icon-Only Buttons
+**Learning:** Icon-only navigation buttons (such as calendar arrows) frequently rely solely on `title` attributes, which are insufficient for screen readers. The inner `dashicons` characters may also be incorrectly announced.
+**Action:** Always provide an explicit `aria-label` on the `<button>` element for icon-only actions, and ensure the inner decorative `<span class="dashicons">` element includes `aria-hidden="true"` to prevent redundant or confusing screen reader announcements.

--- a/ai-post-scheduler/templates/admin/calendar.php
+++ b/ai-post-scheduler/templates/admin/calendar.php
@@ -33,14 +33,14 @@ if (!defined('ABSPATH')) {
 				<!-- Calendar Header with Navigation -->
 				<div class="aips-calendar-header">
 					<div class="aips-calendar-nav">
-						<button class="aips-btn aips-btn-sm aips-btn-secondary aips-calendar-prev" title="<?php esc_attr_e('Previous Month', 'ai-post-scheduler'); ?>">
-							<span class="dashicons dashicons-arrow-left-alt2"></span>
+						<button class="aips-btn aips-btn-sm aips-btn-secondary aips-calendar-prev" title="<?php esc_attr_e('Previous Month', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Previous Month', 'ai-post-scheduler'); ?>">
+							<span class="dashicons dashicons-arrow-left-alt2" aria-hidden="true"></span>
 						</button>
 						<h2 class="aips-calendar-title">
 							<span class="aips-calendar-month-year"></span>
 						</h2>
-						<button class="aips-btn aips-btn-sm aips-btn-secondary aips-calendar-next" title="<?php esc_attr_e('Next Month', 'ai-post-scheduler'); ?>">
-							<span class="dashicons dashicons-arrow-right-alt2"></span>
+						<button class="aips-btn aips-btn-sm aips-btn-secondary aips-calendar-next" title="<?php esc_attr_e('Next Month', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Next Month', 'ai-post-scheduler'); ?>">
+							<span class="dashicons dashicons-arrow-right-alt2" aria-hidden="true"></span>
 						</button>
 					</div>
 					


### PR DESCRIPTION
**What:**
Added `aria-label` to the "Previous Month" and "Next Month" icon-only buttons in the admin calendar template. Also added `aria-hidden="true"` to the decorative `dashicons` icons within those buttons.

**Why:**
Icon-only navigation buttons must have explicit accessible names so screen reader users understand their function. Relying solely on the `title` attribute is insufficient. Hiding the internal font icons ensures the screen reader doesn't announce random character codes.

**Accessibility:**
- The `<button>` elements now have explicit `aria-label`s specifying "Previous Month" and "Next Month".
- The decorative `dashicons` are now hidden from the accessibility tree via `aria-hidden="true"`.

---
*PR created automatically by Jules for task [14585998860847512921](https://jules.google.com/task/14585998860847512921) started by @rpnunez*