### PR TITLE
UI/schedules stats section

### DIFF
--- a/ai-post-scheduler/ai-post-scheduler.php
+++ b/ai-post-scheduler/ai-post-scheduler.php
@@ -3,7 +3,7 @@
  * Plugin Name: AI Post Scheduler
  * Plugin URI: https://nunezserver.com/nunezscheduler
  * Description: Schedule AI-generated posts using advanced features & scheduling options.
- * Version: 2.9.1
+ * Version: 2.9.2
  * Author: Raymond Nunez
  * Author URI: https://nunezserver.com
  * License: GPL v2 or later
@@ -44,7 +44,7 @@ if (!defined('AIPS_TELEMETRY_QUERY_SAMPLE_LIMIT')) {
 
 // Define plugin constants
 if (!defined('AIPS_VERSION')) {
-    define('AIPS_VERSION', '2.9.1');
+    define('AIPS_VERSION', '2.9.2');
 }
 
 if (!defined('AIPS_PLUGIN_DIR')) {

--- a/ai-post-scheduler/assets/css/admin.css
+++ b/ai-post-scheduler/assets/css/admin.css
@@ -223,16 +223,42 @@
 
 .aips-schedule-status-summary-cards {
     display: grid;
-    grid-template-columns: repeat(4, minmax(140px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
     gap: var(--aips-space-3);
 }
 
 .aips-schedule-status-card {
     border: 1px solid var(--aips-gray-200);
+    border-left: 4px solid var(--aips-gray-300);
     border-radius: var(--aips-radius-md);
     background: var(--aips-white);
     padding: var(--aips-space-3) var(--aips-space-4);
     box-shadow: var(--aips-shadow-sm);
+    transition: all var(--aips-transition-base);
+}
+
+.aips-schedule-status-card:hover {
+    box-shadow: var(--aips-shadow-md);
+    transform: translateY(-2px);
+}
+
+.aips-schedule-status-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--aips-space-2);
+}
+
+.aips-schedule-status-card-icon {
+    color: var(--aips-gray-400);
+    font-size: 20px;
+    width: 20px;
+    height: 20px;
+    transition: transform var(--aips-transition-base);
+}
+
+.aips-schedule-status-card:hover .aips-schedule-status-card-icon {
+    transform: scale(1.1);
 }
 
 .aips-schedule-status-card-label {
@@ -251,16 +277,142 @@
     color: var(--aips-gray-900);
 }
 
-.aips-schedule-status-card-success .aips-schedule-status-card-value {
-    color: var(--aips-success-700);
+/* Beautiful color tones for cards */
+.aips-schedule-status-card-info {
+    border-left-color: var(--aips-info);
+    background: linear-gradient(135deg, var(--aips-white) 0%, rgba(34, 113, 177, 0.02) 100%);
 }
-
+.aips-schedule-status-card-info .aips-schedule-status-card-icon {
+    color: var(--aips-info);
+}
 .aips-schedule-status-card-info .aips-schedule-status-card-value {
-    color: var(--aips-info-700);
+    color: var(--aips-info-dark);
 }
 
+.aips-schedule-status-card-success {
+    border-left-color: var(--aips-success);
+    background: linear-gradient(135deg, var(--aips-white) 0%, rgba(0, 163, 42, 0.02) 100%);
+}
+.aips-schedule-status-card-success .aips-schedule-status-card-icon {
+    color: var(--aips-success);
+}
+.aips-schedule-status-card-success .aips-schedule-status-card-value {
+    color: var(--aips-success-dark);
+}
+
+.aips-schedule-status-card-warning {
+    border-left-color: var(--aips-warning);
+    background: linear-gradient(135deg, var(--aips-white) 0%, rgba(219, 166, 23, 0.02) 100%);
+}
+.aips-schedule-status-card-warning .aips-schedule-status-card-icon {
+    color: var(--aips-warning);
+}
+.aips-schedule-status-card-warning .aips-schedule-status-card-value {
+    color: var(--aips-warning-dark);
+}
+
+.aips-schedule-status-card-error {
+    border-left-color: var(--aips-error);
+    background: linear-gradient(135deg, var(--aips-white) 0%, rgba(214, 54, 56, 0.02) 100%);
+}
+.aips-schedule-status-card-error .aips-schedule-status-card-icon {
+    color: var(--aips-error);
+}
 .aips-schedule-status-card-error .aips-schedule-status-card-value {
-    color: var(--aips-error-700);
+    color: var(--aips-error-dark);
+}
+
+.aips-schedule-status-card-neutral {
+    border-left-color: var(--aips-gray-400);
+    background: linear-gradient(135deg, var(--aips-white) 0%, rgba(100, 105, 112, 0.02) 100%);
+}
+.aips-schedule-status-card-neutral .aips-schedule-status-card-icon {
+    color: var(--aips-gray-500);
+}
+.aips-schedule-status-card-neutral .aips-schedule-status-card-value {
+    color: var(--aips-gray-700);
+}
+
+/* Redesigned Overdue Warning Banner */
+.aips-overdue-banner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: linear-gradient(135deg, var(--aips-warning-light) 0%, rgba(219, 166, 23, 0.03) 100%);
+    border: 1px solid var(--aips-warning);
+    border-radius: var(--aips-radius-md);
+    padding: var(--aips-space-4) var(--aips-space-5);
+    margin-bottom: var(--aips-space-4);
+    box-shadow: var(--aips-shadow-sm);
+    gap: var(--aips-space-4);
+    flex-wrap: wrap;
+}
+
+.aips-overdue-banner-left {
+    display: flex;
+    align-items: center;
+    gap: var(--aips-space-3);
+    min-width: 280px;
+    flex: 1;
+}
+
+.aips-overdue-icon {
+    font-size: 32px;
+    width: 32px;
+    height: 32px;
+    color: var(--aips-warning-dark);
+    line-height: 1;
+}
+
+.aips-overdue-text {
+    display: flex;
+    flex-direction: column;
+}
+
+.aips-overdue-title {
+    margin: 0;
+    font-size: var(--aips-text-base);
+    font-weight: var(--aips-font-semibold);
+    color: var(--aips-gray-900);
+}
+
+.aips-overdue-desc {
+    margin: 2px 0 0 0;
+    font-size: var(--aips-text-xs);
+    color: var(--aips-gray-600);
+}
+
+.aips-overdue-banner-right {
+    flex-shrink: 0;
+}
+
+.aips-btn-warning {
+    background: var(--aips-warning) !important;
+    color: var(--aips-gray-900) !important;
+    border: 1px solid var(--aips-warning-dark) !important;
+    font-weight: var(--aips-font-semibold) !important;
+    transition: all var(--aips-transition-base) !important;
+    padding: 6px 14px !important;
+    border-radius: var(--aips-radius-base) !important;
+    display: inline-flex !important;
+    align-items: center !important;
+    gap: 6px !important;
+    cursor: pointer;
+}
+
+.aips-btn-warning:hover,
+.aips-btn-warning:focus {
+    background: var(--aips-warning-dark) !important;
+    color: var(--aips-white) !important;
+    border-color: var(--aips-warning-dark) !important;
+    box-shadow: 0 0 0 2px rgba(219, 166, 23, 0.2) !important;
+}
+
+.aips-btn-warning .dashicons {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    line-height: 1;
 }
 
 .aips-schedule-status-columns {

--- a/ai-post-scheduler/assets/css/admin.css
+++ b/ai-post-scheduler/assets/css/admin.css
@@ -3854,11 +3854,11 @@
 
 .aips-tab-nav {
     display: flex;
-    gap: 10px;
-    margin: 20px 0 0;
+    gap: var(--aips-space-1);
+    margin: var(--aips-space-5) 0 0;
     padding: 0;
     list-style: none;
-    border-bottom: 1px solid #ccd0d4;
+    border-bottom: 1px solid var(--aips-gray-200);
 }
 
 .aips-tab-nav li {
@@ -3868,36 +3868,106 @@
 .aips-tab-nav a,
 .aips-tab-nav button {
     display: block;
-    padding: 12px 20px;
+    padding: 10px 20px;
     text-decoration: none;
-    font-size: 14px;
-    color: #50575e;
-    border-bottom: 2px solid transparent;
+    font-size: var(--aips-text-sm);
+    font-weight: var(--aips-font-medium);
+    color: var(--aips-gray-600);
+    border: 1px solid transparent;
+    border-bottom: none;
+    border-radius: var(--aips-radius-md) var(--aips-radius-md) 0 0;
+    margin-bottom: -1px;
     background: none;
     border-top: none;
     border-left: none;
     border-right: none;
     cursor: pointer;
-    transition: all 0.2s ease;
+    transition: all var(--aips-transition-base);
 }
 
 .aips-tab-nav a:hover,
 .aips-tab-nav button:hover {
-    color: #2271b1;
+    color: var(--aips-primary);
+    background: var(--aips-gray-50);
 }
 
 .aips-tab-nav a.active,
 .aips-tab-nav button.active {
-    color: #2271b1;
-    border-bottom-color: #2271b1;
+    color: var(--aips-primary);
+    background: var(--aips-white);
+    border: 1px solid var(--aips-gray-200) !important;
+    border-bottom-color: var(--aips-white) !important;
     font-weight: 600;
+    position: relative;
+    z-index: 2;
+    box-shadow: 0 -2px 4px rgba(0,0,0,0.02);
 }
 
 .aips-tab-nav a.aips-tab-link-special,
 .aips-tab-nav button.aips-tab-link-special {
     color: #5a4f9b;
     background: rgba(90, 79, 155, 0.08);
-    border-radius: 6px 6px 0 0;
+    border-radius: var(--aips-radius-md) var(--aips-radius-md) 0 0;
+}
+
+/* Page Tab Panel Container */
+.aips-page-tab-panel {
+    background: var(--aips-white);
+    border: 1px solid var(--aips-gray-200);
+    border-radius: 0 var(--aips-radius-lg) var(--aips-radius-lg) var(--aips-radius-lg);
+    box-shadow: var(--aips-shadow-sm);
+    padding: var(--aips-space-5);
+    margin-top: -1px;
+    position: relative;
+    z-index: 1;
+}
+
+/* Strip inner panel decorations when nested inside the Page Tab Panel */
+.aips-page-tab-panel .aips-content-panel {
+    border: none !important;
+    background: transparent !important;
+    box-shadow: none !important;
+    padding: 0 !important;
+    margin-bottom: var(--aips-space-5) !important;
+}
+
+.aips-page-tab-panel .aips-content-panel:last-child {
+    margin-bottom: 0 !important;
+}
+
+.aips-page-tab-panel .aips-content-panel .aips-panel-body {
+    padding: 0 !important;
+}
+
+/* Add a very clean border to the table filter bar when inside the panel */
+.aips-page-tab-panel .aips-content-panel .aips-filter-bar {
+    border: 1px solid var(--aips-gray-200) !important;
+    border-radius: var(--aips-radius-md) var(--aips-radius-md) 0 0 !important;
+}
+
+.aips-page-tab-panel .aips-content-panel .aips-panel-toolbar {
+    border-left: 1px solid var(--aips-gray-200) !important;
+    border-right: 1px solid var(--aips-gray-200) !important;
+    border-bottom: 1px solid var(--aips-gray-200) !important;
+}
+
+.aips-page-tab-panel .aips-content-panel .aips-table {
+    border-left: 1px solid var(--aips-gray-200) !important;
+    border-right: 1px solid var(--aips-gray-200) !important;
+}
+
+.aips-page-tab-panel .aips-content-panel .tablenav {
+    border: 1px solid var(--aips-gray-200) !important;
+    border-top: none !important;
+    border-radius: 0 0 var(--aips-radius-md) var(--aips-radius-md) !important;
+    background: var(--aips-gray-50) !important;
+}
+
+/* For empty states inside nested panels */
+.aips-page-tab-panel .aips-content-panel .aips-empty-state {
+    border: 1px solid var(--aips-gray-200) !important;
+    border-radius: 0 0 var(--aips-radius-md) var(--aips-radius-md) !important;
+    background: var(--aips-white) !important;
 }
 
 .aips-tab-content {

--- a/ai-post-scheduler/assets/js/admin.js
+++ b/ai-post-scheduler/assets/js/admin.js
@@ -156,40 +156,42 @@
                 });
                 $('#aips-schedule-status-summary').html(cardsHtml.join(''));
 
-                var scheduleTimelineItems = (d.timeline || []).sort(function(a, b) {
-                    return a.timestamp - b.timestamp;
-                }).slice(0, 12).map(function(item) {
-                    var typeLabel = typeLabels[item.type] || item.type || '';
-                    var dt = new Date(item.timestamp * 1000);
-                    return '<div class="aips-schedule-status-event">' +
-                        '<div class="aips-schedule-status-event-top">' +
-                            '<span class="aips-badge aips-badge-neutral">' + escapeHtml(typeLabel) + '</span>' +
-                            '<span class="aips-schedule-status-event-time">' + escapeHtml(dt.toLocaleString()) + '</span>' +
-                        '</div>' +
-                        '<div class="aips-schedule-status-event-title">' + escapeHtml(item.title || item.cron_hook || '') + '</div>' +
-                    '</div>';
-                });
+                var formatTimestamp = function(timestamp, fallback) {
+                    if (!timestamp) {
+                        return fallback || '—';
+                    }
+                    var dt = new Date(timestamp * 1000);
+                    return dt.toLocaleString();
+                };
 
-                $('#aips-schedule-status-timeline').html(
-                    scheduleTimelineItems.length ? scheduleTimelineItems.join('') : '<div class="aips-schedule-status-empty">' + escapeHtml(aipsScheduleL10n.noScheduleRunsNext24h) + '</div>'
-                );
+                var lastSuccessItems = [
+                    { label: aipsScheduleL10n.typeTemplateLabel, time: formatTimestamp(d.last_success.template_schedule, 'Never') },
+                    { label: aipsScheduleL10n.typeAuthorTopicLabel, time: formatTimestamp(d.last_success.author_topic_gen, 'Never') },
+                    { label: aipsScheduleL10n.typeAuthorPostLabel, time: formatTimestamp(d.last_success.author_post_gen, 'Never') }
+                ];
 
-                var queueTimelineItems = (d.queue_timeline || []).sort(function(a, b) {
-                    return a.timestamp - b.timestamp;
-                }).slice(0, 12).map(function(item) {
-                    var dt = new Date(item.timestamp * 1000);
-                    return '<div class="aips-schedule-status-event">' +
-                        '<div class="aips-schedule-status-event-top">' +
-                            '<span class="aips-badge aips-badge-neutral">' + escapeHtml(item.hook || '') + '</span>' +
-                            '<span class="aips-schedule-status-event-time">' + escapeHtml(dt.toLocaleString()) + '</span>' +
-                        '</div>' +
-                        '<div class="aips-schedule-status-event-title">' + escapeHtml((item.count || 0) + ' job(s)') + '</div>' +
-                    '</div>';
-                });
+                var nextRunItems = [
+                    { label: aipsScheduleL10n.typeTemplateLabel, time: formatTimestamp(d.next_runs.template_schedule, 'Not scheduled') },
+                    { label: aipsScheduleL10n.typeAuthorTopicLabel, time: formatTimestamp(d.next_runs.author_topic_gen, 'Not scheduled') },
+                    { label: aipsScheduleL10n.typeAuthorPostLabel, time: formatTimestamp(d.next_runs.author_post_gen, 'Not scheduled') }
+                ];
 
-                $('#aips-schedule-status-queue-timeline').html(
-                    queueTimelineItems.length ? queueTimelineItems.join('') : '<div class="aips-schedule-status-empty">' + escapeHtml(aipsScheduleL10n.noQueueEventsNext24h) + '</div>'
-                );
+                var lastSuccessHtml = lastSuccessItems.map(function(item) {
+                    return AIPS.Templates.render('aips-tmpl-schedule-status-row', {
+                        label: item.label,
+                        time: item.time
+                    });
+                }).join('');
+
+                var nextRunHtml = nextRunItems.map(function(item) {
+                    return AIPS.Templates.render('aips-tmpl-schedule-status-row', {
+                        label: item.label,
+                        time: item.time
+                    });
+                }).join('');
+
+                $('#aips-schedule-status-timeline').html(lastSuccessHtml);
+                $('#aips-schedule-status-queue-timeline').html(nextRunHtml);
 
                 var warnings = [];
                 if (d.last_error) {

--- a/ai-post-scheduler/assets/js/admin.js
+++ b/ai-post-scheduler/assets/js/admin.js
@@ -89,7 +89,10 @@
 
                 var d = resp.data;
                 var escapeHtml = function(value) {
-                    return String(value || '')
+                    if (value === undefined || value === null) {
+                        value = '';
+                    }
+                    return String(value)
                         .replace(/&/g, '&amp;')
                         .replace(/</g, '&lt;')
                         .replace(/>/g, '&gt;')
@@ -113,30 +116,43 @@
                     {
                         label: aipsScheduleL10n.activeSchedulesLabel,
                         value: parseInt(counts.active || 0, 10),
-                        tone: 'neutral'
+                        tone: 'info',
+                        icon: 'dashicons-calendar-alt'
                     },
                     {
                         label: aipsScheduleL10n.upcomingSchedulesLabel,
                         value: parseInt(counts.upcoming_24h || 0, 10),
-                        tone: 'success'
+                        tone: 'success',
+                        icon: 'dashicons-clock'
+                    },
+                    {
+                        label: aipsScheduleL10n.successRateLabel || 'Success Rate',
+                        value: (counts.success_rate !== undefined ? counts.success_rate : 0) + '%',
+                        tone: (counts.success_rate || 0) >= 90 ? 'success' : ((counts.success_rate || 0) >= 70 ? 'warning' : 'error'),
+                        icon: 'dashicons-chart-bar'
                     },
                     {
                         label: aipsScheduleL10n.queueDepthLabel,
                         value: queueTotal,
-                        tone: 'info'
+                        tone: queueTotal > 0 ? 'warning' : 'neutral',
+                        icon: 'dashicons-list-view'
                     },
                     {
                         label: aipsScheduleL10n.bulkFailedLabel,
                         value: parseInt((d.bulk_jobs && d.bulk_jobs.failed) || 0, 10),
-                        tone: parseInt((d.bulk_jobs && d.bulk_jobs.failed) || 0, 10) > 0 ? 'error' : 'neutral'
+                        tone: parseInt((d.bulk_jobs && d.bulk_jobs.failed) || 0, 10) > 0 ? 'error' : 'neutral',
+                        icon: 'dashicons-warning'
                     }
                 ];
 
                 var cardsHtml = cards.map(function(card) {
-                    return '<div class="aips-schedule-status-card aips-schedule-status-card-' + escapeHtml(card.tone) + '">' +
-                        '<div class="aips-schedule-status-card-label">' + escapeHtml(card.label) + '</div>' +
-                        '<div class="aips-schedule-status-card-value">' + escapeHtml(card.value) + '</div>' +
-                    '</div>';
+                    var iconHtml = card.icon ? '<span class="dashicons ' + AIPS.Templates.escape(card.icon) + ' aips-schedule-status-card-icon"></span>' : '';
+                    return AIPS.Templates.renderRaw('aips-tmpl-schedule-status-card', {
+                        tone: AIPS.Templates.escape(card.tone),
+                        label: AIPS.Templates.escape(card.label),
+                        iconHtml: iconHtml,
+                        value: AIPS.Templates.escape(card.value)
+                    });
                 });
                 $('#aips-schedule-status-summary').html(cardsHtml.join(''));
 
@@ -183,7 +199,17 @@
                     warnings.push('<div class="notice notice-warning inline"><p>' + AIPS.Utilities.escapeHtml(aipsScheduleL10n.retryPending) + ' <a href="' + AIPS.Utilities.sanitizeUrl(d.quick_links.notifications) + '">' + AIPS.Utilities.escapeHtml(aipsScheduleL10n.notifications) + '</a> · <a href="' + AIPS.Utilities.sanitizeUrl(d.quick_links.telemetry) + '">' + AIPS.Utilities.escapeHtml(aipsScheduleL10n.telemetry) + '</a></p></div>');
                 }
                 if (parseInt((counts.overdue || 0), 10) > 0) {
-                    warnings.push('<div class="notice notice-warning inline"><p>' + aipsScheduleL10n.overdueSchedulesWarning.replace('%d', counts.overdue) + '</p></div>');
+                    var title = aipsScheduleL10n.overdueSchedulesWarning.replace('%d', counts.overdue);
+                    var desc = aipsScheduleL10n.overdueSchedulesDesc || 'Schedules might be stalled due to server cron issues. Click Renew to artificially bring them up to date.';
+                    var btnLabel = aipsScheduleL10n.renewSchedulesLabel || 'Renew Schedules';
+
+                    warnings.push(
+                        AIPS.Templates.render('aips-tmpl-schedule-overdue-banner', {
+                            title: title,
+                            desc: desc,
+                            btnLabel: btnLabel
+                        })
+                    );
                 }
                 $('#aips-schedule-status-warnings').html(warnings.join(''));
             });
@@ -290,6 +316,7 @@
             $(document).on('change', '.aips-unified-toggle-schedule', this.toggleUnifiedSchedule);
             $(document).on('click', '.aips-unified-run-now', this.runNowUnified);
             $(document).on('click', '.aips-view-unified-history', this.viewUnifiedScheduleHistory);
+            $(document).on('click', '.aips-renew-schedules-btn', this.renewSchedules);
             $(document).on('change', '#aips-unified-type-filter', this.filterUnifiedByType);
             $(document).on('keyup search', '#aips-unified-search', this.filterUnifiedSchedules);
             $(document).on('click', '#aips-unified-search-clear', this.clearUnifiedSearch);
@@ -2850,6 +2877,35 @@
                     $loading.hide();
                     AIPS.Utilities.showToast(aipsAdminL10n.errorTryAgain, 'error');
                     $modal.hide();
+                }
+            });
+        },
+
+        renewSchedules: function(e) {
+            e.preventDefault();
+            var $btn = $(this);
+            AIPS.Utilities.setButtonLoading($btn, '<span class="dashicons dashicons-update aips-spin"></span> Renewing...', { isHtml: true });
+
+            $.ajax({
+                url: aipsAjax.ajaxUrl,
+                type: 'POST',
+                data: {
+                    action: 'aips_renew_overdue_schedules',
+                    nonce: aipsAjax.nonce
+                },
+                success: function(response) {
+                    if (response.success) {
+                        var count = response.data.renewed_count || 0;
+                        AIPS.Utilities.showToast(response.data.message || (count + ' schedules renewed successfully.'), 'success');
+                        location.reload();
+                    } else {
+                        AIPS.Utilities.showToast(response.data.message || 'Failed to renew schedules.', 'error');
+                        AIPS.Utilities.resetButton($btn);
+                    }
+                },
+                error: function() {
+                    AIPS.Utilities.showToast(aipsAdminL10n.errorTryAgain, 'error');
+                    AIPS.Utilities.resetButton($btn);
                 }
             });
         },

