### PR TITLE
⚡ Bolt: Optimize Generated Posts page load by hoisting options and pre-fetching post caches

### DIFF
--- a/.build/bolt.md
+++ b/.build/bolt.md
@@ -26,3 +26,9 @@
 ## 2026-03-24 - [Optimize Dashboard History Retrieval]
 **Learning:** Replacing `SELECT *` with hardcoded columns in a core repository method (like `get_history`) as a default fallback is an anti-pattern in this architecture. It creates high regression risks by starving callers of expected data (like `longtext` fields) and breaks forward compatibility when new columns are added. The safest performance optimization is to update the call sites (like list views or dashboard widgets) to explicitly request a lighter payload (e.g. `fields => 'list'`) when heavy data is unnecessary.
 **Action:** When optimizing database queries, prefer passing explicit optimization parameters from the caller rather than blindly altering default fallback behaviors in the underlying repository.
+## 2026-06-06 - [Generated Posts list optimization]
+**Area:** class-aips-generated-posts-controller.php
+**Status:** opened PR
+**PR:** ⚡ Bolt: Optimize Generated Posts page load by hoisting options and pre-fetching post caches
+**Learning:** Hoisting repetitive `get_option` calls out of loops and bulk-priming post caches with `_prime_post_caches` significantly reduces redundant database queries and function overhead on list views.
+**Action:** Always identify loops making single item queries and apply hoisting and bulk-fetching where applicable.

--- a/ai-post-scheduler/includes/class-aips-generated-posts-controller.php
+++ b/ai-post-scheduler/includes/class-aips-generated-posts-controller.php
@@ -90,6 +90,22 @@ class AIPS_Generated_Posts_Controller {
 			'fields' => 'list', // Explicitly use lightweight list fields for UI listing
 		));
 		
+		// Hoist date format to prevent redundant DB calls inside loops
+		$datetime_format = get_option('date_format') . ' ' . get_option('time_format');
+
+		// Pre-fetch post caches to prevent N+1 queries in loops below
+		if (function_exists('_prime_post_caches')) {
+			$post_ids_to_prime = array();
+			foreach ($history['items'] as $item) {
+				if (!empty($item->post_id)) {
+					$post_ids_to_prime[] = $item->post_id;
+				}
+			}
+			if (!empty($post_ids_to_prime)) {
+				_prime_post_caches(array_unique($post_ids_to_prime), false, true);
+			}
+		}
+
 		// Get schedule data for each post
 		$posts_data = array();
 		foreach ($history['items'] as $item) {
@@ -120,9 +136,9 @@ class AIPS_Generated_Posts_Controller {
 				'history_id' => $item->id,
 				'post_id' => $item->post_id,
 				'title' => $post->post_title,
-				'date_generated' => AIPS_DateTime::formatRelativeOrAbsolute($item->created_at, get_option('date_format') . ' ' . get_option('time_format')),
-				'date_published' => AIPS_DateTime::formatRelativeOrAbsolute($published_timestamp, get_option('date_format') . ' ' . get_option('time_format')),
-				'date_scheduled' => AIPS_DateTime::formatRelativeOrAbsolute($schedule ? $schedule->next_run : null, get_option('date_format') . ' ' . get_option('time_format')),
+				'date_generated' => AIPS_DateTime::formatRelativeOrAbsolute($item->created_at, $datetime_format),
+				'date_published' => AIPS_DateTime::formatRelativeOrAbsolute($published_timestamp, $datetime_format),
+				'date_scheduled' => AIPS_DateTime::formatRelativeOrAbsolute($schedule ? $schedule->next_run : null, $datetime_format),
 				'edit_link' => esc_url_raw(get_edit_post_link($item->post_id)),
 				'source' => $source,
 			);
@@ -138,7 +154,7 @@ class AIPS_Generated_Posts_Controller {
 		// Pre-format dates for draft posts
 		if (!empty($draft_posts['items'])) {
 			foreach ($draft_posts['items'] as $item) {
-				$item->created_at_formatted = AIPS_DateTime::formatRelativeOrAbsolute($item->created_at, get_option('date_format') . ' ' . get_option('time_format'));
+				$item->created_at_formatted = AIPS_DateTime::formatRelativeOrAbsolute($item->created_at, $datetime_format);
 			}
 		}
 
@@ -149,6 +165,19 @@ class AIPS_Generated_Posts_Controller {
 			'author_id' => $author_id,
 			'template_id' => $template_id,
 		));
+
+		// Pre-fetch post caches for partial generations to prevent N+1 queries
+		if (function_exists('_prime_post_caches')) {
+			$partial_post_ids_to_prime = array();
+			foreach ($partial_generations['items'] as $item) {
+				if (!empty($item->post_id)) {
+					$partial_post_ids_to_prime[] = $item->post_id;
+				}
+			}
+			if (!empty($partial_post_ids_to_prime)) {
+				_prime_post_caches(array_unique($partial_post_ids_to_prime), false, true);
+			}
+		}
 
 		$partial_posts_data = array();
 		foreach ($partial_generations['items'] as $item) {
@@ -165,8 +194,8 @@ class AIPS_Generated_Posts_Controller {
 				'history_id' => $item->id,
 				'post_id' => $item->post_id,
 				'title' => $post->post_title,
-			'date_generated' => AIPS_DateTime::formatRelativeOrAbsolute($item->created_at, get_option('date_format') . ' ' . get_option('time_format')),
-			'date_updated' => AIPS_DateTime::formatRelativeOrAbsolute($item->post_modified, get_option('date_format') . ' ' . get_option('time_format')),
+			'date_generated' => AIPS_DateTime::formatRelativeOrAbsolute($item->created_at, $datetime_format),
+			'date_updated' => AIPS_DateTime::formatRelativeOrAbsolute($item->post_modified, $datetime_format),
 				'edit_link' => esc_url_raw(get_edit_post_link($item->post_id)),
 				'post_status' => $item->post_status,
 				'is_currently_incomplete' => ('true' === (string) $item->is_currently_incomplete),


### PR DESCRIPTION
**What:**
Hoisted redundant `get_option('date_format')` and `get_option('time_format')` calls out of loops in `AIPS_Generated_Posts_Controller::render_page`. Implemented bulk post cache priming using `_prime_post_caches()` before iterating over history entries and partial generations.

**Why:**
To eliminate N+1 database queries triggered by single `get_post()` calls inside the loops, and to reduce overhead from repetitive WordPress options API calls during string concatenation. This bottleneck affects the Generated Posts admin interface, especially on large installations.

**Impact:**
Noticeable reduction in database queries and improved response time for the Generated Posts admin page.

**Measurement:**
Compare query count on the "Generated Posts" admin page before and after the change using Query Monitor or similar tools. Query counts related to `wp_posts` lookups will drop significantly.

---
*PR created automatically by Jules for task [8618852466756871841](https://jules.google.com/task/8618852466756871841) started by @rpnunez*