### PR TITLE
🎨 Palette: Add type='button' to calendar controls to prevent accidental submissions

### DIFF
--- a/ai-post-scheduler/.build/palette.md
+++ b/ai-post-scheduler/.build/palette.md
@@ -1,0 +1,6 @@
+## 2026-06-05 - Prevent Accidental Calendar Submissions
+**Area:** templates/admin/calendar.php
+**Status:** opened PR
+**PR:** 🎨 Palette: Add type='button' to calendar controls to prevent accidental submissions
+**Learning:** Calendar UI buttons without explicit types default to `submit`, causing unexpected reloads if placed in forms.
+**Action:** Always explicitly define `type="button"` on JS-driven interactive UI controls.

--- a/ai-post-scheduler/templates/admin/calendar.php
+++ b/ai-post-scheduler/templates/admin/calendar.php
@@ -33,31 +33,31 @@ if (!defined('ABSPATH')) {
 				<!-- Calendar Header with Navigation -->
 				<div class="aips-calendar-header">
 					<div class="aips-calendar-nav">
-						<button class="aips-btn aips-btn-sm aips-btn-secondary aips-calendar-prev" title="<?php esc_attr_e('Previous Month', 'ai-post-scheduler'); ?>">
+						<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-calendar-prev" title="<?php esc_attr_e('Previous Month', 'ai-post-scheduler'); ?>">
 							<span class="dashicons dashicons-arrow-left-alt2"></span>
 						</button>
 						<h2 class="aips-calendar-title">
 							<span class="aips-calendar-month-year"></span>
 						</h2>
-						<button class="aips-btn aips-btn-sm aips-btn-secondary aips-calendar-next" title="<?php esc_attr_e('Next Month', 'ai-post-scheduler'); ?>">
+						<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-calendar-next" title="<?php esc_attr_e('Next Month', 'ai-post-scheduler'); ?>">
 							<span class="dashicons dashicons-arrow-right-alt2"></span>
 						</button>
 					</div>
 					
 					<div class="aips-calendar-view-switcher">
-						<button class="aips-btn aips-btn-sm aips-calendar-view-btn active" data-view="month">
+						<button type="button" class="aips-btn aips-btn-sm aips-calendar-view-btn active" data-view="month">
 							<?php esc_html_e('Month', 'ai-post-scheduler'); ?>
 						</button>
-						<button class="aips-btn aips-btn-sm aips-calendar-view-btn" data-view="week">
+						<button type="button" class="aips-btn aips-btn-sm aips-calendar-view-btn" data-view="week">
 							<?php esc_html_e('Week', 'ai-post-scheduler'); ?>
 						</button>
-						<button class="aips-btn aips-btn-sm aips-calendar-view-btn" data-view="day">
+						<button type="button" class="aips-btn aips-btn-sm aips-calendar-view-btn" data-view="day">
 							<?php esc_html_e('Day', 'ai-post-scheduler'); ?>
 						</button>
 					</div>
 					
 					<div class="aips-calendar-today">
-						<button class="aips-btn aips-btn-secondary aips-calendar-today-btn">
+						<button type="button" class="aips-btn aips-btn-secondary aips-calendar-today-btn">
 							<?php esc_html_e('Today', 'ai-post-scheduler'); ?>
 						</button>
 					</div>


### PR DESCRIPTION
**What:**
Added explicit `type="button"` attributes to the navigational and view-switching buttons in the calendar admin template (`ai-post-scheduler/templates/admin/calendar.php`).

**Why:**
By default, HTML `<button>` elements act as form submit buttons. If these JS-driven interactive UI elements ever end up inside or near a `<form>` block in the admin area, they could trigger unintended full-page reloads and form submissions. Explicitly setting the type ensures they always behave safely.

**Accessibility/Semantics:**
Improves HTML semantics by ensuring elements only trigger form submissions when intended, leading to a more robust structure.

**Verification:**
1. Navigate to the Schedule Calendar in the WP Admin.
2. Click the Month/Week/Day tabs and Prev/Next buttons.
3. Confirm they function normally via AJAX/JS without reloading the page or causing form submissions.

---
*PR created automatically by Jules for task [3837928023791431415](https://jules.google.com/task/3837928023791431415) started by @rpnunez*