### PR TITLE
🎨 Palette: Improve accessibility of taxonomy remove post button

### DIFF
--- a/.build/palette.md
+++ b/.build/palette.md
@@ -4,3 +4,9 @@
 ## 2026-05-30 - Added loading indicator when editing authors
 **Learning:** AJAX-driven edit modals within this repo can sometimes appear with empty fields while data is still loading, creating a confusing user experience. The standard pattern to solve this is to use the existing WordPress admin `.spinner` element within a loader container.
 **Action:** For future modal-based edit features, ensure a loader container is added alongside the form, and use JavaScript to hide the form and show the loader during the AJAX fetch phase. Only reveal the form when the data has successfully populated.
+## 2024-05-30 - Added missing aria-label to remove post button
+**Area:** Taxonomy Admin Template (`ai-post-scheduler/templates/admin/taxonomy.php`)
+**Status:** opened PR
+**PR:** [To be created]
+**Learning:** JS HTML templates (using `<script type="text/html">`) often contain icon-only buttons (like `&times;`) that lack `aria-label` attributes because they are dynamically populated.
+**Action:** When auditing WordPress admin pages for accessibility, check the inline JS templates for icon-only buttons that are missing `aria-label` attributes and provide them via `esc_attr_e()`.

--- a/ai-post-scheduler/templates/admin/taxonomy.php
+++ b/ai-post-scheduler/templates/admin/taxonomy.php
@@ -231,6 +231,6 @@ $is_embedded_taxonomy_view = !empty($embedded);
 <script type="text/html" id="aips-tmpl-selected-post">
 <div class="aips-selected-post" data-post-id="{{id}}">
 	<span>{{title}}</span>
-	<button type="button" class="aips-remove-post" data-post-id="{{id}}">&times;</button>
+	<button type="button" class="aips-remove-post" data-post-id="{{id}}" aria-label="<?php esc_attr_e('Remove post', 'ai-post-scheduler'); ?>">&times;</button>
 </div>
 </script>


### PR DESCRIPTION
**What:** 
Added an `aria-label` attribute to the `.aips-remove-post` icon-only button within the dynamic JS template in `ai-post-scheduler/templates/admin/taxonomy.php`.

**Why:** 
The remove button only contained an `&times;` (×) character, which lacks accessible context for screen readers when managing selected posts in the Taxonomy generator UI.

**Accessibility:** 
Provides clear screen reader context ("Remove post") to an otherwise unlabelled icon-only action.

**Verification:** 
Verified the HTML output within `taxonomy.php` templates logic contains the translated `aria-label` attribute via `git diff` and checked the layout remains unaffected. Also ran `composer test`.

---
*PR created automatically by Jules for task [1064496148724306823](https://jules.google.com/task/1064496148724306823) started by @rpnunez*