--- a/ai-post-scheduler/assets/js/admin.js
+++ b/ai-post-scheduler/assets/js/admin.js
@@ -127,7 +127,7 @@
                     },
                     {
                         label: aipsScheduleL10n.successRateLabel || 'Success Rate',
-                        value: (counts.success_rate !== undefined ? counts.success_rate : 0) + '%',
+                        value: (counts.success_rate != null ? counts.success_rate : 0) + '%',
                         tone: (counts.success_rate || 0) >= 90 ? 'success' : ((counts.success_rate || 0) >= 70 ? 'warning' : 'error'),
                         icon: 'dashicons-chart-bar'
                     },
@@ -2913,7 +2913,9 @@
                     if (response.success) {
                         var count = response.data.renewed_count || 0;
                         AIPS.Utilities.showToast(response.data.message || (count + ' schedules renewed successfully.'), 'success');
-                        location.reload();
+                        setTimeout(function() {
+                            location.reload();
+                        }, 1500);
                     } else {
                         AIPS.Utilities.showToast(response.data.message || 'Failed to renew schedules.', 'error');
                         AIPS.Utilities.resetButton($btn);

--- a/ai-post-scheduler/assets/js/admin.js
+++ b/ai-post-scheduler/assets/js/admin.js
@@ -644,6 +644,7 @@
             e.preventDefault();
             $('#aips-template-form')[0].reset();
             $('#template_id').val('');
+            $('#template_campaign_id').val('');
             $('#aips-modal-title').text('Add New Template');
             $('#featured_image_source').val('ai_prompt');
             $('#featured_image_unsplash_keywords').val('');
@@ -722,6 +723,7 @@
                         $('#post_tags').val(t.post_tags);
                         $('#post_author').val(t.post_author);
                         $('#is_active').prop('checked', t.is_active == 1);
+                        $('#template_campaign_id').val(t.campaign_id || '');
                         AIPS.toggleImagePrompt();
                         AIPS.toggleFeaturedImageSourceFields();
 
@@ -928,7 +930,8 @@
                         $('.aips-template-source-group-cb:checked').each(function() { ids.push($(this).val()); });
                         return ids;
                     }()),
-                    is_active: $('#is_active').is(':checked') ? 1 : 0
+                    is_active: $('#is_active').is(':checked') ? 1 : 0,
+                    campaign_id: $('#template_campaign_id').val()
                 },
                 success: function(response) {
                     if (response.success) {
@@ -1004,7 +1007,8 @@
                         $('.aips-template-source-group-cb:checked').each(function() { ids.push($(this).val()); });
                         return ids;
                     }()),
