### PR TITLE
⚡ Bolt: Hoist repeated get_option calls outside loops in campaigns admin templates

### DIFF
--- a/ai-post-scheduler/.build/bolt.md
+++ b/ai-post-scheduler/.build/bolt.md
@@ -4,3 +4,10 @@
 **PR:** ⚡ Bolt: Hoist date and time format options outside of loops in generated posts controller
 **Learning:** Hoisting get_option('date_format') and get_option('time_format') out of loops reduces redundant DB queries and function calls.
 **Action:** Always check loops for repeated WP option calls and extract them into variables.
+
+## 2026-10-14 - Hoist get_option in Campaigns Admin Templates
+**Area:** ai-post-scheduler/templates/admin/campaigns.php, campaign-detail.php, campaign-wizard.php
+**Status:** opened PR
+**PR:** ⚡ Bolt: Hoist repeated get_option calls outside loops in campaigns admin templates
+**Learning:** Hoisting get_option calls out of foreach loops and rendering closures reduces redundant database queries and function calls.
+**Action:** Always extract get_option and config queries outside loops and pass them to variables.

--- a/ai-post-scheduler/templates/admin/campaign-detail.php
+++ b/ai-post-scheduler/templates/admin/campaign-detail.php
@@ -24,12 +24,15 @@ if ((int) $campaign->is_archived === 1) {
 	$status_class = 'aips-badge-success';
 }
 
