### PR TITLE
⚡ Bolt: Prevent N+1 queries in authors and generated posts controllers

### DIFF
--- a/ai-post-scheduler/.build/bolt.md
+++ b/ai-post-scheduler/.build/bolt.md
@@ -4,3 +4,10 @@
 **PR:** ⚡ Bolt: Hoist date and time format options outside of loops in generated posts controller
 **Learning:** Hoisting get_option('date_format') and get_option('time_format') out of loops reduces redundant DB queries and function calls.
 **Action:** Always check loops for repeated WP option calls and extract them into variables.
+
+## 2024-06-11 - Prevent N+1 query in authors and generated posts
+**Area:** ai-post-scheduler/includes/class-aips-authors-controller.php, ai-post-scheduler/includes/class-aips-generated-posts-controller.php
+**Status:** opened PR
+**PR:** ⚡ Bolt: Prevent N+1 queries in authors and generated posts controllers
+**Learning:** Hoisting get_post lookups and priming post caches reduces redundant queries and improves AJAX response time.
+**Action:** Use _prime_post_caches for large loops containing get_post calls.

--- a/ai-post-scheduler/includes/class-aips-authors-controller.php
+++ b/ai-post-scheduler/includes/class-aips-authors-controller.php
@@ -365,6 +365,14 @@ class AIPS_Authors_Controller {
 		
 		$posts = $this->logs_repository->get_generated_posts_by_author($author_id);
 		
+		// Prime post caches to prevent N+1 queries
+		if (function_exists('_prime_post_caches')) {
+			$post_ids = array_filter(array_map(function($p) { return $p->post_id; }, $posts));
+			if (!empty($post_ids)) {
+				_prime_post_caches(array_unique($post_ids), false, true);
+			}
+		}
+
 		// Enrich with WordPress post data
 		foreach ($posts as &$post) {
 			if ($post->post_id) {
@@ -478,6 +486,19 @@ class AIPS_Authors_Controller {
 		// Get logs for this topic (UI display only — capped at 200 entries).
 		$logs = $this->logs_repository->get_by_topic($topic_id, 200);
 		
+		// Prime post caches to prevent N+1 queries
+		if (function_exists('_prime_post_caches')) {
+			$post_ids = array();
+			foreach ($logs as $log) {
+				if ($log->action === 'post_generated' && $log->post_id) {
+					$post_ids[] = $log->post_id;
+				}
+			}
+			if (!empty($post_ids)) {
+				_prime_post_caches(array_unique($post_ids), false, true);
+			}
+		}
+
 		$posts = array();
 		foreach ($logs as $log) {
 			// Only include post_generated logs with valid post IDs.

--- a/ai-post-scheduler/includes/class-aips-generated-posts-controller.php
+++ b/ai-post-scheduler/includes/class-aips-generated-posts-controller.php
@@ -95,6 +95,14 @@ class AIPS_Generated_Posts_Controller {
 		$time_format = get_option('time_format');
 		$datetime_format = $date_format . ' ' . $time_format;
 
+		// Prime post caches to prevent N+1 queries
+		if (function_exists('_prime_post_caches')) {
+			$post_ids = array_filter(array_map(function($item) { return $item->post_id; }, $history['items']));
+			if (!empty($post_ids)) {
+				_prime_post_caches(array_unique($post_ids), false, true);
+			}
+		}
+
 		// Get schedule data for each post
 		$posts_data = array();
 		foreach ($history['items'] as $item) {
@@ -154,6 +162,14 @@ class AIPS_Generated_Posts_Controller {
 			'author_id' => $author_id,
 			'template_id' => $template_id,
 		));
+
+		// Prime post caches to prevent N+1 queries
+		if (function_exists('_prime_post_caches')) {
+			$post_ids = array_filter(array_map(function($item) { return $item->post_id; }, $partial_generations['items']));
+			if (!empty($post_ids)) {
+				_prime_post_caches(array_unique($post_ids), false, true);
+			}
+		}
 
 		$partial_posts_data = array();
 		foreach ($partial_generations['items'] as $item) {


### PR DESCRIPTION
**What:** Implement cache prefetching (`_prime_post_caches`) before executing `get_post` in `foreach` loops inside `AIPS_Authors_Controller` and `AIPS_Generated_Posts_Controller`.
**Why:** Address the N+1 query performance bottleneck caused by repeatedly calling `get_post` within a loop on items that have not had their caches primed.
**Impact:** Significantly reduces the number of database queries during AJAX requests related to authors and generated posts displays, improving overall response time and backend load.
**Measurement:** A debug query monitor plugin (like Query Monitor) will show a noticeable reduction in the raw number of database SELECT statements when accessing the Authors or Generated Posts views in the admin dashboard.

---
*PR created automatically by Jules for task [17454157217462327397](https://jules.google.com/task/17454157217462327397) started by @rpnunez*