### PR TITLE
⚡ Bolt: Hoist date and time format options outside of loops in generated posts controller

### DIFF
--- a/ai-post-scheduler/.build/bolt.md
+++ b/ai-post-scheduler/.build/bolt.md
@@ -1,0 +1,6 @@
+## 2024-06-08 - Hoist get_option in Generated Posts Controller
+**Area:** ai-post-scheduler/includes/class-aips-generated-posts-controller.php
+**Status:** opened PR
+**PR:** ⚡ Bolt: Hoist date and time format options outside of loops in generated posts controller
+**Learning:** Hoisting get_option('date_format') and get_option('time_format') out of loops reduces redundant DB queries and function calls.
+**Action:** Always check loops for repeated WP option calls and extract them into variables.

--- a/ai-post-scheduler/includes/class-aips-generated-posts-controller.php
+++ b/ai-post-scheduler/includes/class-aips-generated-posts-controller.php
@@ -90,6 +90,11 @@ class AIPS_Generated_Posts_Controller {
 			'fields' => 'list', // Explicitly use lightweight list fields for UI listing
 		));
 		
+		// Hoist date/time format lookups outside of loops to prevent N+1 query overhead
+		$date_format = get_option('date_format');
+		$time_format = get_option('time_format');
+		$datetime_format = $date_format . ' ' . $time_format;
+
 		// Get schedule data for each post
 		$posts_data = array();
 		foreach ($history['items'] as $item) {
@@ -120,9 +125,9 @@ class AIPS_Generated_Posts_Controller {
 				'history_id' => $item->id,
 				'post_id' => $item->post_id,
 				'title' => $post->post_title,
-				'date_generated' => AIPS_DateTime::formatRelativeOrAbsolute($item->created_at, get_option('date_format') . ' ' . get_option('time_format')),
-				'date_published' => AIPS_DateTime::formatRelativeOrAbsolute($published_timestamp, get_option('date_format') . ' ' . get_option('time_format')),
-				'date_scheduled' => AIPS_DateTime::formatRelativeOrAbsolute($schedule ? $schedule->next_run : null, get_option('date_format') . ' ' . get_option('time_format')),
+				'date_generated' => AIPS_DateTime::formatRelativeOrAbsolute($item->created_at, $datetime_format),
+				'date_published' => AIPS_DateTime::formatRelativeOrAbsolute($published_timestamp, $datetime_format),
+				'date_scheduled' => AIPS_DateTime::formatRelativeOrAbsolute($schedule ? $schedule->next_run : null, $datetime_format),
 				'edit_link' => esc_url_raw(get_edit_post_link($item->post_id)),
 				'source' => $source,
 			);
@@ -138,7 +143,7 @@ class AIPS_Generated_Posts_Controller {
 		// Pre-format dates for draft posts
 		if (!empty($draft_posts['items'])) {
 			foreach ($draft_posts['items'] as $item) {
-				$item->created_at_formatted = AIPS_DateTime::formatRelativeOrAbsolute($item->created_at, get_option('date_format') . ' ' . get_option('time_format'));
+				$item->created_at_formatted = AIPS_DateTime::formatRelativeOrAbsolute($item->created_at, $datetime_format);
 			}
 		}
 
@@ -165,8 +170,8 @@ class AIPS_Generated_Posts_Controller {
 				'history_id' => $item->id,
 				'post_id' => $item->post_id,
 				'title' => $post->post_title,
-			'date_generated' => AIPS_DateTime::formatRelativeOrAbsolute($item->created_at, get_option('date_format') . ' ' . get_option('time_format')),
-			'date_updated' => AIPS_DateTime::formatRelativeOrAbsolute($item->post_modified, get_option('date_format') . ' ' . get_option('time_format')),
+			'date_generated' => AIPS_DateTime::formatRelativeOrAbsolute($item->created_at, $datetime_format),
+			'date_updated' => AIPS_DateTime::formatRelativeOrAbsolute($item->post_modified, $datetime_format),
 				'edit_link' => esc_url_raw(get_edit_post_link($item->post_id)),
 				'post_status' => $item->post_status,
 				'is_currently_incomplete' => ('true' === (string) $item->is_currently_incomplete),


### PR DESCRIPTION
**What:** Hoisted the `get_option('date_format')` and `get_option('time_format')` calls outside of `foreach` loops in `AIPS_Generated_Posts_Controller::render_page`.

**Why:** To address the bottleneck of N+1 redundant WP option database queries or object cache lookups that occurred for each iteration of generated posts, draft posts, and partial generations on the Generated Posts admin page. 

**Impact:** Improves admin page load time and reduces database overhead by avoiding multiple calls to fetch static standard options.

**Measurement:** Review the execution of `render_page`. `get_option` is called twice overall for date and time options instead of up to twice per looped item across three different lists. All related PHPUnit tests continue to pass seamlessly.

---
*PR created automatically by Jules for task [1583125766980698862](https://jules.google.com/task/1583125766980698862) started by @rpnunez*