### PR TITLE
⚡ Bolt: Fix N+1 queries during bulk operations in generated posts admin

### DIFF
--- a/ai-post-scheduler/.build/bolt.md
+++ b/ai-post-scheduler/.build/bolt.md
@@ -4,3 +4,10 @@
 **PR:** ⚡ Bolt: Hoist date and time format options outside of loops in generated posts controller
 **Learning:** Hoisting get_option('date_format') and get_option('time_format') out of loops reduces redundant DB queries and function calls.
 **Action:** Always check loops for repeated WP option calls and extract them into variables.
+
+## 2024-06-13 - Fix N+1 queries in bulk operations
+**Area:** ai-post-scheduler/includes/class-aips-post-review.php
+**Status:** opened PR
+**PR:** ⚡ Bolt: Fix N+1 queries during bulk operations in generated posts admin
+**Learning:** Bulk operations looping over post IDs such as `get_post()` without pre-fetching cause N+1 queries. We can mitigate this by injecting `_prime_post_caches()` prior to the loop.
+**Action:** Always pre-fetch posts using `_prime_post_caches()` when dealing with arrays of IDs that will sequentially be retrieved via `get_post()`.

--- a/ai-post-scheduler/includes/class-aips-post-review.php
+++ b/ai-post-scheduler/includes/class-aips-post-review.php
@@ -311,6 +311,10 @@ class AIPS_Post_Review {
 		$success_count = 0;
 		$failed_count = 0;
 		
+		if (function_exists('_prime_post_caches') && !empty($post_ids)) {
+			_prime_post_caches(array_unique($post_ids), false, true);
+		}
+
 		foreach ($post_ids as $post_id) {
 			// Verify the post exists and is a draft
 			$post = get_post($post_id);
@@ -841,6 +845,17 @@ class AIPS_Post_Review {
 		
 		if (empty($items)) {
 			AIPS_Ajax_Response::error(__('No posts selected.', 'ai-post-scheduler'));
+		}
+
+		$post_ids_to_prime = array();
+		foreach ($items as $item) {
+			if (is_array($item) && !empty($item['post_id'])) {
+				$post_ids_to_prime[] = absint($item['post_id']);
+			}
+		}
+
+		if (function_exists('_prime_post_caches') && !empty($post_ids_to_prime)) {
+			_prime_post_caches(array_unique($post_ids_to_prime), false, true);
 		}
 		
 		// Create history container for bulk delete operation


### PR DESCRIPTION
**What:** Injected `_prime_post_caches()` before loops that repeatedly call `get_post($post_id)` inside the `AIPS_Post_Review` bulk AJAX endpoints (`ajax_bulk_publish_posts` and `ajax_bulk_delete_draft_posts`).

**Why:** To address severe N+1 database querying bottlenecks when a user triggers bulk publishing or deletion of multiple generated posts.

**Impact:** Performance is substantially improved by pre-fetching the post caching state into memory using a single `IN ()` query, drastically reducing database load.

**Measurement:** To verify, enable Query Monitor in WordPress, select several items in the 'Generated Posts' review queue, trigger a 'Bulk Publish' or 'Bulk Delete', and observe the reduced number of `SELECT * FROM wp_posts WHERE ID = X` queries vs earlier counts.

---
*PR created automatically by Jules for task [8078029397937776860](https://jules.google.com/task/8078029397937776860) started by @rpnunez*