-                    is_active: 0 // Save as inactive draft
+                    is_active: 0, // Save as inactive draft
+                    campaign_id: $('#template_campaign_id').val()
                 },
                 success: function(response) {
                     if (response.success) {
@@ -1445,12 +1449,14 @@
                 // Fallback to legacy modal if wizard not present
                 $('#aips-schedule-form')[0].reset();
                 $('#schedule_id').val('');
+                $('#schedule_campaign_id').val('');
                 $('#aips-schedule-modal-title').text('Add New Schedule');
                 $('#aips-schedule-modal').show();
                 return;
             }
             $('#aips-schedule-wizard-form')[0].reset();
             $('#sw_schedule_id').val('');
+            $('#sw_schedule_campaign_id').val('');
             $wizardModal.find('#aips-schedule-wizard-modal-title').text(aipsScheduleL10n.addNewSchedule || 'Add New Schedule');
             AIPS.wizardGoToStep(1, $wizardModal);
             $wizardModal.show();
@@ -1468,6 +1474,7 @@
             var $row = $(this).closest('tr');
             var scheduleId = $row.data('schedule-id');
             var templateId = $row.data('template-id');
+            var campaignId = $row.data('campaign-id');
             var scheduleTitle = $row.data('title');
             var frequency = $row.data('frequency');
             var topic = $row.data('topic');
@@ -1483,6 +1490,7 @@
                 $('#schedule_id').val(scheduleId);
                 $('#schedule_title').val(scheduleTitle || '');
                 $('#schedule_template').val(templateId);
+                $('#schedule_campaign_id').val(campaignId || '');
                 $('#schedule_frequency').val(frequency);
                 $('#schedule_topic').val(topic || '');
                 $('#article_structure_id').val(articleStructureId || '');
@@ -1505,6 +1513,7 @@
             $('#sw_schedule_id').val(scheduleId);
             $('#sw_schedule_title').val(scheduleTitle || '');
             $('#sw_schedule_template').val(templateId);
+            $('#sw_schedule_campaign_id').val(campaignId || '');
             $('#sw_schedule_frequency').val(frequency);
             $('#sw_schedule_topic').val(topic || '');
             $('#sw_article_structure_id').val(articleStructureId || '');
@@ -1541,6 +1550,7 @@
             // Get data from the row
             var $row = $(this).closest('tr');
             var templateId = $row.data('template-id');
+            var campaignId = $row.data('campaign-id');
             var scheduleTitle = $row.data('title');
             var frequency = $row.data('frequency');
             var topic = $row.data('topic');
@@ -1554,6 +1564,7 @@
                 $('#schedule_id').val('');
                 $('#schedule_title').val(scheduleTitle || '');
                 $('#schedule_template').val(templateId);
+                $('#schedule_campaign_id').val(campaignId || '');
                 $('#schedule_frequency').val(frequency);
                 $('#schedule_topic').val(topic);
                 $('#article_structure_id').val(articleStructureId);
@@ -1571,6 +1582,7 @@
             // Populate wizard form
             $('#sw_schedule_title').val(scheduleTitle || '');
             $('#sw_schedule_template').val(templateId);
+            $('#sw_schedule_campaign_id').val(campaignId || '');
             $('#sw_schedule_frequency').val(frequency);
             $('#sw_schedule_topic').val(topic);
             $('#sw_article_structure_id').val(articleStructureId);
@@ -1618,7 +1630,8 @@
                     topic: $('#schedule_topic').val(),
                     article_structure_id: $('#article_structure_id').val(),
                     rotation_pattern: $('#rotation_pattern').val(),
-                    is_active: $('#schedule_is_active').is(':checked') ? 1 : 0
+                    is_active: $('#schedule_is_active').is(':checked') ? 1 : 0,
+                    campaign_id: $('#schedule_campaign_id').val()
                 },
                 success: function(response) {
                     if (response.success) {
@@ -1682,7 +1695,8 @@
                     topic: $('#sw_schedule_topic').val(),
                     article_structure_id: $('#sw_article_structure_id').val(),
                     rotation_pattern: $('#sw_rotation_pattern').val(),
-                    is_active: $('#sw_schedule_is_active').is(':checked') ? 1 : 0
+                    is_active: $('#sw_schedule_is_active').is(':checked') ? 1 : 0,
+                    campaign_id: $('#sw_schedule_campaign_id').val()
                 },
                 success: function(response) {
                     if (response.success) {

--- a/ai-post-scheduler/assets/js/campaigns.js
+++ b/ai-post-scheduler/assets/js/campaigns.js
@@ -33,6 +33,8 @@
 			$(document).on('click', '.aips-restore-campaign', this.handleRestoreCampaign.bind(this));
 			$(document).on('click', '.aips-delete-campaign', this.handleDeleteCampaign.bind(this));
 			$(document).on('click', '.aips-campaign-run-now', this.handleRunNow.bind(this));
+			$(document).on('click', '.aips-link-existing-template-btn', this.handleLinkExistingTemplate.bind(this));
+			$(document).on('click', '.aips-unlink-template-btn', this.handleUnlinkTemplate.bind(this));
 		},
 
 		/**
@@ -260,6 +262,95 @@
 				}
 			}).fail(function() {
 				AIPS.Utilities.showNotice(aipsCampaignsL10n.errorNetwork, 'error');
+			});
+		},
+
+		/**
+		 * Handle linking an existing template to a campaign.
+		 *
+		 * @param {Event} e Click event.
+		 */
+		handleLinkExistingTemplate: function(e) {
+			e.preventDefault();
+
+			var $button = $(e.currentTarget);
+			var campaignId = $button.data('campaign-id');
+			var templateId = $('#aips-add-existing-template-select').val();
+
+			if (!templateId) {
+				alert(aipsCampaignsL10n.selectTemplate || 'Please select a template first.');
+				return;
+			}
+
+			$button.prop('disabled', true);
+
+			$.ajax({
+				url: ajaxurl,
+				type: 'POST',
+				data: {
+					action: 'aips_link_existing_template',
+					nonce: aipsAjax.nonce,
+					campaign_id: campaignId,
+					template_id: templateId
+				},
+				success: function(response) {
+					if (response.success) {
+						location.reload();
+					} else {
+						AIPS.Utilities.showNotice(response.data.message || 'Failed to link template.', 'error');
+						$button.prop('disabled', false);
+					}
+				},
+				error: function() {
+					AIPS.Utilities.showNotice(aipsCampaignsL10n.errorNetwork, 'error');
+					$button.prop('disabled', false);
+				}
+			});
+		},
+
+		/**
+		 * Handle unlinking a template from a campaign.
+		 *
+		 * @param {Event} e Click event.
+		 */
+		handleUnlinkTemplate: function(e) {
+			e.preventDefault();
+
+			var $button = $(e.currentTarget);
+			var campaignId = $button.data('campaign-id');
+			var templateId = $button.data('template-id');
+			var templateName = $button.data('template-name');
+
+			var confirmMessage = aipsCampaignsL10n.confirmUnlink || 'Are you sure you want to remove this template from this campaign?';
+			confirmMessage = confirmMessage.replace('%s', templateName);
+
+			if (!confirm(confirmMessage)) {
+				return;
+			}
+
+			$button.prop('disabled', true);
+
+			$.ajax({
+				url: ajaxurl,
+				type: 'POST',
+				data: {
+					action: 'aips_unlink_template_from_campaign',
+					nonce: aipsAjax.nonce,
+					campaign_id: campaignId,
+					template_id: templateId
+				},
+				success: function(response) {
+					if (response.success) {
+						location.reload();
+					} else {
+						AIPS.Utilities.showNotice(response.data.message || 'Failed to remove template.', 'error');
+						$button.prop('disabled', false);
+					}
+				},
+				error: function() {
+					AIPS.Utilities.showNotice(aipsCampaignsL10n.errorNetwork, 'error');
+					$button.prop('disabled', false);
+				}
 			});
 		}
 	};

--- a/ai-post-scheduler/includes/class-aips-admin-assets.php
+++ b/ai-post-scheduler/includes/class-aips-admin-assets.php
@@ -1373,6 +1373,8 @@ class AIPS_Admin_Assets {
                 'confirmDuplicate' => __('Duplicate this campaign? The copy will be created in a paused state.', 'ai-post-scheduler'),
                 'confirmArchive'   => __('Archive this campaign? It will be hidden from the active campaigns list.', 'ai-post-scheduler'),
                 'confirmDelete'    => __('Delete this campaign? This removes the campaign and its owned template/schedule rows.', 'ai-post-scheduler'),
+                'confirmUnlink'    => __('Are you sure you want to remove the template "%s" from this campaign?', 'ai-post-scheduler'),
+                'selectTemplate'   => __('Please select a template first.', 'ai-post-scheduler'),
                 'errorToggle'      => __('Failed to update campaign.', 'ai-post-scheduler'),
                 'errorDuplicate'   => __('Failed to duplicate campaign.', 'ai-post-scheduler'),
                 'errorArchive'     => __('Failed to archive campaign.', 'ai-post-scheduler'),

--- a/ai-post-scheduler/includes/class-aips-admin-assets.php
+++ b/ai-post-scheduler/includes/class-aips-admin-assets.php
@@ -932,6 +932,9 @@ class AIPS_Admin_Assets {
                 'retryPending'                   => __('Retry jobs are pending.', 'ai-post-scheduler'),
                 /* translators: %d: number of overdue schedules */
                 'overdueSchedulesWarning'        => __('%d schedule(s) are overdue.', 'ai-post-scheduler'),
+                'overdueSchedulesDesc'           => __('Schedules might be stalled due to server cron issues. Click Renew to artificially bring them up to date.', 'ai-post-scheduler'),
+                'renewSchedulesLabel'            => __('Renew Schedules', 'ai-post-scheduler'),
+                'successRateLabel'               => __('Success Rate', 'ai-post-scheduler'),
                 'viewHistory'                    => __('View history', 'ai-post-scheduler'),
                 'systemStatus'                   => __('System status', 'ai-post-scheduler'),
                 'notifications'                  => __('Notifications', 'ai-post-scheduler'),

--- a/ai-post-scheduler/includes/class-aips-admin-flow-controller.php
+++ b/ai-post-scheduler/includes/class-aips-admin-flow-controller.php
@@ -13,7 +13,7 @@ class AIPS_Admin_Flow_Controller extends AIPS_Campaigns_Controller {
 
 	const PAGE_SLUG = AIPS_Campaigns_Controller::PAGE_SLUG;
 
-	public function render_page() {
+	public function render_page($embedded = false) {
 		$this->render_wizard_page();
 	}
 }

--- a/ai-post-scheduler/includes/class-aips-ajax-registry.php
+++ b/ai-post-scheduler/includes/class-aips-ajax-registry.php
@@ -70,6 +70,8 @@ class AIPS_Ajax_Registry {
 		'aips_archive_campaign'              => 'AIPS_Campaigns_Controller',
 		'aips_restore_campaign'              => 'AIPS_Campaigns_Controller',
 		'aips_delete_campaign'               => 'AIPS_Campaigns_Controller',
+		'aips_link_existing_template'        => 'AIPS_Campaigns_Controller',
+		'aips_unlink_template_from_campaign' => 'AIPS_Campaigns_Controller',
 
 		// Author Topics Controller
 		'aips_approve_topic'              => 'AIPS_Author_Topics_Controller',

--- a/ai-post-scheduler/includes/class-aips-ajax-registry.php
+++ b/ai-post-scheduler/includes/class-aips-ajax-registry.php
@@ -54,6 +54,7 @@ class AIPS_Ajax_Registry {
 		'aips_unified_bulk_delete'        => 'AIPS_Schedule_Controller',
 		'aips_get_unified_schedule_history' => 'AIPS_Schedule_Controller',
 		'aips_get_schedule_status_read_model' => 'AIPS_Schedule_Controller',
+		'aips_renew_overdue_schedules' => 'AIPS_Schedule_Controller',
 
 		// Admin Campaign Wizard
 		'aips_campaign_wizard_save_draft'    => 'AIPS_Campaigns_Controller',

--- a/ai-post-scheduler/includes/class-aips-campaigns-controller.php
+++ b/ai-post-scheduler/includes/class-aips-campaigns-controller.php
@@ -83,6 +83,8 @@ class AIPS_Campaigns_Controller {
 		add_action('wp_ajax_aips_archive_campaign', array($this, 'ajax_archive_campaign'));
 		add_action('wp_ajax_aips_restore_campaign', array($this, 'ajax_restore_campaign'));
 		add_action('wp_ajax_aips_delete_campaign', array($this, 'ajax_delete_campaign'));
+		add_action('wp_ajax_aips_link_existing_template', array($this, 'ajax_link_existing_template'));
+		add_action('wp_ajax_aips_unlink_template_from_campaign', array($this, 'ajax_unlink_template_from_campaign'));
 		add_action('wp_ajax_aips_campaign_wizard_save_draft', array($this, 'ajax_save_draft'));
 		add_action('wp_ajax_aips_campaign_wizard_validate_step', array($this, 'ajax_validate_step'));
 		add_action('wp_ajax_aips_campaign_wizard_finalize', array($this, 'ajax_finalize_campaign'));
@@ -220,6 +222,7 @@ class AIPS_Campaigns_Controller {
 
 		$templates = $this->campaigns_repository->get_templates_by_campaign($campaign_id);
 		$schedules = $this->campaigns_repository->get_schedules_by_campaign($campaign_id);
+		$available_templates = $this->campaigns_repository->get_templates_not_in_campaign($campaign_id);
 		$campaign_health = $this->campaigns_repository->get_campaign_health($campaign_id);
 		$recent_activity = $this->campaigns_repository->get_recent_activity($campaign_id, 10);
 		$recent_generated_posts = $this->campaigns_repository->get_recent_generated_posts($campaign_id, 10);
@@ -481,6 +484,80 @@ class AIPS_Campaigns_Controller {
 		}
 
 		AIPS_Ajax_Response::error(__('Failed to delete campaign.', 'ai-post-scheduler'), 'delete_failed', 500);
+	}
+
+	/**
+	 * AJAX: link an existing template to a campaign.
+	 */
+	public function ajax_link_existing_template() {
+		$this->ajax_guard();
+
+		$campaign_id = isset($_POST['campaign_id']) ? absint($_POST['campaign_id']) : 0;
+		$template_id = isset($_POST['template_id']) ? absint($_POST['template_id']) : 0;
+
+		if (!$campaign_id || !$template_id) {
+			AIPS_Ajax_Response::error(__('Invalid Campaign or Template ID.', 'ai-post-scheduler'), 'invalid_ids', 400);
+		}
+
+		$result = $this->campaigns_repository->link_template_to_campaign($campaign_id, $template_id);
+		if (is_wp_error($result)) {
+			AIPS_Ajax_Response::error($result->get_error_message(), $result->get_error_code(), 500);
+		}
+
+		if ($result) {
+			$template = $this->template_repository->get_by_id($template_id);
+			$template_name = $template ? $template->name : __('Template', 'ai-post-scheduler');
+			$this->record_campaign_lifecycle_activity(
+				$campaign_id,
+				'template_linked',
+				sprintf(
+					/* translators: %s: template name */
+					__('linked template "%s"', 'ai-post-scheduler'),
+					$template_name
+				)
+			);
+
+			AIPS_Ajax_Response::success(array(), __('Template linked successfully.', 'ai-post-scheduler'));
+		}
+
+		AIPS_Ajax_Response::error(__('Failed to link template.', 'ai-post-scheduler'), 'link_failed', 500);
+	}
+
+	/**
+	 * AJAX: unlink a template from a campaign.
+	 */
+	public function ajax_unlink_template_from_campaign() {
+		$this->ajax_guard();
+
+		$campaign_id = isset($_POST['campaign_id']) ? absint($_POST['campaign_id']) : 0;
+		$template_id = isset($_POST['template_id']) ? absint($_POST['template_id']) : 0;
+
+		if (!$campaign_id || !$template_id) {
+			AIPS_Ajax_Response::error(__('Invalid Campaign or Template ID.', 'ai-post-scheduler'), 'invalid_ids', 400);
+		}
+
+		$result = $this->campaigns_repository->unlink_template_from_campaign($campaign_id, $template_id);
+		if (is_wp_error($result)) {
+			AIPS_Ajax_Response::error($result->get_error_message(), $result->get_error_code(), 500);
+		}
+
+		if ($result) {
+			$template = $this->template_repository->get_by_id($template_id);
+			$template_name = $template ? $template->name : __('Template', 'ai-post-scheduler');
+			$this->record_campaign_lifecycle_activity(
+				$campaign_id,
+				'template_unlinked',
+				sprintf(
+					/* translators: %s: template name */
+					__('unlinked template "%s"', 'ai-post-scheduler'),
+					$template_name
+				)
+			);
+
+			AIPS_Ajax_Response::success(array(), __('Template unlinked successfully.', 'ai-post-scheduler'));
+		}
+
+		AIPS_Ajax_Response::error(__('Failed to unlink template.', 'ai-post-scheduler'), 'unlink_failed', 500);
 	}
 
 	/**

--- a/ai-post-scheduler/includes/class-aips-campaigns-repository.php
+++ b/ai-post-scheduler/includes/class-aips-campaigns-repository.php
@@ -277,8 +277,12 @@ class AIPS_Campaigns_Repository {
 			$campaign_id
 		));
 
+		$table_campaign_templates = $this->wpdb->prefix . 'aips_campaign_templates';
 		$empty_prompt_count = (int) $this->wpdb->get_var($this->wpdb->prepare(
-			"SELECT COUNT(*) FROM {$this->templates_table} WHERE campaign_id = %d AND TRIM(COALESCE(prompt_template, '')) = ''",
+			"SELECT COUNT(*) 
+			FROM {$this->templates_table} t
+			INNER JOIN {$table_campaign_templates} ct ON t.id = ct.template_id
+			WHERE ct.campaign_id = %d AND TRIM(COALESCE(t.prompt_template, '')) = ''",
 			$campaign_id
 		));
 
@@ -696,14 +700,37 @@ class AIPS_Campaigns_Repository {
 			}
 		}
 
+		$table_campaign_templates = $this->wpdb->prefix . 'aips_campaign_templates';
 		foreach ($this->get_templates_by_campaign($campaign_id) as $template) {
-			if (!$this->template_repository->delete((int) $template->id)) {
-				return $this->rollback_with_error(
-					$started_transaction,
-					$this->build_campaign_error('campaign_template_delete_failed', __('Failed to delete campaign template.', 'ai-post-scheduler'))
+			$linked_campaigns_count = (int) $this->wpdb->get_var($this->wpdb->prepare(
+				"SELECT COUNT(*) FROM {$table_campaign_templates} WHERE template_id = %d",
+				(int) $template->id
+			));
+
+			if ($linked_campaigns_count <= 1) {
+				if (!$this->template_repository->delete((int) $template->id)) {
+					return $this->rollback_with_error(
+						$started_transaction,
+						$this->build_campaign_error('campaign_template_delete_failed', __('Failed to delete campaign template.', 'ai-post-scheduler'))
+					);
+				}
+			} else {
+				$this->wpdb->delete(
+					$table_campaign_templates,
+					array(
+						'campaign_id' => $campaign_id,
+						'template_id' => (int) $template->id,
+					),
+					array('%d', '%d')
 				);
 			}
 		}
+
+		$this->wpdb->delete(
+			$table_campaign_templates,
+			array('campaign_id' => $campaign_id),
+			array('%d')
+		);
 
 		$deleted = $this->wpdb->delete(
 			$this->campaigns_table,
@@ -883,10 +910,154 @@ class AIPS_Campaigns_Repository {
 	 * @return array
 	 */
 	public function get_templates_by_campaign($campaign_id) {
+		$table_campaign_templates = $this->wpdb->prefix . 'aips_campaign_templates';
 		return $this->wpdb->get_results($this->wpdb->prepare(
-			"SELECT * FROM {$this->templates_table} WHERE campaign_id = %d ORDER BY id ASC",
+			"SELECT t.* 
+			FROM {$this->templates_table} t
+			INNER JOIN {$table_campaign_templates} ct ON t.id = ct.template_id
+			WHERE ct.campaign_id = %d 
+			ORDER BY t.id ASC",
 			absint($campaign_id)
 		));
+	}
+
+	/**
+	 * Get all templates that are not currently associated with the specified campaign.
+	 *
+	 * @param int $campaign_id Campaign ID.
+	 * @return array Array of template objects.
+	 */
+	public function get_templates_not_in_campaign($campaign_id) {
+		$table_campaign_templates = $this->wpdb->prefix . 'aips_campaign_templates';
+		return $this->wpdb->get_results($this->wpdb->prepare(
+			"SELECT t.* 
+			FROM {$this->templates_table} t
+			WHERE t.id NOT IN (
+				SELECT template_id 
+				FROM {$table_campaign_templates} 
+				WHERE campaign_id = %d
+			)
+			ORDER BY t.name ASC",
+			absint($campaign_id)
+		));
+	}
+
+	/**
+	 * Link an existing template to a campaign.
+	 *
+	 * @param int $campaign_id Campaign ID.
+	 * @param int $template_id Template ID.
+	 * @return bool|WP_Error
+	 */
+	public function link_template_to_campaign($campaign_id, $template_id) {
+		$campaign_id = absint($campaign_id);
+		$template_id = absint($template_id);
+
+		if (!$campaign_id || !$template_id) {
+			return $this->build_campaign_error('invalid_ids', __('Invalid Campaign or Template ID.', 'ai-post-scheduler'));
+		}
+
+		$table_campaign_templates = $this->wpdb->prefix . 'aips_campaign_templates';
+
+		// Check if already linked
+		$exists = $this->wpdb->get_var($this->wpdb->prepare(
+			"SELECT COUNT(*) FROM {$table_campaign_templates} WHERE campaign_id = %d AND template_id = %d",
+			$campaign_id,
+			$template_id
+		));
+
+		if ($exists) {
+			return true;
+		}
+
+		$inserted = $this->wpdb->insert(
+			$table_campaign_templates,
+			array(
+				'campaign_id' => $campaign_id,
+				'template_id' => $template_id,
+			),
+			array('%d', '%d')
+		);
+
+		if ($inserted === false) {
+			return $this->build_campaign_error('link_failed', __('Failed to link template to campaign.', 'ai-post-scheduler'));
+		}
+
+		// Also update the campaign_id in aips_templates if it is currently NULL, to preserve backward compatibility.
+		$current_campaign_id = $this->wpdb->get_var($this->wpdb->prepare(
+			"SELECT campaign_id FROM {$this->templates_table} WHERE id = %d",
+			$template_id
+		));
+		if (empty($current_campaign_id)) {
+			$this->wpdb->update(
+				$this->templates_table,
+				array('campaign_id' => $campaign_id),
+				array('id' => $template_id),
+				array('%d'),
+				array('%d')
+			);
+		}
+
+		$this->flush_campaign_cache($campaign_id);
+		AIPS_Template_Repository::instance()->cache->flush();
+
+		return true;
+	}
+
+	/**
+	 * Unlink a template from a campaign.
+	 *
+	 * @param int $campaign_id Campaign ID.
+	 * @param int $template_id Template ID.
+	 * @return bool|WP_Error
+	 */
+	public function unlink_template_from_campaign($campaign_id, $template_id) {
+		$campaign_id = absint($campaign_id);
+		$template_id = absint($template_id);
+
+		if (!$campaign_id || !$template_id) {
+			return $this->build_campaign_error('invalid_ids', __('Invalid Campaign or Template ID.', 'ai-post-scheduler'));
+		}
+
+		$table_campaign_templates = $this->wpdb->prefix . 'aips_campaign_templates';
+
+		$deleted = $this->wpdb->delete(
+			$table_campaign_templates,
+			array(
+				'campaign_id' => $campaign_id,
+				'template_id' => $template_id,
+			),
+			array('%d', '%d')
+		);
+
+		if ($deleted === false) {
+			return $this->build_campaign_error('unlink_failed', __('Failed to unlink template from campaign.', 'ai-post-scheduler'));
+		}
+
+		// Also check if the template's campaign_id column matches this campaign. If so, update it to the next campaign ID in the join table, or NULL.
+		$current_campaign_id = (int) $this->wpdb->get_var($this->wpdb->prepare(
+			"SELECT campaign_id FROM {$this->templates_table} WHERE id = %d",
+			$template_id
+		));
+
+		if ($current_campaign_id === $campaign_id) {
+			$next_campaign_id = $this->wpdb->get_var($this->wpdb->prepare(
+				"SELECT campaign_id FROM {$table_campaign_templates} WHERE template_id = %d LIMIT 1",
+				$template_id
+			));
+			$this->wpdb->update(
+				$this->templates_table,
+				array('campaign_id' => !empty($next_campaign_id) ? absint($next_campaign_id) : null),
+				array('id' => $template_id),
+				array('%d'),
+				array('%d')
+			);
+		}
+
+		$this->flush_campaign_cache($campaign_id);
+		AIPS_Template_Repository::instance()->cache->flush();
+
+		return true;
 	}
 
 	/**
@@ -897,7 +1068,10 @@ class AIPS_Campaigns_Repository {
 	 */
 	public function get_schedules_by_campaign($campaign_id) {
 		return $this->wpdb->get_results($this->wpdb->prepare(
-			"SELECT * FROM {$this->schedule_table} WHERE campaign_id = %d ORDER BY id ASC",
+			"SELECT s.*, t.name AS template_name 
+			FROM {$this->schedule_table} s 
+			LEFT JOIN {$this->templates_table} t ON s.template_id = t.id 
+			WHERE s.campaign_id = %d ORDER BY s.id ASC",
 			absint($campaign_id)
 		));
 	}
@@ -1035,9 +1209,8 @@ class AIPS_Campaigns_Repository {
 				s.primary_schedule_id AS primary_schedule_id
 			FROM {$this->campaigns_table} c
 			LEFT JOIN (
-				SELECT campaign_id, COUNT(*) AS linked_template_count, MIN(id) AS primary_template_id
-				FROM {$this->templates_table}
-				WHERE campaign_id IS NOT NULL
+				SELECT campaign_id, COUNT(*) AS linked_template_count, MIN(template_id) AS primary_template_id
+				FROM {$this->wpdb->prefix}aips_campaign_templates
 				GROUP BY campaign_id
 			) t ON t.campaign_id = c.id
 			LEFT JOIN (

--- a/ai-post-scheduler/includes/class-aips-db-manager.php
+++ b/ai-post-scheduler/includes/class-aips-db-manager.php
@@ -33,6 +33,7 @@ class AIPS_DB_Manager {
         'aips_bulk_batch_jobs',
         'aips_cache_index',
         'aips_cache_events',
+        'aips_campaign_templates',
     );
 
     public function __construct() {
@@ -94,6 +95,7 @@ class AIPS_DB_Manager {
         $table_bulk_batch_jobs      = $tables['aips_bulk_batch_jobs'];
         $table_cache_index          = $tables['aips_cache_index'];
         $table_cache_events         = $tables['aips_cache_events'];
+        $table_campaign_templates   = $tables['aips_campaign_templates'];
 
         $sql = array();
 
@@ -155,6 +157,16 @@ class AIPS_DB_Manager {
             KEY is_archived (is_archived),
             KEY campaign_mode (campaign_mode),
             KEY active_archived (is_active, is_archived)
+        ) $charset_collate;";
+
+        $sql[] = "CREATE TABLE $table_campaign_templates (
+            id bigint(20) NOT NULL AUTO_INCREMENT,
+            campaign_id bigint(20) NOT NULL,
+            template_id bigint(20) NOT NULL,
+            PRIMARY KEY  (id),
+            KEY campaign_id (campaign_id),
+            KEY template_id (template_id),
+            UNIQUE KEY campaign_template (campaign_id, template_id)
         ) $charset_collate;";
 
         $sql[] = "CREATE TABLE $table_templates (

--- a/ai-post-scheduler/includes/class-aips-db-migrations.php
+++ b/ai-post-scheduler/includes/class-aips-db-migrations.php
@@ -154,6 +154,10 @@ class AIPS_DB_Migrations {
 			$this->migrate_to_2_9_1();
 		}
 
+		if ( version_compare( $from_version, '2.9.2', '<' ) ) {
+			$this->migrate_to_2_9_2();
+		}
+
 		// Use AIPS_Config::set_option() so the per-request option cache is
 		// invalidated immediately; bare update_option() would leave the cache
 		// stale for the rest of this request.
@@ -812,5 +816,56 @@ class AIPS_DB_Migrations {
 		}
 
 		return (int) $run_at->getTimestamp();
+	}
+
+	/**
+	 * Migration for version 2.9.2.
+	 *
+	 * Backfills the `aips_campaign_templates` join table by copying existing
+	 * `campaign_id` associations from the `aips_templates` table.
+	 *
+	 * @return void
+	 */
+	private function migrate_to_2_9_2() {
+		global $wpdb;
+
+		$table_campaign_templates = $wpdb->prefix . 'aips_campaign_templates';
+		$table_templates = $wpdb->prefix . 'aips_templates';
+
+		// Guard check: make sure the join table exists
+		$table_exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_campaign_templates ) );
+		if ( $table_exists !== $table_campaign_templates ) {
+			return;
+		}
+
+		$templates = $wpdb->get_results(
+			"SELECT id, campaign_id FROM `{$table_templates}` WHERE campaign_id IS NOT NULL AND campaign_id > 0",
+			ARRAY_A
+		);
+
+		if ( ! empty( $templates ) ) {
+			foreach ( $templates as $template ) {
+				$template_id = absint( $template['id'] );
+				$campaign_id = absint( $template['campaign_id'] );
+
+				// Check if this mapping already exists
+				$exists = $wpdb->get_var( $wpdb->prepare(
+					"SELECT COUNT(*) FROM `{$table_campaign_templates}` WHERE campaign_id = %d AND template_id = %d",
+					$campaign_id,
+					$template_id
+				) );
+
+				if ( ! $exists ) {
+					$wpdb->insert(
+						$table_campaign_templates,
+						array(
+							'campaign_id' => $campaign_id,
+							'template_id' => $template_id,
+						),
+						array( '%d', '%d' )
+					);
+				}
+			}
+		}
 	}
 }

--- a/ai-post-scheduler/includes/class-aips-schedule-controller.php
+++ b/ai-post-scheduler/includes/class-aips-schedule-controller.php
@@ -47,6 +47,7 @@ class AIPS_Schedule_Controller {
         add_action('wp_ajax_aips_unified_bulk_delete', array($this, 'ajax_unified_bulk_delete'));
         add_action('wp_ajax_aips_get_unified_schedule_history', array($this, 'ajax_get_unified_schedule_history'));
         add_action('wp_ajax_aips_get_schedule_status_read_model', array($this, 'ajax_get_schedule_status_read_model'));
+        add_action('wp_ajax_aips_renew_overdue_schedules', array($this, 'ajax_renew_overdue_schedules'));
     }
 
     public function ajax_get_schedule_status_read_model() {
@@ -174,6 +175,7 @@ class AIPS_Schedule_Controller {
                 'active' => $active_schedules,
                 'upcoming_24h' => count($timeline),
                 'overdue' => $overdue_schedules,
+                'success_rate' => $this->history_repository->get_stats()['success_rate'],
             ),
             'last_success' => $last_success,
             'retry_pending' => ($queue_depth['aips_retry_failed_author_slices_topics'] + $queue_depth['aips_retry_failed_author_slices_posts']) > 0,
@@ -188,6 +190,59 @@ class AIPS_Schedule_Controller {
 
         $cache->set($cache_key, $payload, 60);
         AIPS_Ajax_Response::success($payload);
+    }
+
+    public function ajax_renew_overdue_schedules() {
+        if ( ! check_ajax_referer('aips_ajax_nonce', 'nonce', false) ) {
+            AIPS_Ajax_Response::error(__('Invalid nonce.', 'ai-post-scheduler'));
+        }
+        if (!current_user_can('manage_options')) {
+            AIPS_Ajax_Response::error(__('Unauthorized.', 'ai-post-scheduler'));
+        }
+
+        $unified_service = new AIPS_Unified_Schedule_Service();
+        $all_schedules = $unified_service->get_all('', false);
+        $now = time();
+        $renewed_count = 0;
+
+        $interval_calculator = new AIPS_Interval_Calculator();
+        $authors_repo = new AIPS_Authors_Repository();
+
+        foreach ($all_schedules as $schedule) {
+            $is_active = !empty($schedule['is_active']);
+            $next_run = isset($schedule['next_run']) ? (int) $schedule['next_run'] : 0;
+            if (!$is_active || $next_run <= 0 || $next_run >= $now) {
+                continue;
+            }
+
+            $frequency = $schedule['frequency'];
+            $id = $schedule['id'];
+            $type = $schedule['type'];
+
+            $new_next_run = $interval_calculator->calculate_next_run($frequency, $now);
+
+            if ($type === AIPS_Unified_Schedule_Service::TYPE_TEMPLATE) {
+                $this->schedule_repository->update_next_run($id, $new_next_run);
+                $renewed_count++;
+            } elseif ($type === AIPS_Unified_Schedule_Service::TYPE_AUTHOR_TOPIC) {
+                $authors_repo->update_topic_generation_schedule($id, $new_next_run);
+                $renewed_count++;
+            } elseif ($type === AIPS_Unified_Schedule_Service::TYPE_AUTHOR_POST) {
+                $authors_repo->update_post_generation_schedule($id, $new_next_run);
+                $renewed_count++;
+            }
+        }
+
+        $cache = AIPS_Cache_Factory::make();
+        $cache->delete('aips_schedule_status_strip_v2');
+
+        AIPS_Ajax_Response::success(array(
+            'renewed_count' => $renewed_count,
+            'message' => sprintf(
+                _n('%d schedule renewed successfully.', '%d schedules renewed successfully.', $renewed_count, 'ai-post-scheduler'),
+                $renewed_count
+            ),
+        ));
     }
 
     /**

--- a/ai-post-scheduler/includes/class-aips-schedule-controller.php
+++ b/ai-post-scheduler/includes/class-aips-schedule-controller.php
@@ -361,6 +361,7 @@ class AIPS_Schedule_Controller {
             'topic' => isset($_POST['topic']) ? sanitize_text_field(wp_unslash($_POST['topic'])) : '',
             'article_structure_id' => isset($_POST['article_structure_id']) && $_POST['article_structure_id'] !== '' ? absint($_POST['article_structure_id']) : null,
             'rotation_pattern' => isset($_POST['rotation_pattern']) && $_POST['rotation_pattern'] !== '' ? sanitize_text_field(wp_unslash($_POST['rotation_pattern'])) : null,
+            'campaign_id' => !empty($_POST['campaign_id']) ? absint($_POST['campaign_id']) : null,
         );
 
         if (empty($data['template_id'])) {

--- a/ai-post-scheduler/includes/class-aips-schedule-controller.php
+++ b/ai-post-scheduler/includes/class-aips-schedule-controller.php
@@ -175,7 +175,7 @@ class AIPS_Schedule_Controller {
                 'active' => $active_schedules,
                 'upcoming_24h' => count($timeline),
                 'overdue' => $overdue_schedules,
-                'success_rate' => $this->history_repository->get_stats()['success_rate'],
+                'success_rate' => isset($this->history_repository->get_stats()['success_rate']) ? $this->history_repository->get_stats()['success_rate'] : 0,
             ),
             'last_success' => $last_success,
             'retry_pending' => ($queue_depth['aips_retry_failed_author_slices_topics'] + $queue_depth['aips_retry_failed_author_slices_posts']) > 0,
@@ -222,14 +222,17 @@ class AIPS_Schedule_Controller {
             $new_next_run = $interval_calculator->calculate_next_run($frequency, $now);
 
             if ($type === AIPS_Unified_Schedule_Service::TYPE_TEMPLATE) {
-                $this->schedule_repository->update_next_run($id, $new_next_run);
-                $renewed_count++;
+                if ($this->schedule_repository->update_next_run($id, $new_next_run) !== false) {
+                    $renewed_count++;
+                }
             } elseif ($type === AIPS_Unified_Schedule_Service::TYPE_AUTHOR_TOPIC) {
-                $authors_repo->update_topic_generation_schedule($id, $new_next_run);
-                $renewed_count++;
+                if ($authors_repo->update_topic_generation_schedule($id, $new_next_run) !== false) {
+                    $renewed_count++;
+                }
             } elseif ($type === AIPS_Unified_Schedule_Service::TYPE_AUTHOR_POST) {
-                $authors_repo->update_post_generation_schedule($id, $new_next_run);
-                $renewed_count++;
+                if ($authors_repo->update_post_generation_schedule($id, $new_next_run) !== false) {
+                    $renewed_count++;
+                }
             }
         }
 

--- a/ai-post-scheduler/includes/class-aips-template-repository.php
+++ b/ai-post-scheduler/includes/class-aips-template-repository.php
@@ -199,6 +199,18 @@ class AIPS_Template_Repository {
         $result = $this->wpdb->insert($this->table_name, $insert_data, $format);
         
         if ( $result ) {
+            $template_id = $this->wpdb->insert_id;
+            if ( !empty($data['campaign_id']) ) {
+                $table_campaign_templates = $this->wpdb->prefix . 'aips_campaign_templates';
+                $this->wpdb->insert(
+                    $table_campaign_templates,
+                    array(
+                        'campaign_id' => absint($data['campaign_id']),
+                        'template_id' => $template_id,
+                    ),
+                    array('%d', '%d')
+                );
+            }
             $this->cache->flush();
         }
 
@@ -329,6 +341,27 @@ class AIPS_Template_Repository {
         ) !== false;
 
         if ( $result ) {
+            if ( isset($data['campaign_id']) ) {
+                $campaign_id = !empty($data['campaign_id']) ? absint($data['campaign_id']) : 0;
+                $table_campaign_templates = $this->wpdb->prefix . 'aips_campaign_templates';
+                if ($campaign_id > 0) {
+                    $exists = $this->wpdb->get_var($this->wpdb->prepare(
+                        "SELECT COUNT(*) FROM {$table_campaign_templates} WHERE campaign_id = %d AND template_id = %d",
+                        $campaign_id,
+                        $id
+                    ));
+                    if (!$exists) {
+                        $this->wpdb->insert(
+                            $table_campaign_templates,
+                            array(
+                                'campaign_id' => $campaign_id,
+                                'template_id' => $id,
+                            ),
+                            array('%d', '%d')
+                        );
+                    }
+                }
+            }
             $this->cache->flush();
         }
 
@@ -342,6 +375,8 @@ class AIPS_Template_Repository {
      * @return bool True on success, false on failure.
      */
     public function delete($id) {
+        $table_campaign_templates = $this->wpdb->prefix . 'aips_campaign_templates';
+        $this->wpdb->delete($table_campaign_templates, array('template_id' => $id), array('%d'));
         $result = $this->wpdb->delete($this->table_name, array('id' => $id), array('%d')) !== false;
         if ( $result ) {
             $this->cache->flush();
@@ -356,8 +391,12 @@ class AIPS_Template_Repository {
      * @return int
      */
     public function count_by_campaign($campaign_id) {
+        $table_campaign_templates = $this->wpdb->prefix . 'aips_campaign_templates';
         return (int) $this->wpdb->get_var($this->wpdb->prepare(
-            "SELECT COUNT(*) FROM {$this->table_name} WHERE campaign_id = %d",
+            "SELECT COUNT(*) 
+            FROM {$this->table_name} t
+            INNER JOIN {$table_campaign_templates} ct ON t.id = ct.template_id
+            WHERE ct.campaign_id = %d",
             absint($campaign_id)
         ));
     }

--- a/ai-post-scheduler/includes/class-aips-template-repository.php
+++ b/ai-post-scheduler/includes/class-aips-template-repository.php
@@ -329,6 +329,12 @@ class AIPS_Template_Repository {
             return false;
         }
 
+        $old_campaign_id = 0;
+        if ( isset($data['campaign_id']) ) {
+            $current_template = $this->get_by_id($id);
+            $old_campaign_id = $current_template ? (int) $current_template->campaign_id : 0;
+        }
+
         $update_data['updated_at'] = AIPS_DateTime::now()->timestamp();
         $format[] = '%d';
         
@@ -342,19 +348,19 @@ class AIPS_Template_Repository {
 
         if ( $result ) {
             if ( isset($data['campaign_id']) ) {
-                $campaign_id = !empty($data['campaign_id']) ? absint($data['campaign_id']) : 0;
-                $table_campaign_templates = $this->wpdb->prefix . 'aips_campaign_templates';
-                if ($campaign_id > 0) {
-                    $exists = $this->wpdb->get_var($this->wpdb->prepare(
-                        "SELECT COUNT(*) FROM {$table_campaign_templates} WHERE campaign_id = %d AND template_id = %d",
-                        $campaign_id,
-                        $id
-                    ));
-                    if (!$exists) {
+                $new_campaign_id = !empty($data['campaign_id']) ? absint($data['campaign_id']) : 0;
+                if ($new_campaign_id !== $old_campaign_id) {
+                    $table_campaign_templates = $this->wpdb->prefix . 'aips_campaign_templates';
+                    $this->wpdb->delete(
+                        $table_campaign_templates,
+                        array('template_id' => $id),
+                        array('%d')
+                    );
+                    if ($new_campaign_id > 0) {
                         $this->wpdb->insert(
                             $table_campaign_templates,
                             array(
-                                'campaign_id' => $campaign_id,
+                                'campaign_id' => $new_campaign_id,
                                 'template_id' => $id,
                             ),
                             array('%d', '%d')

--- a/ai-post-scheduler/includes/class-aips-templates-controller.php
+++ b/ai-post-scheduler/includes/class-aips-templates-controller.php
@@ -123,6 +123,7 @@ class AIPS_Templates_Controller {
                 ? wp_json_encode(array_map('absint', $_POST['source_group_ids']))
                 : wp_json_encode(array()),
             'is_active' => isset($_POST['is_active']) ? 1 : 0,
+            'campaign_id' => isset($_POST['campaign_id']) ? absint($_POST['campaign_id']) : 0,
         );
 
         if (empty(trim($data['name'])) || empty(trim($data['prompt_template']))) {
@@ -176,7 +177,18 @@ class AIPS_Templates_Controller {
 
         $template = $this->templates->get($id);
 
-        if ($template && !empty($template->campaign_id)) {
+        global $wpdb;
+        $table_campaign_templates = $wpdb->prefix . 'aips_campaign_templates';
+        $linked_campaigns = 0;
+        $table_exists = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table_campaign_templates));
+        if ($table_exists === $table_campaign_templates) {
+            $linked_campaigns = (int) $wpdb->get_var($wpdb->prepare(
+                "SELECT COUNT(*) FROM {$table_campaign_templates} WHERE template_id = %d",
+                $id
+            ));
+        }
+
+        if ($linked_campaigns > 0 || ($template && !empty($template->campaign_id))) {
             AIPS_Ajax_Response::error(__('This template cannot be deleted here because it belongs to a campaign. Delete it from the Campaigns page.', 'ai-post-scheduler'));
         }
 
@@ -309,6 +321,7 @@ class AIPS_Templates_Controller {
             'post_category' => $this->extract_post_categories( isset($_POST['post_category']) ? $_POST['post_category'] : null ),
             'post_tags' => isset($_POST['post_tags']) ? sanitize_text_field(wp_unslash($_POST['post_tags'])) : '',
             'post_author' => isset($_POST['post_author']) ? absint($_POST['post_author']) : get_current_user_id(),
+            'campaign_id' => isset($_POST['campaign_id']) ? absint($_POST['campaign_id']) : 0,
         );
 
         if (empty(trim($data['prompt_template']))) {

--- a/ai-post-scheduler/templates/admin/automations.php
+++ b/ai-post-scheduler/templates/admin/automations.php
@@ -34,7 +34,7 @@ if (!defined('ABSPATH')) {
 			<?php endforeach; ?>
 		</div>
 
-		<div class="aips-automations-tab-content">
+		<div class="aips-automations-tab-content aips-page-tab-panel">
 			<?php $automations_controller->render_tab_content($active_tab); ?>
 		</div>
 	</div>

--- a/ai-post-scheduler/templates/admin/campaign-detail.php
+++ b/ai-post-scheduler/templates/admin/campaign-detail.php
@@ -9,6 +9,103 @@ if (!defined('ABSPATH')) {
 	exit;
 }
 
+/**
+ * Helper: render a human-readable frequency label.
+ */
+if (!function_exists('aips_frequency_label')) {
+	function aips_frequency_label($frequency) {
+		if (empty($frequency)) {
+			return __('—', 'ai-post-scheduler');
+		}
+		$schedules = wp_get_schedules();
+		if (isset($schedules[$frequency])) {
+			return $schedules[$frequency]['display'];
+		}
+		return ucfirst(str_replace('_', ' ', $frequency));
+	}
+}
+
+/**
+ * Helper: format a future/past timestamp as a relative countdown string.
+ * Returns e.g. "In 2 hours 15 minutes", "In 6 days 4 hours", or "Past due".
+ */
+if (!function_exists('aips_next_run_relative')) {
+	function aips_next_run_relative($timestamp) {
+		$diff = $timestamp - time();
+		if ($diff <= 0) {
+			return __('Past due', 'ai-post-scheduler');
+		}
+
+		$units = array(
+			array(
+				'seconds'  => DAY_IN_SECONDS,
+				'singular' => '%s day',
+				'plural'   => '%s days',
+			),
+			array(
+				'seconds'  => HOUR_IN_SECONDS,
+				'singular' => '%s hour',
+				'plural'   => '%s hours',
+			),
+			array(
+				'seconds'  => MINUTE_IN_SECONDS,
+				'singular' => '%s minute',
+				'plural'   => '%s minutes',
+			),
+		);
+		$parts = array();
+
+		foreach ($units as $unit) {
+			if ($diff < $unit['seconds']) {
+				continue;
+			}
+
+			$value = (int) floor($diff / $unit['seconds']);
+			if ($value <= 0) {
+				continue;
+			}
+
+			$parts[] = sprintf(
+				_n($unit['singular'], $unit['plural'], $value, 'ai-post-scheduler'),
+				number_format_i18n($value)
+			);
+			$diff -= $value * $unit['seconds'];
+
+			if (count($parts) === 2) {
+				break;
+			}
+		}
+
+		if (empty($parts)) {
+			$parts[] = sprintf(_n('%s minute', '%s minutes', 1, 'ai-post-scheduler'), '1');
+		}
+
+		/* translators: %s = human-readable time difference, e.g. "6 days 4 hours" */
+		return sprintf(__('In %s', 'ai-post-scheduler'), implode(' ', $parts));
+	}
+}
+
+/**
+ * Helper: normalize a DB date/time value to an AIPS_DateTime instance.
+ */
+if (!function_exists('aips_datetime_from_db_value')) {
+	function aips_datetime_from_db_value($value) {
+		if (empty($value) || '0000-00-00 00:00:00' === $value) {
+			return null;
+		}
+
+		if (is_numeric($value)) {
+			$timestamp = (int) $value;
+			if ($timestamp > 0 && $timestamp < AIPS_Date_Time_DB_Repair::MIN_VALID_TIMESTAMP) {
+				return null;
+			}
+			return AIPS_DateTime::fromTimestampOrNull($timestamp);
+		}
+
+		return AIPS_DateTime::fromMysqlOrNull((string) $value);
+	}
+}
+
 $campaigns_url       = admin_url('admin.php?page=aips-campaigns');
 $schedule_url        = add_query_arg(array('page' => 'aips-schedule', 'campaign_id' => absint($campaign->id)), admin_url('admin.php'));
 $generated_posts_url = add_query_arg(array('page' => 'aips-generated-posts', 'campaign_id' => absint($campaign->id)), admin_url('admin.php'));
@@ -188,16 +285,174 @@ $activity_summary = static function($details) {
 		</div>
 
 		<div class="aips-content-panel">
-			<div class="aips-filter-bar"><strong><?php esc_html_e('Owned Resources', 'ai-post-scheduler'); ?></strong></div>
-			<div class="aips-panel-body">
-				<p><strong><?php esc_html_e('Templates:', 'ai-post-scheduler'); ?></strong> <?php echo esc_html((int) count($templates)); ?></p>
-				<p><strong><?php esc_html_e('Schedules:', 'ai-post-scheduler'); ?></strong> <?php echo esc_html((int) count($schedules)); ?></p>
-				<?php if (!empty($templates)) : ?>
-					<ul>
-						<?php foreach ($templates as $template) : ?>
-							<li><a href="<?php echo esc_url(add_query_arg(array('page' => 'aips-templates', 'edit' => absint($template->id)), admin_url('admin.php'))); ?>"><?php echo esc_html($template->name); ?></a></li>
-						<?php endforeach; ?>
-					</ul>
+			<div class="aips-filter-bar" style="display: flex; justify-content: space-between; align-items: center;">
+				<strong><?php esc_html_e('Campaign Templates', 'ai-post-scheduler'); ?></strong>
+				<?php if (!empty($available_templates)) : ?>
+					<div class="aips-add-existing-template-container" style="display: flex; gap: 8px; align-items: center;">
+						<select id="aips-add-existing-template-select" style="max-width: 250px;">
+							<option value=""><?php esc_html_e('Select existing template...', 'ai-post-scheduler'); ?></option>
+							<?php foreach ($available_templates as $avail_temp) : ?>
+								<option value="<?php echo esc_attr($avail_temp->id); ?>"><?php echo esc_html($avail_temp->name); ?></option>
+							<?php endforeach; ?>
+						</select>
+						<button type="button" class="aips-btn aips-btn-secondary aips-btn-sm aips-link-existing-template-btn" data-campaign-id="<?php echo esc_attr(absint($campaign->id)); ?>">
+							<span class="dashicons dashicons-plus" style="margin-top: 3px;"></span>
+							<?php esc_html_e('Add Existing', 'ai-post-scheduler'); ?>
+						</button>
+					</div>
+				<?php endif; ?>
+			</div>
+			<div class="aips-panel-body no-padding">
+				<?php if (empty($templates)) : ?>
+					<p class="aips-muted" style="padding: 20px;"><?php esc_html_e('No templates associated with this campaign.', 'ai-post-scheduler'); ?></p>
+				<?php else : ?>
+					<table class="aips-table">
+						<thead>
+							<tr>
+								<th><?php esc_html_e('Template Name', 'ai-post-scheduler'); ?></th>
+								<th><?php esc_html_e('Post Status', 'ai-post-scheduler'); ?></th>
+								<th><?php esc_html_e('Status', 'ai-post-scheduler'); ?></th>
+								<th><?php esc_html_e('Actions', 'ai-post-scheduler'); ?></th>
+							</tr>
+						</thead>
+						<tbody>
+							<?php foreach ($templates as $template) : ?>
+								<tr>
+									<td class="column-name">
+										<div class="cell-primary">
+											<strong><?php echo esc_html($template->name); ?></strong>
+										</div>
+									</td>
+									<td>
+										<span class="aips-badge aips-badge-neutral">
+											<?php echo esc_html(ucfirst($template->post_status)); ?>
+										</span>
+									</td>
+									<td>
+										<?php if ($template->is_active): ?>
+										<span class="aips-badge aips-badge-success">
+											<span class="dashicons dashicons-yes-alt"></span>
+											<?php esc_html_e('Active', 'ai-post-scheduler'); ?>
+										</span>
+										<?php else: ?>
+										<span class="aips-badge aips-badge-neutral">
+											<span class="dashicons dashicons-minus"></span>
+											<?php esc_html_e('Inactive', 'ai-post-scheduler'); ?>
+										</span>
+										<?php endif; ?>
+									</td>
+									<td>
+										<div class="cell-actions">
+											<a class="aips-btn aips-btn-sm aips-btn-secondary" href="<?php echo esc_url(add_query_arg(array('page' => 'aips-templates', 'edit' => absint($template->id)), admin_url('admin.php'))); ?>">
+												<span class="dashicons dashicons-edit"></span>
+												<?php esc_html_e('Edit', 'ai-post-scheduler'); ?>
+											</a>
+											<button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-unlink-template-btn" data-campaign-id="<?php echo esc_attr(absint($campaign->id)); ?>" data-template-id="<?php echo esc_attr(absint($template->id)); ?>" data-template-name="<?php echo esc_attr($template->name); ?>" style="margin-left: 6px;">
+												<span class="dashicons dashicons-no-alt"></span>
+												<?php esc_html_e('Remove', 'ai-post-scheduler'); ?>
+											</button>
+										</div>
+									</td>
+								</tr>
+							<?php endforeach; ?>
+						</tbody>
+					</table>
+				<?php endif; ?>
+			</div>
+		</div>
+
+		<div class="aips-content-panel" style="margin-top: 20px;">
+			<div class="aips-filter-bar"><strong><?php esc_html_e('Campaign Schedules', 'ai-post-scheduler'); ?></strong></div>
+			<div class="aips-panel-body no-padding">
+				<?php if (empty($schedules)) : ?>
+					<p class="aips-muted" style="padding: 20px;"><?php esc_html_e('No schedules associated with this campaign.', 'ai-post-scheduler'); ?></p>
+				<?php else : ?>
+					<table class="aips-table">
+						<thead>
+							<tr>
+								<th><?php esc_html_e('Schedule Title', 'ai-post-scheduler'); ?></th>
+								<th><?php esc_html_e('Template', 'ai-post-scheduler'); ?></th>
+								<th><?php esc_html_e('Frequency', 'ai-post-scheduler'); ?></th>
+								<th><?php esc_html_e('Next Run', 'ai-post-scheduler'); ?></th>
+								<th><?php esc_html_e('Status', 'ai-post-scheduler'); ?></th>
+								<th><?php esc_html_e('Actions', 'ai-post-scheduler'); ?></th>
+							</tr>
+						</thead>
+						<tbody>
+							<?php foreach ($schedules as $schedule) : ?>
+								<?php
+								$next_run_dt = aips_datetime_from_db_value($schedule->next_run);
+								$next_run_ts = $next_run_dt ? $next_run_dt->timestamp() : 0;
+								$is_active = $schedule->is_active;
+								$status = $schedule->status;
+
+								switch ($status) {
+									case 'failed':
+										$badge_cls = 'aips-badge-error';
+										$icon_cls  = 'dashicons-warning';
+										$status_lbl = __('Failed', 'ai-post-scheduler');
+										break;
+									case 'inactive':
+										$badge_cls = 'aips-badge-neutral';
+										$icon_cls  = 'dashicons-minus';
+										$status_lbl = __('Paused', 'ai-post-scheduler');
+										break;
+									default:
+										$badge_cls = 'aips-badge-success';
+										$icon_cls  = 'dashicons-yes-alt';
+										$status_lbl = __('Active', 'ai-post-scheduler');
+								}
+								?>
+								<tr>
+									<td>
+										<div class="cell-primary">
+											<strong><?php echo esc_html($schedule->title ? $schedule->title : __('Untitled Schedule', 'ai-post-scheduler')); ?></strong>
+										</div>
+									</td>
+									<td>
+										<?php echo esc_html($schedule->template_name ? $schedule->template_name : __('Unknown Template', 'ai-post-scheduler')); ?>
+									</td>
+									<td>
+										<span class="aips-badge aips-badge-info">
+											<?php echo esc_html(aips_frequency_label($schedule->frequency)); ?>
+										</span>
+									</td>
+									<td>
+										<?php if (!$is_active): ?>
+											<span class="aips-muted"><?php esc_html_e('N/A', 'ai-post-scheduler'); ?></span>
+										<?php elseif ($next_run_ts): ?>
+											<div class="cell-primary aips-next-run-countdown" title="<?php echo esc_attr(date_i18n(get_option('date_format') . ' ' . get_option('time_format'), $next_run_ts)); ?>">
+												<?php echo esc_html(aips_next_run_relative($next_run_ts)); ?>
+											</div>
+											<div class="cell-meta aips-muted" style="font-size:11px;">
+												<?php echo esc_html(date_i18n(get_option('date_format') . ' ' . get_option('time_format'), $next_run_ts)); ?>
+											</div>
+										<?php else: ?>
+											<span class="aips-muted">—</span>
+										<?php endif; ?>
+									</td>
+									<td>
+										<span class="aips-badge <?php echo esc_attr($badge_cls); ?>">
+											<span class="dashicons <?php echo esc_attr($icon_cls); ?>"></span>
+											<?php echo esc_html($status_lbl); ?>
+										</span>
+									</td>
+									<td>
+										<div class="cell-actions">
+											<button class="aips-btn aips-btn-sm aips-btn-secondary aips-unified-run-now"
+												data-id="<?php echo esc_attr($schedule->id); ?>"
+												data-type="template_schedule"
+												aria-label="<?php esc_attr_e('Run now', 'ai-post-scheduler'); ?>"
+												title="<?php esc_attr_e('Run Now', 'ai-post-scheduler'); ?>">
+												<span class="dashicons dashicons-controls-play"></span>
+												<?php esc_html_e('Run Now', 'ai-post-scheduler'); ?>
+											</button>
+										</div>
+									</td>
+								</tr>
+							<?php endforeach; ?>
+						</tbody>
+					</table>
 				<?php endif; ?>
 			</div>
 		</div>

--- a/ai-post-scheduler/templates/admin/schedule.php
+++ b/ai-post-scheduler/templates/admin/schedule.php
@@ -619,3 +619,30 @@ if (!function_exists('aips_datetime_from_db_value')) {
 		</div>
 	</div>
 </div>
+
+<script type="text/html" id="aips-tmpl-schedule-status-card">
+	<div class="aips-schedule-status-card aips-schedule-status-card-{{tone}}">
+		<div class="aips-schedule-status-card-header">
+			<div class="aips-schedule-status-card-label">{{label}}</div>
+			{{iconHtml}}
+		</div>
+		<div class="aips-schedule-status-card-value">{{value}}</div>
+	</div>
+</script>
+
+<script type="text/html" id="aips-tmpl-schedule-overdue-banner">
+	<div class="aips-overdue-banner">
+		<div class="aips-overdue-banner-left">
+			<span class="dashicons dashicons-warning aips-overdue-icon" aria-hidden="true"></span>
+			<div class="aips-overdue-text">
+				<h4 class="aips-overdue-title">{{title}}</h4>
+				<p class="aips-overdue-desc">{{desc}}</p>
+			</div>
+		</div>
+		<div class="aips-overdue-banner-right">
+			<button type="button" class="aips-btn aips-btn-warning aips-renew-schedules-btn">
+				<span class="dashicons dashicons-update" aria-hidden="true"></span> {{btnLabel}}
+			</button>
+		</div>
+	</div>
+</script>

--- a/ai-post-scheduler/templates/admin/schedule.php
+++ b/ai-post-scheduler/templates/admin/schedule.php
@@ -188,11 +188,11 @@ if (!function_exists('aips_datetime_from_db_value')) {
 				<div id="aips-schedule-status-summary" class="aips-schedule-status-summary-cards"><?php esc_html_e('Loading schedule status…', 'ai-post-scheduler'); ?></div>
 				<div class="aips-schedule-status-columns">
 					<div class="aips-schedule-status-column">
-						<h3 class="aips-schedule-status-heading"><?php esc_html_e('Upcoming Schedule Runs (Next 24h)', 'ai-post-scheduler'); ?></h3>
+						<h3 class="aips-schedule-status-heading"><?php esc_html_e('Last Successful Runs', 'ai-post-scheduler'); ?></h3>
 						<div id="aips-schedule-status-timeline" class="aips-schedule-status-timeline"></div>
 					</div>
 					<div class="aips-schedule-status-column">
-						<h3 class="aips-schedule-status-heading"><?php esc_html_e('Worker Queue Jobs (Next 24h)', 'ai-post-scheduler'); ?></h3>
+						<h3 class="aips-schedule-status-heading"><?php esc_html_e('Next Scheduled Cycles', 'ai-post-scheduler'); ?></h3>
 						<div id="aips-schedule-status-queue-timeline" class="aips-schedule-status-timeline"></div>
 					</div>
 				</div>
@@ -643,6 +643,15 @@ if (!function_exists('aips_datetime_from_db_value')) {
 			<button type="button" class="aips-btn aips-btn-warning aips-renew-schedules-btn">
 				<span class="dashicons dashicons-update" aria-hidden="true"></span> {{btnLabel}}
 			</button>
+		</div>
+	</div>
+</script>
+
+<script type="text/html" id="aips-tmpl-schedule-status-row">
+	<div class="aips-schedule-status-event">
+		<div class="aips-schedule-status-event-top">
+			<span class="aips-badge aips-badge-neutral">{{label}}</span>
+			<span class="aips-schedule-status-event-time">{{time}}</span>
 		</div>
 	</div>
 </script>

--- a/ai-post-scheduler/templates/admin/schedule.php
+++ b/ai-post-scheduler/templates/admin/schedule.php
@@ -307,6 +307,7 @@ if (!function_exists('aips_datetime_from_db_value')) {
 						data-title="<?php echo esc_attr($sched['title']); ?>"
 						data-schedule-id="<?php echo esc_attr($sched['id']); ?>"
 						data-template-id="<?php echo esc_attr($sched['template_id'] ?? ''); ?>"
+						data-campaign-id="<?php echo esc_attr($sched['campaign_id'] ?? ''); ?>"
 						data-frequency="<?php echo esc_attr($sched['frequency'] ?? ''); ?>"
 						data-topic="<?php echo esc_attr($sched['topic'] ?? ''); ?>"
 						data-article-structure-id="<?php echo esc_attr($sched['article_structure_id'] ?? ''); ?>"
@@ -411,6 +412,7 @@ if (!function_exists('aips_datetime_from_db_value')) {
 									title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>"
 									data-schedule-id="<?php echo esc_attr($sched['id']); ?>"
 									data-template-id="<?php echo esc_attr($sched['template_id'] ?? ''); ?>"
+									data-campaign-id="<?php echo esc_attr($sched['campaign_id'] ?? ''); ?>"
 									data-title="<?php echo esc_attr($sched['title']); ?>"
 									data-frequency="<?php echo esc_attr($sched['frequency']); ?>"
 									data-topic="<?php echo esc_attr($sched['topic'] ?? ''); ?>"
@@ -578,6 +580,15 @@ if (!function_exists('aips_datetime_from_db_value')) {
 						<option value=""><?php esc_html_e('No Rotation', 'ai-post-scheduler'); ?></option>
 						<?php foreach ($rotation_patterns as $key => $label): ?>
 						<option value="<?php echo esc_attr($key); ?>"><?php echo esc_html($label); ?></option>
+						<?php endforeach; ?>
+					</select>
+				</div>
+				<div class="aips-form-row">
+					<label for="schedule_campaign_id"><?php esc_html_e('Campaign (Optional)', 'ai-post-scheduler'); ?></label>
+					<select id="schedule_campaign_id" name="campaign_id">
+						<option value=""><?php esc_html_e('None (No Campaign)', 'ai-post-scheduler'); ?></option>
+						<?php foreach ($campaign_options as $campaign_opt): ?>
+						<option value="<?php echo esc_attr($campaign_opt->id); ?>"><?php echo esc_html($campaign_opt->name); ?></option>
 						<?php endforeach; ?>
 					</select>
 				</div>

--- a/ai-post-scheduler/templates/admin/templates.php
+++ b/ai-post-scheduler/templates/admin/templates.php
@@ -536,6 +536,19 @@ $is_embedded_templates_view = !empty($embedded);
                         </div>
                         
                         <div class="aips-form-row">
+                            <label for="template_campaign_id"><?php esc_html_e('Campaign (Optional)', 'ai-post-scheduler'); ?></label>
+                            <select id="template_campaign_id" name="campaign_id">
+                                <option value=""><?php esc_html_e('None (No Campaign)', 'ai-post-scheduler'); ?></option>
+                                <?php foreach ($campaign_options as $campaign_opt): ?>
+                                <option value="<?php echo esc_attr($campaign_opt->id); ?>">
+                                    <?php echo esc_html($campaign_opt->name); ?>
+                                </option>
+                                <?php endforeach; ?>
+                            </select>
+                            <p class="description"><?php esc_html_e('Associate this template with a Campaign.', 'ai-post-scheduler'); ?></p>
+                        </div>
+                        
+                        <div class="aips-form-row">
                             <label for="post_tags"><?php esc_html_e('Tags', 'ai-post-scheduler'); ?></label>
                             <input type="text" id="post_tags" name="post_tags" class="regular-text" placeholder="<?php esc_attr_e('tag1, tag2, tag3', 'ai-post-scheduler'); ?>">
                             <p class="description"><?php esc_html_e('Comma-separated list of tags', 'ai-post-scheduler'); ?></p>

--- a/ai-post-scheduler/tests/Test_AIPS_Schedule_Controller_Renew.php
+++ b/ai-post-scheduler/tests/Test_AIPS_Schedule_Controller_Renew.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * Tests for AIPS_Schedule_Controller overdue schedules renewal AJAX endpoint.
+ *
+ * @package AI_Post_Scheduler
+ */
+
+class Test_AIPS_Schedule_Controller_Renew extends WP_Ajax_UnitTestCase {
+
+	/** @var AIPS_Schedule_Controller */
+	private $controller;
+
+	/** @var int */
+	private $admin_user_id;
+
+	/** @var int */
+	private $editor_user_id;
+
+	/** @var int */
+	private $template_id;
+
+	/** @var int[] */
+	private $created_schedule_ids = array();
+
+	/** @var int[] */
+	private $created_author_ids = array();
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->admin_user_id  = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$this->editor_user_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+
+		// Create a test template
+		global $wpdb;
+		$wpdb->insert(
+			$wpdb->prefix . 'aips_templates',
+			array(
+				'name'            => 'Test Template for Renew',
+				'prompt_template' => 'Write about {{topic}}',
+				'is_active'       => 1,
+			)
+		);
+		$this->template_id = (int) $wpdb->insert_id;
+
+		$this->controller = new AIPS_Schedule_Controller();
+	}
+
+	public function tearDown(): void {
+		global $wpdb;
+
+		// Clean up schedules
+		if ( ! empty( $this->created_schedule_ids ) ) {
+			$ids_placeholders = implode( ',', array_fill( 0, count( $this->created_schedule_ids ), '%d' ) );
+			$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}aips_schedule WHERE id IN ($ids_placeholders)", $this->created_schedule_ids ) );
+		}
+
+		// Clean up template
+		$wpdb->delete( $wpdb->prefix . 'aips_templates', array( 'id' => $this->template_id ), array( '%d' ) );
+
+		// Clean up authors
+		if ( ! empty( $this->created_author_ids ) ) {
+			$ids_placeholders = implode( ',', array_fill( 0, count( $this->created_author_ids ), '%d' ) );
+			$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}aips_authors WHERE id IN ($ids_placeholders)", $this->created_author_ids ) );
+		}
+
+		$_POST    = array();
+		$_REQUEST = array();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Call a controller method and capture its JSON output.
+	 *
+	 * @param callable $callable Controller callback.
+	 * @return array Decoded JSON response.
+	 */
+	private function call_ajax( callable $callable ) {
+		ob_start();
+		try {
+			$callable();
+		} catch ( WPAjaxDieContinueException $e ) {
+			// Expected when wp_send_json_* is called.
+		} catch ( WPAjaxDieStopException $e ) {
+			// Expected for early exits.
+		}
+
+		$output = ob_get_clean();
+
+		return json_decode( strtok( trim( $output ), "\r\n" ), true );
+	}
+
+	public function test_ajax_renew_overdue_schedules_unauthorized_for_non_admins() {
+		wp_set_current_user( $this->editor_user_id );
+
+		$_POST = array(
+			'nonce' => wp_create_nonce( 'aips_ajax_nonce' ),
+		);
+		$_REQUEST = $_POST;
+
+		$response = $this->call_ajax( array( $this->controller, 'ajax_renew_overdue_schedules' ) );
+
+		$this->assertFalse( $response['success'] );
+		$this->assertEquals( 'Unauthorized.', $response['data']['message'] );
+	}
+
+	public function test_ajax_renew_overdue_schedules_invalid_nonce() {
+		wp_set_current_user( $this->admin_user_id );
+
+		$_POST = array(
+			'nonce' => 'invalid-nonce-value',
+		);
+		$_REQUEST = $_POST;
+
+		$response = $this->call_ajax( array( $this->controller, 'ajax_renew_overdue_schedules' ) );
+
+		$this->assertFalse( $response['success'] );
+		$this->assertEquals( 'Invalid nonce.', $response['data']['message'] );
+	}
+
+	public function test_ajax_renew_overdue_schedules_success() {
+		wp_set_current_user( $this->admin_user_id );
+		global $wpdb;
+
+		$now = time();
+		$one_hour_ago = $now - 3600;
+		$two_hours_future = $now + 7200;
+
+		// 1. Insert overdue template schedule (next_run set to 1 hour ago)
+		$wpdb->insert(
+			$wpdb->prefix . 'aips_schedule',
+			array(
+				'template_id' => $this->template_id,
+				'frequency'   => 'daily',
+				'next_run'    => $one_hour_ago,
+				'is_active'   => 1,
+				'topic'       => 'Overdue Template Topic',
+			)
+		);
+		$overdue_schedule_id = (int) $wpdb->insert_id;
+		$this->created_schedule_ids[] = $overdue_schedule_id;
+
+		// 2. Insert future template schedule (next_run set to 2 hours in the future)
+		$wpdb->insert(
+			$wpdb->prefix . 'aips_schedule',
+			array(
+				'template_id' => $this->template_id,
+				'frequency'   => 'daily',
+				'next_run'    => $two_hours_future,
+				'is_active'   => 1,
+				'topic'       => 'Future Template Topic',
+			)
+		);
+		$future_schedule_id = (int) $wpdb->insert_id;
+		$this->created_schedule_ids[] = $future_schedule_id;
+
+		// 3. Insert author with overdue topic generation (topic_generation_next_run set to 1 hour ago)
+		$wpdb->insert(
+			$wpdb->prefix . 'aips_authors',
+			array(
+				'name'                          => 'Overdue Topic Author',
+				'field_niche'                   => 'Technology',
+				'is_active'                     => 1,
+				'topic_generation_frequency'    => 'daily',
+				'topic_generation_next_run'     => $one_hour_ago,
+				'topic_generation_is_active'    => 1,
+			)
+		);
+		$overdue_author_topic_id = (int) $wpdb->insert_id;
+		$this->created_author_ids[] = $overdue_author_topic_id;
+
+		// 4. Insert author with overdue post generation (post_generation_next_run set to 1 hour ago)
+		$wpdb->insert(
+			$wpdb->prefix . 'aips_authors',
+			array(
+				'name'                         => 'Overdue Post Author',
+				'field_niche'                  => 'Science',
+				'is_active'                    => 1,
+				'post_generation_frequency'   => 'daily',
+				'post_generation_next_run'    => $one_hour_ago,
+				'post_generation_is_active'   => 1,
+			)
+		);
+		$overdue_author_post_id = (int) $wpdb->insert_id;
+		$this->created_author_ids[] = $overdue_author_post_id;
+
+		$_POST = array(
+			'nonce' => wp_create_nonce( 'aips_ajax_nonce' ),
+		);
+		$_REQUEST = $_POST;
+
+		$response = $this->call_ajax( array( $this->controller, 'ajax_renew_overdue_schedules' ) );
+
+		$this->assertTrue( $response['success'] );
+		$this->assertGreaterThanOrEqual( 3, $response['data']['renewed_count'] );
+
+		// Assertions: Overdue schedule updated to future
+		$updated_overdue_sched = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}aips_schedule WHERE id = %d", $overdue_schedule_id ) );
+		$this->assertGreaterThan( $now, (int) $updated_overdue_sched->next_run );
+
+		// Assertions: Future schedule is unchanged
+		$updated_future_sched = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}aips_schedule WHERE id = %d", $future_schedule_id ) );
+		$this->assertEquals( $two_hours_future, (int) $updated_future_sched->next_run );
+
+		// Assertions: Overdue author topic generation updated to future
+		$updated_author_topic = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}aips_authors WHERE id = %d", $overdue_author_topic_id ) );
+		$this->assertGreaterThan( $now, (int) $updated_author_topic->topic_generation_next_run );
+
+		// Assertions: Overdue author post generation updated to future
+		$updated_author_post = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}aips_authors WHERE id = %d", $overdue_author_post_id ) );
+		$this->assertGreaterThan( $now, (int) $updated_author_post->post_generation_next_run );
+	}
+}

--- a/ai-post-scheduler/tests/Test_AIPS_Schedule_Controller_Renew.php
+++ b/ai-post-scheduler/tests/Test_AIPS_Schedule_Controller_Renew.php
@@ -88,7 +88,7 @@ class Test_AIPS_Schedule_Controller_Renew extends WP_Ajax_UnitTestCase {
 
 		$output = ob_get_clean();
 
-		return json_decode( strtok( trim( $output ), "\r\n" ), true );
+		return json_decode( trim( $output ), true );
 	}
 
 	public function test_ajax_renew_overdue_schedules_unauthorized_for_non_admins() {

--- a/docs/page_tab_panel_guide.md
+++ b/docs/page_tab_panel_guide.md
@@ -1,0 +1,53 @@
+# Page Tab Panel Guide
+
+This guide explains how to use the seamless **Page Tab Panel** component in the AI Post Scheduler admin views. This design eliminates visual margins, gaps, and double borders, merging active navigation tabs directly into the white container body below them.
+
+---
+
+## Layout Architecture
+
+The layout relies on a parent tab bar immediately followed by a tab content wrapper.
+
+### HTML Structure
+To implement this layout, use the following markup pattern in your templates:
+
+```html
+<!-- Tab Navigation Bar -->
+<div class="aips-tab-nav">
+    <!-- Active Link -->
+    <a href="#" class="aips-tab-link active">Active Tab</a>
+    <!-- Inactive Link -->
+    <a href="#" class="aips-tab-link">Inactive Tab</a>
+</div>
+
+<!-- Page Tab Panel Wrapper -->
+<div class="aips-page-tab-panel">
+    <!-- Inner panels (if any) will have their outer border decoration stripped automatically -->
+    <div class="aips-content-panel">
+        <div class="aips-filter-bar">
+            <!-- Filter Actions -->
+        </div>
+        <div class="aips-panel-body">
+            <!-- Main Content / Table / Form -->
+        </div>
+    </div>
+</div>
+```
+
+---
+
+## Styling Rules (`admin.css`)
+
+The core styles are defined in `assets/css/admin.css` and handle:
+1. **Tabs Alignment**: Pulls active tabs down by `1px` using `margin-bottom: -1px` to sit on top of the tab nav's bottom border.
+2. **Seamless Border Blending**: Sets `border-bottom-color: var(--aips-white)` on the active tab, hiding the border segment beneath it.
+3. **Corner Rounding**: Restricts the panel's border-radius (`0 var(--aips-radius-lg) var(--aips-radius-lg) var(--aips-radius-lg)`) so that the top-left corner is sharp, aligning flush with the left edge of the tab menu.
+4. **Nested Flattening**: Automatically strips backgrounds, shadows, and outer borders from any nested `.aips-content-panel` elements inside `.aips-page-tab-panel`. Re-draws unified borders specifically around table components (`.aips-filter-bar`, `.aips-table`, `.tablenav`).
+
+---
+
+## How to Apply to a Page
+
+1. Ensure the tab wrapper has the class `aips-tab-nav` and the individual tabs have class `aips-tab-link`.
+2. Add the `aips-page-tab-panel` class to the container immediately following the `aips-tab-nav` block.
+3. If the page templates inside the tab utilize `.aips-content-panel` elements, do not remove them; the CSS automatically refactors their borders, padding, and backgrounds when nested.


### PR DESCRIPTION
## Summary
- What changed?
- Why now?

## Verification
- [ ] `composer test` (or targeted tests) run for changed behavior
- [ ] Manual verification completed for changed admin/runtime paths
- [ ] Documentation updated (if behavior or workflow changed)

## Risk Checklist
- [ ] Label `schema-change` applied when DB schema/version is touched
- [ ] Label `admin-ui` + `needs-browser-test` applied when admin UI is touched
- [ ] Label `ajax-registry` applied when AJAX handlers/registry are touched
- [ ] Label `cron` applied when cron/queue/retry paths are touched
- [ ] Label `generation-pipeline` applied when prompt/generation flow is touched
- [ ] Label `security-sensitive` applied when auth/nonce/capability/data-safety paths are touched
- [ ] Label duplicate-risk applied and addressed before merge
