### PR TITLE
⚡ Bolt: Optimize Generated Posts admin page load (N+1 queries)

### DIFF
--- a/ai-post-scheduler/.build/bolt.md
+++ b/ai-post-scheduler/.build/bolt.md
@@ -1,0 +1,4 @@
+
+## 2025-02-18 - Optimized Generated Posts admin page load
+**Learning:** Found N+1 query patterns in `AIPS_Generated_Posts_Controller::render_page()` when iterating over `$history['items']` and `$partial_generations['items']` calling `get_post()`. Also found multiple `get_option('date_format')` and `get_option('time_format')` calls per item within the loops.
+**Action:** Used `_prime_post_caches(array_unique($post_ids), false, true)` to pre-fetch post caches for both history loops (wrapped in `function_exists` check), and cached the formatted datetime string outside the loops, significantly reducing database queries per request for this admin view.

--- a/ai-post-scheduler/includes/class-aips-generated-posts-controller.php
+++ b/ai-post-scheduler/includes/class-aips-generated-posts-controller.php
@@ -90,6 +90,23 @@ class AIPS_Generated_Posts_Controller {
 			'fields' => 'list', // Explicitly use lightweight list fields for UI listing
 		));
 		
+		$date_format = get_option('date_format');
+		$time_format = get_option('time_format');
+		$datetime_format = $date_format . ' ' . $time_format;
+
+		// Pre-fetch post caches to prevent N+1 queries
+		if (function_exists('_prime_post_caches')) {
+			$post_ids = array();
+			foreach ($history['items'] as $item) {
+				if ($item->post_id) {
+					$post_ids[] = $item->post_id;
+				}
+			}
+			if (!empty($post_ids)) {
+				_prime_post_caches(array_unique($post_ids), false, true);
+			}
+		}
+
 		// Get schedule data for each post
 		$posts_data = array();
 		foreach ($history['items'] as $item) {
@@ -120,9 +137,9 @@ class AIPS_Generated_Posts_Controller {
 				'history_id' => $item->id,
 				'post_id' => $item->post_id,
 				'title' => $post->post_title,
-				'date_generated' => AIPS_DateTime::formatRelativeOrAbsolute($item->created_at, get_option('date_format') . ' ' . get_option('time_format')),
-				'date_published' => AIPS_DateTime::formatRelativeOrAbsolute($published_timestamp, get_option('date_format') . ' ' . get_option('time_format')),
-				'date_scheduled' => AIPS_DateTime::formatRelativeOrAbsolute($schedule ? $schedule->next_run : null, get_option('date_format') . ' ' . get_option('time_format')),
+				'date_generated' => AIPS_DateTime::formatRelativeOrAbsolute($item->created_at, $datetime_format),
+				'date_published' => AIPS_DateTime::formatRelativeOrAbsolute($published_timestamp, $datetime_format),
+				'date_scheduled' => AIPS_DateTime::formatRelativeOrAbsolute($schedule ? $schedule->next_run : null, $datetime_format),
 				'edit_link' => esc_url_raw(get_edit_post_link($item->post_id)),
 				'source' => $source,
 			);
@@ -150,6 +167,19 @@ class AIPS_Generated_Posts_Controller {
 			'template_id' => $template_id,
 		));
 
+		// Pre-fetch post caches for partial generations to prevent N+1 queries
+		if (function_exists('_prime_post_caches')) {
+			$partial_post_ids = array();
+			foreach ($partial_generations['items'] as $item) {
+				if ($item->post_id) {
+					$partial_post_ids[] = $item->post_id;
+				}
+			}
+			if (!empty($partial_post_ids)) {
+				_prime_post_caches(array_unique($partial_post_ids), false, true);
+			}
+		}
+
 		$partial_posts_data = array();
 		foreach ($partial_generations['items'] as $item) {
 			if (!$item->post_id) {
@@ -165,8 +195,8 @@ class AIPS_Generated_Posts_Controller {
 				'history_id' => $item->id,
 				'post_id' => $item->post_id,
 				'title' => $post->post_title,
-			'date_generated' => AIPS_DateTime::formatRelativeOrAbsolute($item->created_at, get_option('date_format') . ' ' . get_option('time_format')),
-			'date_updated' => AIPS_DateTime::formatRelativeOrAbsolute($item->post_modified, get_option('date_format') . ' ' . get_option('time_format')),
+			'date_generated' => AIPS_DateTime::formatRelativeOrAbsolute($item->created_at, $datetime_format),
+			'date_updated' => AIPS_DateTime::formatRelativeOrAbsolute($item->post_modified, $datetime_format),
 				'edit_link' => esc_url_raw(get_edit_post_link($item->post_id)),
 				'post_status' => $item->post_status,
 				'is_currently_incomplete' => ('true' === (string) $item->is_currently_incomplete),


### PR DESCRIPTION
💡 **What:**
Optimized the `AIPS_Generated_Posts_Controller::render_page()` method by utilizing `_prime_post_caches()` to bulk load post object caches and hoisted repeated `get_option` calls outside of `foreach` loops.

🎯 **Why:**
The Generated Posts admin page renders lists of history items using the `$history['items']` and `$partial_generations['items']` data arrays. Inside the loops iterating over these lists, `get_post($item->post_id)` was called to fetch WordPress post data, creating an N+1 query vulnerability. Furthermore, the timezone calculation repeatedly called `get_option('date_format')` and `get_option('time_format')` on every loop pass (up to 40+ times unnecessarily). 

📊 **Impact:**
- **Database:** Drops the number of WordPress Core Queries for rendering historical post titles and statuses from roughly $O(N)$ down to $O(1)$ batch query. 
- **PHP Efficiency:** Avoids duplicate option lookups, avoiding both option cache misses and the function call overhead.
- **Admin Page Load:** The reduction in unbatched database hits noticeably decreases latency when scrolling across large historical schedules of AI generations in the system.

🔬 **Measurement:**
This improvement can be measured via Query Monitor or by enabling `$wpdb->save_queries = true` and logging query count prior to this change vs. after viewing the Generated Posts history tabs. It works safely in isolation and cleanly wraps standard framework optimizations safely.

---
*PR created automatically by Jules for task [1887992172909662898](https://jules.google.com/task/1887992172909662898) started by @rpnunez*