### PR TITLE
🎨 Palette: Add missing aria attributes to taxonomy and campaign wizard

### DIFF
--- a/.build/palette.md
+++ b/.build/palette.md
@@ -4,3 +4,8 @@
 ## 2026-05-30 - Added loading indicator when editing authors
 **Learning:** AJAX-driven edit modals within this repo can sometimes appear with empty fields while data is still loading, creating a confusing user experience. The standard pattern to solve this is to use the existing WordPress admin `.spinner` element within a loader container.
 **Action:** For future modal-based edit features, ensure a loader container is added alongside the form, and use JavaScript to hide the form and show the loader during the AJAX fetch phase. Only reveal the form when the data has successfully populated.
+## 2026-06-06 - Add missing aria attributes to taxonomy and campaign wizard
+**Area:** taxonomy.php and campaign-wizard.php
+**Status:** opened PR
+**PR:** TBD
+**Action:** Always audit close buttons for aria-label and decorative icons for aria-hidden.

--- a/ai-post-scheduler/templates/admin/campaign-wizard.php
+++ b/ai-post-scheduler/templates/admin/campaign-wizard.php
@@ -19,7 +19,7 @@ $authors = get_users(array(
 					<p class="aips-page-description"><?php esc_html_e('Build a campaign template, publishing defaults, review policy, and schedule in one flow.', 'ai-post-scheduler'); ?></p>
 				</div>
 				<a class="aips-btn aips-btn-secondary" href="<?php echo esc_url(AIPS_Admin_Menu_Helper::get_page_url('schedule')); ?>">
-					<span class="dashicons dashicons-calendar-alt"></span>
+					<span class="dashicons dashicons-calendar-alt" aria-hidden="true"></span>
 					<?php esc_html_e('Schedules', 'ai-post-scheduler'); ?>
 				</a>
 			</div>
@@ -216,7 +216,7 @@ $authors = get_users(array(
 										</div>
 										<div style="padding-top: 20px;">
 											<button type="button" class="button button-small aips-remove-post-type-rule" title="<?php esc_attr_e('Remove', 'ai-post-scheduler'); ?>">
-												<span class="dashicons dashicons-no-alt" style="margin-top: 2px;"></span>
+												<span class="dashicons dashicons-no-alt" aria-hidden="true" style="margin-top: 2px;"></span>
 											</button>
 										</div>
 									</div>
@@ -227,7 +227,7 @@ $authors = get_users(array(
 						?>
 					</div>
 					<button type="button" id="aips-add-post-type-rule" class="button" style="margin-top: 10px;">
-						<span class="dashicons dashicons-plus-alt2" style="margin-top: 2px;"></span> <?php esc_html_e('Add Post Type Rule', 'ai-post-scheduler'); ?>
+						<span class="dashicons dashicons-plus-alt2" aria-hidden="true" style="margin-top: 2px;"></span> <?php esc_html_e('Add Post Type Rule', 'ai-post-scheduler'); ?>
 					</button>
 				</section>
 

--- a/ai-post-scheduler/templates/admin/taxonomy.php
+++ b/ai-post-scheduler/templates/admin/taxonomy.php
@@ -226,6 +226,6 @@ $total_items = $status_counts['categories']['pending'] + $status_counts['categor
 <script type="text/html" id="aips-tmpl-selected-post">
 <div class="aips-selected-post" data-post-id="{{id}}">
 	<span>{{title}}</span>
-	<button type="button" class="aips-remove-post" data-post-id="{{id}}">&times;</button>
+	<button type="button" class="aips-remove-post" data-post-id="{{id}}" aria-label="<?php esc_attr_e('Remove post', 'ai-post-scheduler'); ?>">&times;</button>
 </div>
 </script>


### PR DESCRIPTION
**What:** Added missing `aria-label` and `aria-hidden` attributes to UI elements.
**Why:** To improve accessibility for screen readers interacting with modal close buttons and decorative icons.
**Accessibility:** Prevents screen readers from announcing confusing icon characters and provides context to the `&times;` close button.
**Verification:** Tested visually with code diffs, passed PHP linting, and confirmed in `composer test`.
**Before/After:** Modified `ai-post-scheduler/templates/admin/taxonomy.php` and `ai-post-scheduler/templates/admin/campaign-wizard.php`.

---
*PR created automatically by Jules for task [17425764634431288768](https://jules.google.com/task/17425764634431288768) started by @rpnunez*