-$format_campaign_datetime = static function($timestamp, $empty_label) {
+$date_format = get_option('date_format');
+$time_format = get_option('time_format');
+
+$format_campaign_datetime = static function($timestamp, $empty_label) use ($date_format, $time_format) {
 	if (empty($timestamp)) {
 		return $empty_label;
 	}
 
-	return AIPS_DateTime::formatRelativeOrAbsolute($timestamp, get_option('date_format') . ' ' . get_option('time_format'));
+	return AIPS_DateTime::formatRelativeOrAbsolute($timestamp, $date_format . ' ' . $time_format);
 };
 
 $activity_summary = static function($details) {

--- a/ai-post-scheduler/templates/admin/campaign-wizard.php
+++ b/ai-post-scheduler/templates/admin/campaign-wizard.php
@@ -171,11 +171,13 @@ $authors = get_users(array(
 						</tr>
 						<tr>
 							<th scope="row"><label for="aips_article_structure_id"><?php esc_html_e('Article Structure', 'ai-post-scheduler'); ?></label></th>
-							<td><select id="aips_article_structure_id" name="article_structure_id"><option value="0"><?php esc_html_e('Default structure', 'ai-post-scheduler'); ?></option><?php foreach ($structures as $structure) : ?><option value="<?php echo esc_attr($structure->id); ?>" <?php selected($draft['article_structure_id'] ?? $aips_config->get_option('aips_default_article_structure_id'), $structure->id); ?>><?php echo esc_html($structure->name); ?></option><?php endforeach; ?></select></td>
+							<?php $default_structure = $aips_config->get_option('aips_default_article_structure_id'); ?>
+							<td><select id="aips_article_structure_id" name="article_structure_id"><option value="0"><?php esc_html_e('Default structure', 'ai-post-scheduler'); ?></option><?php foreach ($structures as $structure) : ?><option value="<?php echo esc_attr($structure->id); ?>" <?php selected($draft['article_structure_id'] ?? $default_structure, $structure->id); ?>><?php echo esc_html($structure->name); ?></option><?php endforeach; ?></select></td>
 						</tr>
 						<tr>
 							<th scope="row"><label for="aips_post_category"><?php esc_html_e('Category', 'ai-post-scheduler'); ?></label></th>
-							<td><select id="aips_post_category" name="post_category"><option value="0"><?php esc_html_e('Default category', 'ai-post-scheduler'); ?></option><?php foreach ($categories as $category) : ?><option value="<?php echo esc_attr($category->term_id); ?>" <?php selected($draft['post_category'] ?? $aips_config->get_option('aips_default_category'), $category->term_id); ?>><?php echo esc_html($category->name); ?></option><?php endforeach; ?></select></td>
+							<?php $default_category = $aips_config->get_option('aips_default_category'); ?>
+							<td><select id="aips_post_category" name="post_category"><option value="0"><?php esc_html_e('Default category', 'ai-post-scheduler'); ?></option><?php foreach ($categories as $category) : ?><option value="<?php echo esc_attr($category->term_id); ?>" <?php selected($draft['post_category'] ?? $default_category, $category->term_id); ?>><?php echo esc_html($category->name); ?></option><?php endforeach; ?></select></td>
 						</tr>
 						<tr>
 							<th scope="row"><label for="aips_post_tags"><?php esc_html_e('Tags', 'ai-post-scheduler'); ?></label></th>

--- a/ai-post-scheduler/templates/admin/campaigns.php
+++ b/ai-post-scheduler/templates/admin/campaigns.php
@@ -16,7 +16,10 @@ $archived_campaigns = $campaigns_repo->get_campaigns(true);
 $stats = $campaigns_repo->get_summary_stats();
 $is_embedded_campaigns_view = !empty($embedded);
 
-$render_campaign_rows = static function($campaigns, $archived = false) {
+$date_format = get_option('date_format');
+$time_format = get_option('time_format');
+
+$render_campaign_rows = static function($campaigns, $archived = false) use ($date_format, $time_format) {
 	foreach ($campaigns as $campaign) :
 		$is_running = !$archived && (int) $campaign->active_schedule_count > 0;
 		$status_label = $archived ? __('Archived', 'ai-post-scheduler') : ($is_running ? __('Active', 'ai-post-scheduler') : __('Paused', 'ai-post-scheduler'));
@@ -34,8 +37,8 @@ $render_campaign_rows = static function($campaigns, $archived = false) {
 					<?php echo esc_html((int) $campaign->generated_posts_count); ?>
 				</a>
 			</td>
-			<td><?php echo !empty($campaign->last_run) ? esc_html(AIPS_DateTime::formatRelativeOrAbsolute($campaign->last_run, get_option('date_format') . ' ' . get_option('time_format'))) : esc_html__('Never', 'ai-post-scheduler'); ?></td>
-			<td><?php echo !empty($campaign->next_run) ? esc_html(AIPS_DateTime::formatRelativeOrAbsolute($campaign->next_run, get_option('date_format') . ' ' . get_option('time_format'))) : esc_html__('Not scheduled', 'ai-post-scheduler'); ?></td>
+			<td><?php echo !empty($campaign->last_run) ? esc_html(AIPS_DateTime::formatRelativeOrAbsolute($campaign->last_run, $date_format . ' ' . $time_format)) : esc_html__('Never', 'ai-post-scheduler'); ?></td>
+			<td><?php echo !empty($campaign->next_run) ? esc_html(AIPS_DateTime::formatRelativeOrAbsolute($campaign->next_run, $date_format . ' ' . $time_format)) : esc_html__('Not scheduled', 'ai-post-scheduler'); ?></td>
 			<td>
 				<span class="aips-badge aips-badge-<?php echo esc_attr($status_class); ?>">
 					<?php echo esc_html($status_label); ?>


### PR DESCRIPTION
**What:**
Hoisted repeated `get_option('date_format')`, `get_option('time_format')`, and `$aips_config->get_option()` calls outside of `foreach` loops and closures in `templates/admin/campaigns.php`, `templates/admin/campaign-detail.php`, and `templates/admin/campaign-wizard.php`.

**Why:**
Repeatedly calling WP options or config properties inside list-rendering closures or array iterators creates unnecessary overhead (redundant function calls and potential DB reads/memory hits) when generating admin UI views. Pre-fetching these standard settings reduces N+1 query patterns in view layer rendering.

**Impact:**
Slightly faster load times and reduced CPU overhead when viewing the Campaigns list, Detail view, and Wizard view, especially on sites with large numbers of campaigns or system configurations.

**Measurement:**
Verify page loads without fatal errors. Compare query counts/timing in a profiler (like Query Monitor) when loading the `/wp-admin/admin.php?page=aips-campaigns` screens before and after the patch.

---
*PR created automatically by Jules for task [12689159688396521679](https://jules.google.com/task/12689159688396521679) started by @rpnunez*