### PR TITLE
Consolidate Content and History into single Content admin page with tabs

### DIFF
--- a/ai-post-scheduler/assets/js/admin.js
+++ b/ai-post-scheduler/assets/js/admin.js
@@ -531,9 +531,14 @@
          * @param {Event} e - Click event from an `.aips-tab-link` element.
          */
         switchAipsTab: function(e) {
-            e.preventDefault();
             var $tabLink = $(e.currentTarget);
             var tabId = $tabLink.data('tab');
+
+            if (!tabId) {
+                return;
+            }
+
+            e.preventDefault();
             var $tabNav = $tabLink.closest('.aips-tab-nav, .aips-topics-tabs, .aips-page-tabs');
 
             if (!$tabNav.length) {

--- a/ai-post-scheduler/includes/class-aips-admin-menu.php
+++ b/ai-post-scheduler/includes/class-aips-admin-menu.php
@@ -27,10 +27,8 @@ class AIPS_Admin_Menu {
     /**
      * Add menu pages to the WordPress admin dashboard.
      *
-     * Registers a traditional flat submenu structure:
-     * Dashboard, Templates, Voices, Article Structures, Authors, Research,
-     * Schedule, Schedule Calendar, Generated Posts, History,
-     * Settings, System Status, Seeder, Dev Tools (when enabled).
+     * Registers a traditional flat submenu structure while keeping legacy
+     * Content/History routes available behind one visible Content submenu.
      *
      * @return void
      */
@@ -175,8 +173,9 @@ class AIPS_Admin_Menu {
             array($this, 'render_generated_posts_page')
         );
 
+        // Legacy History route - hidden from menu navigation, exposed from the Content tabs.
         add_submenu_page(
-            'ai-post-scheduler',
+            null,
             __('History', 'ai-post-scheduler'),
             __('History', 'ai-post-scheduler'),
             'manage_options',
@@ -270,7 +269,7 @@ class AIPS_Admin_Menu {
     }
 
     /**
-     * Expand the "AI Post Scheduler" top-level menu when on the hidden Author Topics page.
+     * Expand the "AI Post Scheduler" top-level menu when on hidden plugin pages.
      *
      * WordPress collapses the parent menu when a page is registered with null parent_slug.
      * This filter overrides that behaviour so the plugin menu stays open.
@@ -280,17 +279,18 @@ class AIPS_Admin_Menu {
      */
     public function fix_author_topics_parent_file($parent_file) {
         $page = isset($_GET['page']) ? sanitize_key(wp_unslash($_GET['page'])) : '';
-        if ($page === 'aips-author-topics' || $page === AIPS_Campaigns_Controller::DETAIL_PAGE_SLUG) {
+        if (in_array($page, array('aips-author-topics', 'aips-history', AIPS_Campaigns_Controller::DETAIL_PAGE_SLUG), true)) {
             return 'ai-post-scheduler';
         }
         return $parent_file;
     }
 
     /**
-     * Highlight the "Authors" submenu item when on the hidden Author Topics page.
+     * Highlight the visible parent submenu item when on hidden plugin pages.
      *
-     * Because the Author Topics page is registered with a null parent, WordPress
-     * does not activate any submenu item. This filter makes "Authors" appear active.
+     * Because hidden pages are registered with a null parent, WordPress does
+     * not activate any submenu item. This filter maps them back to their
+     * visible navigation entries.
      *
      * @param string $submenu_file The current submenu file slug.
      * @return string
@@ -299,6 +299,9 @@ class AIPS_Admin_Menu {
         $page = isset($_GET['page']) ? sanitize_key(wp_unslash($_GET['page'])) : '';
         if ($page === 'aips-author-topics') {
             return 'aips-authors';
+        }
+        if ($page === 'aips-history') {
+            return 'aips-generated-posts';
         }
         if ($page === AIPS_Campaigns_Controller::DETAIL_PAGE_SLUG) {
             return 'aips-campaigns';

--- a/ai-post-scheduler/templates/admin/content-tabs.php
+++ b/ai-post-scheduler/templates/admin/content-tabs.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Content page tab navigation.
+ *
+ * @package AI_Post_Scheduler
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+$active_content_tab = isset($active_content_tab) ? sanitize_key($active_content_tab) : 'generated_posts';
+$generated_posts_url = AIPS_Admin_Menu_Helper::get_page_url('generated_posts');
+$history_url = AIPS_Admin_Menu_Helper::get_page_url('history');
+$failed_runs_url = AIPS_Admin_Menu_Helper::get_page_url('history', array(
+	'status' => 'failed',
+	'content_tab' => 'failed_runs',
+));
+$uses_local_content_tabs = in_array($active_content_tab, array('generated_posts', 'review_queue', 'partial_generations'), true);
+?>
+<div class="aips-tab-nav">
+	<?php if ($uses_local_content_tabs): ?>
+		<a href="#aips-generated-posts" class="aips-tab-link <?php echo $active_content_tab === 'generated_posts' ? 'active' : ''; ?>" data-tab="aips-generated-posts"><?php esc_html_e('Generated Posts', 'ai-post-scheduler'); ?></a>
+		<a href="#aips-pending-review" class="aips-tab-link <?php echo $active_content_tab === 'review_queue' ? 'active' : ''; ?>" data-tab="aips-pending-review"><?php esc_html_e('Drafts / Review Queue', 'ai-post-scheduler'); ?></a>
+		<a href="#aips-partial-generations" class="aips-tab-link <?php echo $active_content_tab === 'partial_generations' ? 'active' : ''; ?>" data-tab="aips-partial-generations"><?php esc_html_e('Partial Generations', 'ai-post-scheduler'); ?></a>
+	<?php else: ?>
+		<a href="<?php echo esc_url($generated_posts_url); ?>#aips-generated-posts" class="aips-tab-link"><?php esc_html_e('Generated Posts', 'ai-post-scheduler'); ?></a>
+		<a href="<?php echo esc_url($generated_posts_url); ?>#aips-pending-review" class="aips-tab-link"><?php esc_html_e('Drafts / Review Queue', 'ai-post-scheduler'); ?></a>
+		<a href="<?php echo esc_url($generated_posts_url); ?>#aips-partial-generations" class="aips-tab-link"><?php esc_html_e('Partial Generations', 'ai-post-scheduler'); ?></a>
+	<?php endif; ?>
+	<a href="<?php echo esc_url($history_url); ?>" class="aips-tab-link <?php echo $active_content_tab === 'history' ? 'active' : ''; ?>"><?php esc_html_e('History', 'ai-post-scheduler'); ?></a>
+	<a href="<?php echo esc_url($failed_runs_url); ?>" class="aips-tab-link <?php echo $active_content_tab === 'failed_runs' ? 'active' : ''; ?>"><?php esc_html_e('Failed Runs', 'ai-post-scheduler'); ?></a>
+</div>

--- a/ai-post-scheduler/templates/admin/content.php
+++ b/ai-post-scheduler/templates/admin/content.php
@@ -2,11 +2,9 @@
 /**
  * Content Admin Template
  *
- * Container for the Content admin page with three tab panels:
- *
- * Tab 1: Generated Posts  - @see templates/admin/tab-generated-posts.php
- * Tab 2: Partial Generations - @see templates/admin/tab-partial-generations.php
- * Tab 3: Pending Review      - @see templates/admin/tab-pending-review.php
+ * Container for the consolidated Content admin page. Local tabs render
+ * generated posts, drafts/review, and partial generations; history tabs link
+ * to the hidden legacy history route for backward compatibility.
  *
  * @package AI_Post_Scheduler
  * @since 2.0.0
@@ -17,6 +15,7 @@ if (!defined('ABSPATH')) {
 }
 
 /** @var AIPS_Generated_Posts_Controller $controller */
+$active_content_tab = 'generated_posts';
 ?>
 
 <div class="wrap aips-wrap">
@@ -32,11 +31,7 @@ if (!defined('ABSPATH')) {
 		</div>
 
 		<!-- Tabs navigation -->
-		<div class="aips-tab-nav">
-			<a href="#aips-generated-posts" class="aips-tab-link active" data-tab="aips-generated-posts"><?php esc_html_e('Generated Posts', 'ai-post-scheduler'); ?></a>
-			<a href="#aips-partial-generations" class="aips-tab-link" data-tab="aips-partial-generations"><?php esc_html_e('Partial Generations', 'ai-post-scheduler'); ?></a>
-			<a href="#aips-pending-review" class="aips-tab-link" data-tab="aips-pending-review"><?php esc_html_e('Pending Review', 'ai-post-scheduler'); ?></a>
-		</div>
+		<?php include AIPS_PLUGIN_DIR . 'templates/admin/content-tabs.php'; ?>
 
 		<!-- Tab 1: Generated Posts -->
 		<div id="aips-generated-posts-tab" class="aips-tab-content active" role="tabpanel" aria-hidden="false">

--- a/ai-post-scheduler/templates/admin/history.php
+++ b/ai-post-scheduler/templates/admin/history.php
@@ -13,6 +13,8 @@ $actor_filter = isset($actor_filter) ? $actor_filter : (isset($_GET['actor']) ? 
 $correlation_filter = isset($correlation_id) ? $correlation_id : (isset($_GET['correlation_id']) ? sanitize_text_field(wp_unslash($_GET['correlation_id'])) : '');
 $date_from = isset($date_from) ? $date_from : (isset($_GET['date_from']) ? sanitize_text_field(wp_unslash($_GET['date_from'])) : '');
 $date_to = isset($date_to) ? $date_to : (isset($_GET['date_to']) ? sanitize_text_field(wp_unslash($_GET['date_to'])) : '');
+$content_tab = isset($_GET['content_tab']) ? sanitize_key(wp_unslash($_GET['content_tab'])) : '';
+$active_content_tab = ($status_filter === 'failed' || $content_tab === 'failed_runs') ? 'failed_runs' : 'history';
 
 $items       = array();
 $total_items = 0;
@@ -44,8 +46,8 @@ if (is_object($history)) {
         <div class="aips-page-header">
             <div class="aips-page-header-top">
                 <div>
-                    <h1 class="aips-page-title"><?php esc_html_e('History', 'ai-post-scheduler'); ?></h1>
-                    <p class="aips-page-description"><?php esc_html_e('View generation history containers and inspect every logged step, AI call, and error for each run.', 'ai-post-scheduler'); ?></p>
+                    <h1 class="aips-page-title"><?php esc_html_e('Content', 'ai-post-scheduler'); ?></h1>
+                    <p class="aips-page-description"><?php esc_html_e('View generated posts, review drafts, and inspect generation history from one consolidated content workspace.', 'ai-post-scheduler'); ?></p>
                 </div>
                 <div class="aips-page-actions">
                     <button class="aips-btn aips-btn-secondary" id="aips-export-history-btn">
@@ -55,6 +57,8 @@ if (is_object($history)) {
                 </div>
             </div>
         </div>
+
+        <?php include AIPS_PLUGIN_DIR . 'templates/admin/content-tabs.php'; ?>
 
         <?php
         $has_active_filter = !empty($status_filter) || !empty($search_query);


### PR DESCRIPTION
### Motivation
- Provide a single visible `Content` admin area that exposes generated posts and generation history as tabs while preserving existing history routes for backward compatibility.
- Reduce menu clutter by showing only one visible entry for generated content and surfacing `History`/`Failed Runs` as tab destinations or hidden routes.

### Description
- Update `AIPS_Admin_Menu::add_menu_pages()` to register a single visible `Content` submenu (`aips-generated-posts`) and preserve the legacy `aips-history` route as a hidden page (registered with `null` parent) so it can still be linked from tabs and external links.
- Map hidden pages back to the visible navigation by updating `fix_author_topics_parent_file()` and `fix_author_topics_submenu_file()` so the plugin menu stays open and the `Content` submenu is highlighted when viewing legacy history pages.
- Add a new shared tabs template `templates/admin/content-tabs.php` and update `templates/admin/content.php` to include it so the Content workspace exposes tabs for `Generated Posts`, `Drafts / Review Queue`, `Partial Generations`, `History`, and `Failed Runs` (History/Failed Runs link to the hidden history route when appropriate).
- Adjust the history template `templates/admin/history.php` to render inside the consolidated Content workspace (it now sets `$active_content_tab` from `status`/`content_tab` query params) and include the shared tabs for consistent navigation.
- Make a small JS change in `assets/js/admin.js` (`switchAipsTab`) to allow tab-style links that do not include a `data-tab` attribute to navigate normally (guard early return when `data-tab` is missing), enabling the History/Failed Runs links to behave correctly.

### Testing
- Syntax checks were run with `php -l` for the modified files and returned no syntax errors for `ai-post-scheduler/includes/class-aips-admin-menu.php`, `ai-post-scheduler/templates/admin/content.php`, `ai-post-scheduler/templates/admin/content-tabs.php`, and `ai-post-scheduler/templates/admin/history.php`.
- `composer test` was attempted from `ai-post-scheduler/` but the automated WordPress test setup failed during `test:setup` because `svn` could not reach `https://develop.svn.wordpress.org` in this environment (network unreachable), so the PHPUnit suite could not complete.
- All changes are focused on admin rendering and tab navigation and were exercised via static checks and local file validation in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ef7de9000832195b80c73840d8838)