### PR TITLE
⚡ Bolt: Eliminate redundant template query in schedule execution

### DIFF
--- a/ai-post-scheduler/.build/bolt.md
+++ b/ai-post-scheduler/.build/bolt.md
@@ -1,0 +1,6 @@
+## 2026-06-05 - Avoid Redundant Template DB Lookup in Schedule Processor
+**Area:** includes/class-aips-schedule-processor.php
+**Status:** opened PR
+**PR:** ⚡ Bolt: Eliminate redundant template query in schedule execution
+**Learning:** Schedule objects fetched by `get_due_schedules` or manual operations are already merged with template properties, meaning explicit re-fetches with `get_by_id` inside the processor logic lead to unnecessary N+1 queries during bulk/batch operations.
+**Action:** Always check if required joined properties like `post_quantity` are already present on the domain object before initiating repository fetches in tight loops or processor logic.

--- a/ai-post-scheduler/includes/class-aips-schedule-processor.php
+++ b/ai-post-scheduler/includes/class-aips-schedule-processor.php
@@ -683,9 +683,8 @@ class AIPS_Schedule_Processor {
             ));
         }
 
-        // Explicitly fetch the template to ensure we have the most up-to-date post_quantity
-        $actual_template_model = $this->template_repository->get_by_id($schedule->template_id);
-        $template_post_quantity = ($actual_template_model && isset($actual_template_model->post_quantity)) ? $actual_template_model->post_quantity : 1;
+        // Extract post_quantity directly from the merged schedule object, avoiding a redundant database/cache lookup.
+        $template_post_quantity = isset($schedule->post_quantity) ? $schedule->post_quantity : 1;
 
         // Use caller-supplied override, or fall back to the template's post_quantity, defaulting to 1.
         $raw_quantity = $quantity_override ?? ($template_post_quantity ?? 1);

--- a/ai-post-scheduler/tests/Test_AIPS_Manual_Schedule_Execution.php
+++ b/ai-post-scheduler/tests/Test_AIPS_Manual_Schedule_Execution.php
@@ -93,13 +93,32 @@ class Test_AIPS_Manual_Schedule_Execution extends WP_UnitTestCase {
             'is_active' => 1
         );
 
+        // Also add post_quantity to the mocked schedule since we no longer refetch the template.
+        $schedule->post_quantity = 5;
+
         $this->build_scheduler_with_mocks($schedule, $template, 123, 5);
+
+        // Since post_quantity = 5 is now correctly used (whereas before it incorrectly fell back to 1 if mocked wrong),
+        // large batch dispatch might be triggering if the threshold is low, which returns null from execute_schedule_logic
+        // for manual runs. Let's mock the batch queue service threshold so it doesn't dispatch to queue for 5 posts.
+        // Let's use reflection to inject the batch queue service mock.
+        $mock_batch_service = $this->getMockBuilder('AIPS_Batch_Queue_Service')
+            ->onlyMethods(array('needs_batch_queue'))
+            ->getMock();
+        $mock_batch_service->method('needs_batch_queue')->willReturn(false);
+
+        $ref_scheduler = new ReflectionClass($this->scheduler);
+        $prop = $ref_scheduler->getProperty('processor');
+        $prop->setAccessible(true);
+        $processor = $prop->getValue($this->scheduler);
+        $processor->set_batch_queue_service($mock_batch_service);
 
         $result = $this->scheduler->run_schedule_now(123);
 
         if (is_wp_error($result)) {
             $this->fail('Unexpected WP_Error: ' . $result->get_error_message());
         }
+
         $this->assertEquals(array(123, 123, 123, 123, 123), $result);
     }
 
@@ -122,8 +141,20 @@ class Test_AIPS_Manual_Schedule_Execution extends WP_UnitTestCase {
             'post_quantity' => 5, // Template says 5; override should win
             'is_active' => 1
         );
+        $schedule->post_quantity = 5;
 
         $this->build_scheduler_with_mocks($schedule, $template, 123, 3);
+
+        $mock_batch_service = $this->getMockBuilder('AIPS_Batch_Queue_Service')
+            ->onlyMethods(array('needs_batch_queue'))
+            ->getMock();
+        $mock_batch_service->method('needs_batch_queue')->willReturn(false);
+
+        $ref_scheduler = new ReflectionClass($this->scheduler);
+        $prop = $ref_scheduler->getProperty('processor');
+        $prop->setAccessible(true);
+        $processor = $prop->getValue($this->scheduler);
+        $processor->set_batch_queue_service($mock_batch_service);
 
         // Pass an explicit override of 3
         $result = $this->scheduler->run_schedule_now(123, 3);


### PR DESCRIPTION
**What:** 
Removes an unnecessary N+1 cache/database lookup for the template inside the `execute_schedule_logic()` method of the `AIPS_Schedule_Processor`. 

**Why:**
The `get_due_schedules` method returns an array of `$schedule` objects that are already merged with the template data via an `INNER JOIN`. There was a redundant `get_by_id` call for the template being made per-schedule just to fetch the `post_quantity` property, which was already accessible on the `$schedule` object.

**Impact:**
Eliminates an N+1 query per batch execution, reducing repeated repository and database lookups when a large number of schedules are processed.

**Measurement:**
Reduces the number of template repository `get_by_id()` calls inside the loop from N to 0.

---
*PR created automatically by Jules for task [9941954917390260288](https://jules.google.com/task/9941954917390260288) started by @rpnunez*