### PR TITLE
⚡ Bolt: Batch date format lookups in Generated Posts controller

### DIFF
--- a/ai-post-scheduler/.build/bolt.md
+++ b/ai-post-scheduler/.build/bolt.md
@@ -1,0 +1,6 @@
+## 2026-06-07 - Optimize Generated Posts formatting overhead
+**Area:** includes/class-aips-generated-posts-controller.php
+**Status:** opened PR
+**PR:** [pending]
+**Learning:** Repeated get_option calls in loops to fetch date and time formats are unnecessary and should be cached in a variable beforehand, especially in list/listing endpoints.
+**Action:** Always extract get_option calls for format strings (and other constants) outside of iterating loops to minimize function overhead and database/object cache interactions.

--- a/ai-post-scheduler/includes/class-aips-generated-posts-controller.php
+++ b/ai-post-scheduler/includes/class-aips-generated-posts-controller.php
@@ -92,6 +92,9 @@ class AIPS_Generated_Posts_Controller {
 		
 		// Get schedule data for each post
 		$posts_data = array();
+
+		$format = get_option('date_format') . ' ' . get_option('time_format');
+
 		foreach ($history['items'] as $item) {
 			if (!$item->post_id) {
 				continue;
@@ -120,9 +123,9 @@ class AIPS_Generated_Posts_Controller {
 				'history_id' => $item->id,
 				'post_id' => $item->post_id,
 				'title' => $post->post_title,
-				'date_generated' => AIPS_DateTime::formatRelativeOrAbsolute($item->created_at, get_option('date_format') . ' ' . get_option('time_format')),
-				'date_published' => AIPS_DateTime::formatRelativeOrAbsolute($published_timestamp, get_option('date_format') . ' ' . get_option('time_format')),
-				'date_scheduled' => AIPS_DateTime::formatRelativeOrAbsolute($schedule ? $schedule->next_run : null, get_option('date_format') . ' ' . get_option('time_format')),
+				'date_generated' => AIPS_DateTime::formatRelativeOrAbsolute($item->created_at, $format),
+				'date_published' => AIPS_DateTime::formatRelativeOrAbsolute($published_timestamp, $format),
+				'date_scheduled' => AIPS_DateTime::formatRelativeOrAbsolute($schedule ? $schedule->next_run : null, $format),
 				'edit_link' => esc_url_raw(get_edit_post_link($item->post_id)),
 				'source' => $source,
 			);
@@ -138,7 +141,7 @@ class AIPS_Generated_Posts_Controller {
 		// Pre-format dates for draft posts
 		if (!empty($draft_posts['items'])) {
 			foreach ($draft_posts['items'] as $item) {
-				$item->created_at_formatted = AIPS_DateTime::formatRelativeOrAbsolute($item->created_at, get_option('date_format') . ' ' . get_option('time_format'));
+				$item->created_at_formatted = AIPS_DateTime::formatRelativeOrAbsolute($item->created_at, $format);
 			}
 		}
 
@@ -165,8 +168,8 @@ class AIPS_Generated_Posts_Controller {
 				'history_id' => $item->id,
 				'post_id' => $item->post_id,
 				'title' => $post->post_title,
-			'date_generated' => AIPS_DateTime::formatRelativeOrAbsolute($item->created_at, get_option('date_format') . ' ' . get_option('time_format')),
-			'date_updated' => AIPS_DateTime::formatRelativeOrAbsolute($item->post_modified, get_option('date_format') . ' ' . get_option('time_format')),
+				'date_generated' => AIPS_DateTime::formatRelativeOrAbsolute($item->created_at, $format),
+				'date_updated' => AIPS_DateTime::formatRelativeOrAbsolute($item->post_modified, $format),
 				'edit_link' => esc_url_raw(get_edit_post_link($item->post_id)),
 				'post_status' => $item->post_status,
 				'is_currently_incomplete' => ('true' === (string) $item->is_currently_incomplete),


### PR DESCRIPTION
**What:** Extracted `get_option('date_format')` and `get_option('time_format')` lookups outside of loops in `AIPS_Generated_Posts_Controller`.
**Why:** The loops iterating over generated posts, drafts, and partial generations were making repeated database/object cache queries for standard date format options, resulting in unnecessary function overhead.
**Impact:** Eliminates $N$ redundant `get_option()` calls where $N$ is the number of posts in the table, slightly reducing PHP execution time and memory allocations on the Generated Posts page.
**Measurement:** The controller will now call `get_option` exactly twice per request rather than hundreds of times for large generation batches. This can be verified using Query Monitor or standard profiling tools.

---
*PR created automatically by Jules for task [11517309992052123378](https://jules.google.com/task/11517309992052123378) started by @rpnunez*