### PR TITLE
Restore Automations tab header actions

### DIFF
--- a/ai-post-scheduler/includes/class-aips-automations-controller.php
+++ b/ai-post-scheduler/includes/class-aips-automations-controller.php
@@ -39,6 +39,7 @@ class AIPS_Automations_Controller {
 
 		$active_tab = self::get_active_tab_key();
 		$tabs = $this->get_tabs($active_tab);
+		$tab_actions = $this->get_tab_actions($active_tab);
 		$automations_controller = $this;
 
 		include AIPS_PLUGIN_DIR . 'templates/admin/automations.php';
@@ -89,6 +90,175 @@ class AIPS_Automations_Controller {
 		}
 
 		return $tabs;
+	}
+
+
+	/**
+	 * Get header actions for the active Automations tab.
+	 *
+	 * These mirror the primary actions from the standalone pages because the
+	 * embedded tab templates intentionally suppress their own page headers.
+	 *
+	 * @param string $active_tab Active tab key.
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function get_tab_actions($active_tab) {
+		switch ($active_tab) {
+			case 'campaigns':
+				return array(
+					array(
+						'type'  => 'link',
+						'url'   => admin_url('admin.php?page=' . AIPS_Campaigns_Controller::PAGE_SLUG),
+						'class' => 'aips-btn aips-btn-primary',
+						'icon'  => 'dashicons-plus-alt',
+						'label' => __('Add New Campaign', 'ai-post-scheduler'),
+					),
+				);
+			case 'templates':
+				return array(
+					array(
+						'type'  => 'button',
+						'class' => 'aips-btn aips-btn-primary aips-add-template-btn',
+						'icon'  => 'dashicons-plus-alt',
+						'label' => __('Add Template', 'ai-post-scheduler'),
+					),
+				);
+			case 'authors':
+				return array(
+					array(
+						'type'  => 'button',
+						'id'    => 'aips-suggest-authors-btn',
+						'class' => 'aips-btn aips-btn-secondary',
+						'icon'  => 'dashicons-lightbulb',
+						'label' => __('Suggest Authors', 'ai-post-scheduler'),
+					),
+					array(
+						'type'  => 'button',
+						'class' => 'aips-btn aips-btn-primary aips-add-author-btn',
+						'icon'  => 'dashicons-plus-alt',
+						'label' => __('Add Author', 'ai-post-scheduler'),
+					),
+				);
+			case 'sources':
+				return array(
+					array(
+						'type'  => 'button',
+						'id'    => 'aips-manage-source-groups-btn',
+						'class' => 'aips-btn aips-btn-secondary',
+						'icon'  => 'dashicons-category',
+						'label' => __('Manage Groups', 'ai-post-scheduler'),
+					),
+					array(
+						'type'  => 'button',
+						'id'    => 'aips-add-source-btn',
+						'class' => 'aips-btn aips-btn-primary',
+						'icon'  => 'dashicons-plus-alt2',
+						'label' => __('Add Source', 'ai-post-scheduler'),
+					),
+				);
+			case 'internal-links':
+				return array(
+					array(
+						'type'  => 'button',
+						'id'    => 'aips-start-indexing-btn',
+						'class' => 'aips-btn aips-btn-secondary',
+						'icon'  => 'dashicons-database-import',
+						'label' => __('Index Posts', 'ai-post-scheduler'),
+					),
+					array(
+						'type'  => 'button',
+						'id'    => 'aips-clear-index-btn',
+						'class' => 'aips-btn aips-btn-ghost aips-btn-danger',
+						'icon'  => 'dashicons-trash',
+						'label' => __('Clear Index', 'ai-post-scheduler'),
+					),
+				);
+			case 'taxonomy':
+				return array(
+					array(
+						'type'  => 'button',
+						'id'    => 'aips-open-generate-modal',
+						'class' => 'aips-btn aips-btn-primary aips-generate-taxonomy',
+						'icon'  => 'dashicons-update',
+						'label' => __('Generate Taxonomy', 'ai-post-scheduler'),
+					),
+				);
+			case self::TAB_AUTHOR_TOPICS:
+				return $this->get_author_topics_tab_actions();
+			case 'schedules':
+			default:
+				return $this->get_schedule_tab_actions();
+		}
+	}
+
+	/**
+	 * Get header actions for the schedules tab.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function get_schedule_tab_actions() {
+		$templates_handler = new AIPS_Templates();
+		$templates = $templates_handler->get_all(true);
+
+		if (!empty($templates)) {
+			return array(
+				array(
+					'type'  => 'button',
+					'class' => 'aips-btn aips-btn-primary aips-add-schedule-btn',
+					'icon'  => 'dashicons-plus-alt',
+					'label' => __('Add Template Schedule', 'ai-post-scheduler'),
+				),
+			);
+		}
+
+		return array(
+			array(
+				'type'  => 'link',
+				'url'   => AIPS_Admin_Menu_Helper::get_page_url('templates'),
+				'class' => 'aips-btn aips-btn-secondary',
+				'icon'  => 'dashicons-media-document',
+				'label' => __('Create Template First', 'ai-post-scheduler'),
+			),
+		);
+	}
+
+	/**
+	 * Get header actions for the Author Topics tab.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function get_author_topics_tab_actions() {
+		$author_id = self::get_request_author_id();
+
+		if ($author_id <= 0) {
+			return array();
+		}
+
+		return array(
+			array(
+				'type'  => 'link',
+				'url'   => AIPS_Admin_Menu_Helper::get_page_url('authors'),
+				'class' => 'aips-btn aips-btn-secondary',
+				'icon'  => 'dashicons-edit',
+				'label' => __('Edit Author', 'ai-post-scheduler'),
+			),
+			array(
+				'type'       => 'button',
+				'class'      => 'aips-btn aips-btn-primary aips-generate-topics-now',
+				'icon'       => 'dashicons-update',
+				'label'      => __('Generate Topics', 'ai-post-scheduler'),
+				'data_attrs' => array(
+					'id' => $author_id,
+				),
+			),
+			array(
+				'type'  => 'link',
+				'url'   => add_query_arg(array('page' => 'aips-generated-posts', 'author_id' => $author_id), admin_url('admin.php')),
+				'class' => 'aips-btn aips-btn-secondary',
+				'icon'  => 'dashicons-admin-post',
+				'label' => __('View Generated Posts', 'ai-post-scheduler'),
+			),
+		);
 	}
 
 	/**

--- a/ai-post-scheduler/includes/class-aips-automations-controller.php
+++ b/ai-post-scheduler/includes/class-aips-automations-controller.php
@@ -108,7 +108,7 @@ class AIPS_Automations_Controller {
 				return array(
 					array(
 						'type'  => 'link',
-						'url'   => admin_url('admin.php?page=' . AIPS_Campaigns_Controller::PAGE_SLUG),
+						'url'   => AIPS_Admin_Menu_Helper::get_page_url('campaign_wizard'),
 						'class' => 'aips-btn aips-btn-primary',
 						'icon'  => 'dashicons-plus-alt',
 						'label' => __('Add New Campaign', 'ai-post-scheduler'),
@@ -237,7 +237,7 @@ class AIPS_Automations_Controller {
 		return array(
 			array(
 				'type'  => 'link',
-				'url'   => AIPS_Admin_Menu_Helper::get_page_url('authors'),
+				'url'   => AIPS_Admin_Menu_Helper::get_page_url('authors', array('author_id' => $author_id)),
 				'class' => 'aips-btn aips-btn-secondary',
 				'icon'  => 'dashicons-edit',
 				'label' => __('Edit Author', 'ai-post-scheduler'),
@@ -253,11 +253,11 @@ class AIPS_Automations_Controller {
 			),
 			array(
 				'type'  => 'link',
-				'url'   => add_query_arg(array('page' => 'aips-generated-posts', 'author_id' => $author_id), admin_url('admin.php')),
+				'url'   => AIPS_Admin_Menu_Helper::get_page_url('generated_posts', array('author_id' => $author_id)),
 				'class' => 'aips-btn aips-btn-secondary',
 				'icon'  => 'dashicons-admin-post',
 				'label' => __('View Generated Posts', 'ai-post-scheduler'),
-			),
+			)
 		);
 	}
 

--- a/ai-post-scheduler/templates/admin/automations.php
+++ b/ai-post-scheduler/templates/admin/automations.php
@@ -17,6 +17,39 @@ if (!defined('ABSPATH')) {
 					<h1 class="aips-page-title"><?php esc_html_e('Automations', 'ai-post-scheduler'); ?></h1>
 					<p class="aips-page-description"><?php esc_html_e('Manage schedules, campaigns, templates, authors, sources, internal links, and taxonomy from one place.', 'ai-post-scheduler'); ?></p>
 				</div>
+				<?php if (!empty($tab_actions)) : ?>
+					<div class="aips-page-actions">
+						<?php foreach ($tab_actions as $tab_action) : ?>
+							<?php
+							$action_type = isset($tab_action['type']) ? $tab_action['type'] : 'button';
+							$action_class = isset($tab_action['class']) ? $tab_action['class'] : 'aips-btn aips-btn-secondary';
+							$action_icon = isset($tab_action['icon']) ? $tab_action['icon'] : '';
+							$action_id = isset($tab_action['id']) ? $tab_action['id'] : '';
+							$action_label = isset($tab_action['label']) ? $tab_action['label'] : '';
+							$data_attrs = isset($tab_action['data_attrs']) && is_array($tab_action['data_attrs']) ? $tab_action['data_attrs'] : array();
+							$data_attr_html = '';
+							foreach ($data_attrs as $data_key => $data_value) {
+								$data_attr_html .= ' data-' . esc_attr(sanitize_key($data_key)) . '="' . esc_attr($data_value) . '"';
+							}
+							?>
+							<?php if ('link' === $action_type && !empty($tab_action['url'])) : ?>
+								<a href="<?php echo esc_url($tab_action['url']); ?>" class="<?php echo esc_attr($action_class); ?>"<?php echo $action_id ? ' id="' . esc_attr($action_id) . '"' : ''; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?><?php echo $data_attr_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
+									<?php if ($action_icon) : ?>
+										<span class="dashicons <?php echo esc_attr($action_icon); ?>"></span>
+									<?php endif; ?>
+									<?php echo esc_html($action_label); ?>
+								</a>
+							<?php else : ?>
+								<button type="button" class="<?php echo esc_attr($action_class); ?>"<?php echo $action_id ? ' id="' . esc_attr($action_id) . '"' : ''; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?><?php echo $data_attr_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
+									<?php if ($action_icon) : ?>
+										<span class="dashicons <?php echo esc_attr($action_icon); ?>"></span>
+									<?php endif; ?>
+									<?php echo esc_html($action_label); ?>
+								</button>
+							<?php endif; ?>
+						<?php endforeach; ?>
+					</div>
+				<?php endif; ?>
 			</div>
 		</div>
 


### PR DESCRIPTION
### Motivation
- The new Automations page rendered embedded tab content without the per-page header actions, which removed top-right controls like the Sources “Manage Groups” / “Add Source” button; the change restores those missing header actions so embedded tabs retain their primary controls.

### Description
- Added `AIPS_Automations_Controller::get_tab_actions()` plus helpers (`get_schedule_tab_actions()`, `get_author_topics_tab_actions()`) to compute the per-tab header actions based on the active tab and site state (e.g., whether templates exist).
- Restored actions for `schedules`, `campaigns`, `templates`, `authors`, `sources`, `internal-links`, `taxonomy`, and `author-topics`, including IDs and classes that match existing JS listeners (e.g. `#aips-manage-source-groups-btn`, `#aips-add-source-btn`, `#aips-start-indexing-btn`).
- Updated the Automations template to render the computed actions in the top-right header with safe escaping and optional data attributes; relevant files changed: `ai-post-scheduler/includes/class-aips-automations-controller.php` and `ai-post-scheduler/templates/admin/automations.php`.

### Testing
- Ran PHP syntax checks with `php -l` on `ai-post-scheduler/includes/class-aips-automations-controller.php` and `ai-post-scheduler/templates/admin/automations.php`, and both returned no syntax errors (success).
- Ran `composer test` which attempted to set up the WordPress test library but the suite failed during test setup because SVN access to `develop.svn.wordpress.org` was unreachable from the environment (environment/network limitation), so full PHPUnit suite could not be executed here (setup failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25c6a67868832197bb51594acecda0)