### PR TITLE
Refactor: Clean up main plugin file, extract constants and core bootstrap to AIPS_Core

### DIFF
--- a/ai-post-scheduler/ai-post-scheduler.php
+++ b/ai-post-scheduler/ai-post-scheduler.php
@@ -15,849 +15,53 @@
  */
 
 if (!defined('ABSPATH')) {
-    exit;
+	exit;
 }
 
-// Capture the request start time as early as possible so AIPS_Telemetry
-// can compute an accurate elapsed-time measurement.
-if (!defined('AIPS_REQUEST_START')) {
-    define('AIPS_REQUEST_START', microtime(true));
+// Load constants.
+require_once plugin_dir_path(__FILE__) . 'includes/constants.php';
+
+// Bootstrap dependency loaders.
+// Primary autoloader: Composer-generated classmap.
+$vendor_autoload = AIPS_PLUGIN_DIR . 'vendor/autoload.php';
+if (file_exists($vendor_autoload)) {
+	require_once $vendor_autoload;
 }
 
-// Enable SAVEQUERIES as early as possible for telemetry-enabled requests so
-// slow/duplicate query analysis can inspect the collected query log.
-if (!defined('SAVEQUERIES') && function_exists('get_option') && get_option('aips_enable_telemetry', false)) {
-    define('SAVEQUERIES', true);
-}
+// Fallback shim: legacy autoloader.
+require_once AIPS_PLUGIN_DIR . 'includes/class-aips-autoloader.php';
+AIPS_Autoloader::register();
 
-if (!defined('AIPS_TELEMETRY_SLOW_QUERY_MS')) {
-    define('AIPS_TELEMETRY_SLOW_QUERY_MS', 100);
-}
-
-if (!defined('AIPS_TELEMETRY_SLOW_REQUEST_MS')) {
-    define('AIPS_TELEMETRY_SLOW_REQUEST_MS', 1500);
-}
-
-if (!defined('AIPS_TELEMETRY_QUERY_SAMPLE_LIMIT')) {
-    define('AIPS_TELEMETRY_QUERY_SAMPLE_LIMIT', 10);
-}
-
-// Define plugin constants
-if (!defined('AIPS_VERSION')) {
-    define('AIPS_VERSION', '2.9.1');
-}
-
-if (!defined('AIPS_PLUGIN_DIR')) {
-    define('AIPS_PLUGIN_DIR', plugin_dir_path(__FILE__));
-}
-
-if (!defined('AIPS_PLUGIN_URL')) {
-    define('AIPS_PLUGIN_URL', plugin_dir_url(__FILE__));
-}
-
-if (!defined('AIPS_PLUGIN_BASENAME')) {
-    define('AIPS_PLUGIN_BASENAME', plugin_basename(__FILE__));
-}
-
-// Prompt-preview logging can expose generated content in logs. Off by default;
-// opt-in by defining the constant to true earlier (e.g. in wp-config.php), or
-// it will automatically enable when WP_DEBUG is true.
-if (!defined('AIPS_AI_DEBUG_LOG_PROMPTS')) {
-    define('AIPS_AI_DEBUG_LOG_PROMPTS', defined('WP_DEBUG') && WP_DEBUG);
-}
-
+/**
+ * Backward compatibility class wrapper.
+ */
 final class AI_Post_Scheduler {
-    
-    /**
-     * @var AI_Post_Scheduler|null Singleton instance
-     */
-    private static $instance = null;
-
-    /**
-     * Get plugin cron definitions.
-     *
-     * @return array<string,array<string,string>>
-     */
-    public static function get_cron_events() {
-        return array(
-            'aips_generate_scheduled_posts' => array(
-                'schedule' => 'hourly',
-                'label'   => __( 'Post Generation', 'ai-post-scheduler' ),
-            ),
-            'aips_generate_author_topics' => array(
-                'schedule' => 'hourly',
-                'label'   => __( 'Author Topic Generation', 'ai-post-scheduler' ),
-            ),
-            'aips_generate_author_posts' => array(
-                'schedule' => 'hourly',
-                'label'   => __( 'Author Post Generation', 'ai-post-scheduler' ),
-            ),
-            'aips_scheduled_research' => array(
-                'schedule' => 'daily',
-                'label'   => __( 'Automated Research', 'ai-post-scheduler' ),
-            ),
-            'aips_notification_rollups' => array(
-                'schedule' => 'daily',
-                'label'   => __( 'Notification Rollups', 'ai-post-scheduler' ),
-            ),
-            'aips_cleanup_export_files' => array(
-                'schedule' => 'daily',
-                'label'   => __( 'Export Cleanup', 'ai-post-scheduler' ),
-            ),
-            'aips_fetch_sources' => array(
-                'schedule' => 'daily',
-                'label'   => __( 'Sources Fetch', 'ai-post-scheduler' ),
-            ),
-            'aips_cleanup_bulk_batch_jobs' => array(
-                'schedule' => 'daily',
-                'label'   => __( 'Bulk Batch Job Cleanup', 'ai-post-scheduler' ),
-            ),
-            'aips_cache_monitor_maintenance' => array(
-                'schedule' => 'daily',
-                'label'   => __( 'Cache Monitor Maintenance', 'ai-post-scheduler' ),
-            ),
-        );
-    }
-
-    /**
-     * Get the singleton instance.
-     *
-     * @return AI_Post_Scheduler
-     */
-    public static function get_instance() {
-        if (null === self::$instance) {
-            self::$instance = new self();
-        }
-        return self::$instance;
-    }
-
-    /**
-     * Construct the plugin bootstrap instance.
-     *
-     * Registers dependency checks, includes, and runtime hooks.
-     */
-    private function __construct() {
-        $this->check_dependencies();
-        $this->includes();
-        $this->init_hooks();
-    }
-
-    /**
-     * Register dependency checks for required runtime plugins.
-     *
-     * @return void
-     */
-    private function check_dependencies() {
-        add_action('admin_init', function() {
-            if (!class_exists('Meow_MWAI_Core')) {
-                add_action('admin_notices', function() {
-                    echo '<div class="notice notice-error"><p>';
-                    echo esc_html__('AI Post Scheduler requires Meow Apps AI Engine plugin to be installed and activated.', 'ai-post-scheduler');
-                    echo '</p></div>';
-                });
-            }
-        });
-    }
-
-    /**
-     * Load required bootstrap files.
-     *
-     * @return void
-     */
-    private function includes() {
-        // Primary autoloader: Composer-generated classmap (O(1) hash lookup, no filesystem hits).
-        $vendor_autoload = AIPS_PLUGIN_DIR . 'vendor/autoload.php';
-        
-        if ( file_exists( $vendor_autoload ) ) {
-            require_once $vendor_autoload;
-        }
-
-        // Fallback shim: the legacy autoloader handles any AIPS_ class that the
-        // Composer classmap does not resolve (e.g. on installs without a vendor/
-        // directory or after adding a new class before re-running composer dump-autoload).
-        require_once AIPS_PLUGIN_DIR . 'includes/class-aips-autoloader.php';
-        AIPS_Autoloader::register();
-
-        // Helpers
-        require_once AIPS_PLUGIN_DIR . 'includes/class-aips-admin-menu-helper.php';
-    }
-
-    /**
-     * Register plugin lifecycle and runtime hooks.
-     *
-     * @return void
-     */
-    private function init_hooks() {
-        add_action('plugins_loaded', array($this, 'check_upgrades'));
-        add_action('init', array($this, 'init'));
-    }
-
-    /**
-     * Handle plugin activation tasks.
-     *
-     * Seeds default options, runs upgrades/table checks, schedules cron events,
-     * and applies onboarding redirect logic for first-time installs.
-     *
-     * @return void
-     */
-    public function activate() {
-        // Ensure logger is available
-        if (!class_exists('AIPS_Logger')) {
-            require_once AIPS_PLUGIN_DIR . 'includes/class-aips-logger.php';
-        }
-
-        $logger = new AIPS_Logger();
-
-        $logger->log('Running plugin activation.');
-
-        // Detect a prior installation before set_default_options() writes defaults.
-        $previously_installed = AIPS_Config::get_instance()->has_option('aips_db_version');
-        $wizard_completed     = (bool) AIPS_Config::get_instance()->get_option('aips_onboarding_completed');
-
-        $this->set_default_options();
-
-        if ($previously_installed || $wizard_completed) {
-            // Plugin already had data or the wizard was already run — mark it
-            // complete so the wizard never resurfaces on future reactivations.
-            if (!$wizard_completed) {
-                update_option('aips_onboarding_completed', 1, false);
-            }
-        } else {
-            // Fresh install: redirect admins to the onboarding wizard once.
-            set_transient('aips_onboarding_redirect', 1, MINUTE_IN_SECONDS * 10);
-        }
-        $this->check_upgrades();
-
-        // Ensure tables exist even if version matches (e.g. re-activation after manual deletion or partial install)
-        $install_result = AIPS_DB_Manager::install_tables();
-
-        if (is_wp_error($install_result)) {
-            $logger->log('Table installation failed during activation: ' . $install_result->get_error_message(), 'error');
-
-            $notifications = class_exists('AIPS_Notifications') ? new AIPS_Notifications() : null;
-            if ($notifications instanceof AIPS_Notifications) {
-                $notifications->system_error(array(
-                    'title'         => __('Database installation failed', 'ai-post-scheduler'),
-                    'error_code'    => $install_result->get_error_code(),
-                    'error_message' => $install_result->get_error_message(),
-                    'url'           => admin_url('admin.php?page=aips-status'),
-                    'dedupe_key'    => 'db_install_failed_activation',
-                    'dedupe_window' => 1800,
-                ));
-            }
-        }
-        
-        $crons = self::get_cron_events();
-
-        foreach ($crons as $hook => $cron_config) {
-            $schedule = $cron_config['schedule'];
-            $logger->log("Checking cron: $hook");
-
-            if (!wp_next_scheduled($hook)) {
-                $logger->log("Cron '$hook' not scheduled. Scheduling now with schedule: '$schedule'.");
-
-                wp_schedule_event(time(), $schedule, $hook);
-                
-                $next_run = wp_next_scheduled($hook);
-
-                if ($next_run) {
-                    $logger->log("Successfully scheduled '$hook'. Next run: " . date('Y-m-d H:i:s', $next_run));
-                } else {
-                    $logger->log("Failed to schedule '$hook'. wp_next_scheduled returned false.", 'error');
-                }
-            } else {
-                $logger->log("Cron '$hook' is already scheduled.");
-            }
-        }
-        
-        flush_rewrite_rules();
-
-        $logger->log('Plugin activation finished.');
-    }
-
-    /**
-     * Run versioned upgrade checks.
-     *
-     * Called both on plugin activation (via activate()) and on every page load
-     * via the plugins_loaded hook. WordPress plugin auto-updates skip activation,
-     * so this must be self-contained: AIPS_DB_Migrations::check_and_run() runs
-     * migrations AND install_tables() (dbDelta) when an upgrade is detected,
-     * ensuring the schema is fully applied regardless of the call path.
-     *
-     * Call-order guarantee inside AIPS_DB_Migrations::run_upgrade() (must not change):
-     *   1. Versioned migrations run first — column renames/type changes/index ops
-     *      that dbDelta cannot perform. Schema must be consistent before dbDelta.
-     *   2. AIPS_DB_Manager::install_tables() (dbDelta) runs second — adds any new
-     *      tables/columns introduced in the current plugin version.
-     *
-     * Note: activate() also calls install_tables() directly afterward for the
-     * fresh-install / re-activation edge case. The double invocation is harmless
-     * because dbDelta is fully idempotent.
-     *
-     * @return void
-     */
-    public function check_upgrades() {
-        AIPS_DB_Migrations::check_and_run();
-    }
-
-    /**
-     * Handle plugin deactivation cleanup.
-     *
-     * @return void
-     */
-    public function deactivate() {
-        foreach (array_keys(self::get_cron_events()) as $hook) {
-            wp_clear_scheduled_hook($hook);
-        }
-        flush_rewrite_rules();
-    }
-
-    /**
-     * Seed plugin options with default values when missing.
-     *
-     * Uses AIPS_Config defaults as the source of truth and adds activation-
-     * specific values where required.
-     *
-     * @return void
-     */
-    private function set_default_options() {
-        $defaults = AIPS_Config::get_instance()->get_default_options();
-
-        // Activation-specific fallback: if unset in defaults, use admin email.
-        if (empty($defaults['aips_review_notifications_email'])) {
-            $defaults['aips_review_notifications_email'] = get_option('admin_email');
-        }
-
-        // Keep DB version initialization during activation.
-        $defaults['aips_db_version'] = AIPS_VERSION;
-        
-        foreach ($defaults as $key => $value) {
-            if (!AIPS_Config::get_instance()->has_option($key)) {
-                add_option($key, $value);
-            }
-        }
-    }
-
-    /**
-     * Register initial container bindings for core singletons.
-     *
-     * Phase 1 registration as described in the container architecture plan:
-     * Registers the most-duplicated singletons to validate the container works
-     * correctly before more complex refactors.
-     *
-     * @return void
-     */
-    private function register_container_bindings() {
-        $container = AIPS_Container::get_instance();
-
-        // Register AIPS_Config (uses get_instance() instead of instance())
-        $container->singleton(AIPS_Config::class, function( $container ) {
-            return AIPS_Config::get_instance();
-        });
-
-        // Register AIPS_History_Repository
-        $container->singleton(AIPS_History_Repository::class, function( $container ) {
-            return AIPS_History_Repository::instance();
-        });
-
-		$container->singleton(AIPS_History_Repository_Interface::class, function( $container ) {
-			return $container->make(AIPS_History_Repository::class);
-		});
-
-        // Register AIPS_History_Service
-        $container->singleton(AIPS_History_Service::class, function( $container ) {
-            return AIPS_History_Service::instance();
-        });
-
-		$container->singleton(AIPS_History_Service_Interface::class, function( $container ) {
-			return $container->make(AIPS_History_Service::class);
-		});
-
-        // Register AIPS_Notifications_Repository
-        $container->singleton(AIPS_Notifications_Repository::class, function( $container ) {
-            return AIPS_Notifications_Repository::instance();
-        });
-
-        $container->singleton(AIPS_Notifications_Repository_Interface::class, function( $container ) {
-            return $container->make(AIPS_Notifications_Repository::class);
-        });
-
-        $container->singleton(AIPS_Logger::class, function( $container ) {
-            return AIPS_Logger::instance();
-        });
-
-        $container->singleton(AIPS_Logger_Interface::class, function( $container ) {
-            return $container->make(AIPS_Logger::class);
-        });
-
-        $container->singleton(AIPS_AI_Service::class, function( $container ) {
-            return AIPS_AI_Service::instance();
-        });
-
-        $container->singleton(AIPS_AI_Service_Interface::class, function( $container ) {
-            return $container->make(AIPS_AI_Service::class);
-        });
-
-        $container->singleton(AIPS_Schedule_Repository::class, function( $container ) {
-            return AIPS_Schedule_Repository::instance();
-        });
-
-        $container->singleton(AIPS_Schedule_Repository_Interface::class, function( $container ) {
-            return $container->make(AIPS_Schedule_Repository::class);
-        });
-
-        $container->singleton(AIPS_Telemetry_Repository::class, function( $container ) {
-            return AIPS_Telemetry_Repository::instance();
-        });
-
-        // Register AIPS_Template_Repository
-        $container->singleton(AIPS_Template_Repository::class, function( $container ) {
-            return AIPS_Template_Repository::instance();
-        });
-    }
-
-    /**
-     * Register thin lazy-resolving wp_ajax_* hooks for all actions in the registry.
-     *
-     * Each closure registered at priority 5 removes itself and then constructs the
-     * correct controller (which registers its own handler at the default priority 10).
-     * WordPress continues iterating priorities after priority 5 completes, so the
-     * controller's handler at priority 10 fires automatically on the same request.
-     *
-     * This satisfies WordPress's requirement that wp_ajax_* hooks are added during
-     * the init phase while deferring controller construction to request time, so
-     * only one controller is constructed per AJAX request.
-     *
-     * Used as a fallback in boot_ajax() when an action is not found in the registry.
-     *
-     * @return void
-     */
-    private function register_lazy_ajax_hooks() {
-        foreach (AIPS_Ajax_Registry::all_actions() as $action) {
-            // $resolver is set to null first so the closure can capture it by reference
-            // and call remove_action() on itself — PHP requires the variable to exist
-            // before the closure is assigned.
-            $resolver = null;
-            $resolver = function() use ($action, &$resolver) {
-                // Remove this resolver before constructing the controller so that
-                // if do_action('wp_ajax_' . $action) is re-entered (e.g. via a
-                // recursive call or test scaffolding) the closure does not fire twice.
-                remove_action('wp_ajax_' . $action, $resolver, 5);
-
-                $controller_class = AIPS_Ajax_Registry::get_controller_for($action);
-                if ($controller_class && class_exists($controller_class)) {
-                    // Intentionally not capturing the return value: each controller
-                    // registers its own wp_ajax_{$action} handler at priority 10 as
-                    // a constructor side-effect.  WordPress will invoke that handler
-                    // as the next hook priority in this same wp_ajax_{$action} cycle.
-                    new $controller_class();
-                }
-            };
-            add_action('wp_ajax_' . $action, $resolver, 5);
-        }
-    }
-
-    /**
-     * Initialize plugin runtime.
-     *
-     * Dispatches to the appropriate context-specific boot method based on the
-     * current request type, ensuring only the subsystems required for that
-     * context are instantiated.
-     *
-     * @return void
-     */
-    public function init() {
-        $this->boot_common();
-
-        if (wp_doing_cron()) {
-            $this->boot_cron();
-        } elseif (wp_doing_ajax()) {
-            $this->boot_ajax();
-        } elseif (is_admin()) {
-            $this->boot_admin();
-        } else {
-            $this->boot_frontend();
-        }
-    }
-
-    /**
-     * Boot subsystems required in every request context.
-     *
-     * Loads text domain, registers container bindings, and registers the
-     * Source Group taxonomy. Called before any context-specific boot method.
-     *
-     * @return void
-     */
-    private function boot_common() {
-        load_plugin_textdomain('ai-post-scheduler', false, dirname(AIPS_PLUGIN_BASENAME) . '/languages');
-
-        // Register initial container bindings for core singletons.
-        $this->register_container_bindings();
-
-        // Boot request-level telemetry if the option is enabled.
-        if (AIPS_Config::get_instance()->get_option('aips_enable_telemetry')) {
-            AIPS_Telemetry::instance()->boot();
-        }
-
-        // Register the Source Group taxonomy (not attached to any post type).
-        register_taxonomy(
-            'aips_source_group',
-            array(),
-            array(
-                'labels'            => array(
-                    'name'              => __('Source Groups', 'ai-post-scheduler'),
-                    'singular_name'     => __('Source Group', 'ai-post-scheduler'),
-                    'add_new_item'      => __('Add New Source Group', 'ai-post-scheduler'),
-                    'edit_item'         => __('Edit Source Group', 'ai-post-scheduler'),
-                    'new_item'          => __('New Source Group', 'ai-post-scheduler'),
-                    'not_found'         => __('No source groups found.', 'ai-post-scheduler'),
-                ),
-                'hierarchical'      => false,
-                'show_ui'           => false,
-                'show_in_nav_menus' => false,
-                'show_in_rest'      => false,
-                'public'            => false,
-                'rewrite'           => false,
-                'query_var'         => false,
-            )
-        );
-    }
-
-    /**
-     * Boot subsystems required only during WP-Cron execution.
-     *
-     * Registers cron hook callbacks as closures that resolve the singleton
-     * instance at runtime (when WordPress fires the event). This means that
-     * a cron request dispatched for, say, aips_generate_author_topics will only
-     * ever instantiate AIPS_Author_Topics_Scheduler — the other scheduler
-     * objects are never constructed unless their own hooks fire in the same run.
-     *
-     * Also boots the notification event handler (for generation-failure and quota
-     * alerts fired from cron) and the partial-generation reconciler
-     * (save_post fires when cron creates posts).
-     *
-     * @return void
-     */
-    private function boot_cron() {
-        // Lazy-resolve the main template scheduler only when its hook fires.
-        add_action('aips_generate_scheduled_posts', function() {
-            AIPS_Scheduler::instance()->process();
-        });
-        add_filter('cron_schedules', function($schedules) {
-            return AIPS_Scheduler::instance()->add_cron_intervals($schedules);
-        });
-
-        // Batch-queue single events: each call processes one slice of a large schedule.
-        // Args: schedule_id, start_index, batch_size, total_quantity, correlation_id.
-        add_action('aips_process_schedule_batch', function(
-            $schedule_id,
-            $start_index,
-            $batch_size,
-            $total_quantity,
-            $correlation_id = ''
-        ) {
-            AIPS_Scheduler::instance()->process_batch(
-                (int) $schedule_id,
-                (int) $start_index,
-                (int) $batch_size,
-                (int) $total_quantity,
-                (string) $correlation_id
-            );
-        }, 10, 5);
-
-        // Lazy-resolve the author-topics scheduler only when its hook fires.
-        add_action('aips_generate_author_topics', function() {
-            AIPS_Author_Topics_Scheduler::instance()->process_topic_generation();
-        });
-
-        // Per-author topic-generation slice: process one author's topics in a dedicated cron event.
-        // Args: author_id, correlation_id.
-        add_action('aips_process_author_topics_slice', function( $author_id, $correlation_id = '' ) {
-            AIPS_Author_Topics_Scheduler::instance()->process_author_slice(
-                (int) $author_id,
-                (string) $correlation_id
-            );
-        }, 10, 2);
-
-        // Retry failed topic-generation slices: re-dispatch authors that failed to schedule.
-        // Args: author_ids_json, correlation_id.
-        add_action('aips_retry_failed_author_slices_topics', function( $author_ids_json, $correlation_id = '' ) {
-            AIPS_Author_Topics_Scheduler::instance()->retry_failed_topic_slices(
-                (string) $author_ids_json,
-                (string) $correlation_id
-            );
-        }, 10, 2);
-
-        // Lazy-resolve the author-post generator only when its hook fires.
-        add_action('aips_generate_author_posts', function() {
-            AIPS_Author_Post_Generator::instance()->process();
-        });
-
-        // Per-author post-generation slice: process one author's post in a dedicated cron event.
-        // Args: author_id, correlation_id.
-        add_action('aips_process_author_post_slice', function( $author_id, $correlation_id = '' ) {
-            AIPS_Author_Post_Generator::instance()->process_author_slice(
-                (int) $author_id,
-                (string) $correlation_id
-            );
-        }, 10, 2);
-
-        // Retry failed post-generation slices: re-dispatch authors that failed to schedule.
-        // Args: author_ids_json, correlation_id.
-        add_action('aips_retry_failed_author_slices_posts', function( $author_ids_json, $correlation_id = '' ) {
-            AIPS_Author_Post_Generator::instance()->retry_failed_post_slices(
-                (string) $author_ids_json,
-                (string) $correlation_id
-            );
-        }, 10, 2);
-
-        // Async bulk-batch processing: each single event processes one slice of a stored job.
-        // Args: job_id, start_index, batch_size, total_quantity, correlation_id.
-        add_action('aips_process_bulk_batch', function(
-            $job_id,
-            $start_index,
-            $batch_size,
-            $total_quantity,
-            $correlation_id = ''
-        ) {
-            AIPS_Bulk_Batch_Processor::instance()->process(
-                (string) $job_id,
-                (int)    $start_index,
-                (int)    $batch_size,
-                (int)    $total_quantity,
-                (string) $correlation_id
-            );
-        }, 10, 5);
-
-        // Register bulk-batch strategies for each supported job type.
-        // Strategies are registered directly (not via add_action) so they are
-        // available immediately when boot_cron() runs — before any later cron
-        // hook could fire in the same request.  Closures are safe here because
-        // they are never serialised; only the job_type string goes to the DB.
-        //
-        // Every handler receives ($item, $job_id, $job) so that per-job context
-        // stored in $job->options (e.g. template_id) can be read inside the closure.
-        $processor = AIPS_Bulk_Batch_Processor::instance();
-
-        $processor->register(
-            'author_topic_post',
-            function( $topic_id, $job_id, $job ) {
-                return AIPS_Author_Post_Generator::instance()->generate_now( (int) $topic_id );
-            }
-        );
-
-        $processor->register(
-            'planner_post',
-            function( $item, $job_id, $job ) {
-                $template_id = isset( $job->options['history_meta']['template_id'] )
-                    ? (int) $job->options['history_meta']['template_id']
-                    : 0;
-
-                if ( $template_id <= 0 ) {
-                    return new WP_Error(
-                        'planner_post_missing_template',
-                        __( 'planner_post strategy requires a template_id stored in job options.', 'ai-post-scheduler' )
-                    );
-                }
-
-                $template = ( new AIPS_Template_Repository() )->get_by_id( $template_id );
-
-                if ( ! $template || empty( $template->is_active ) ) {
-                    return new WP_Error(
-                        'planner_post_template_not_found',
-                        /* translators: %d: template ID */
-                        sprintf( __( 'Template %d not found or inactive for planner_post strategy.', 'ai-post-scheduler' ), $template_id )
-                    );
-                }
-
-                $topic     = is_array( $item ) ? ( $item['topic'] ?? (string) $item ) : (string) $item;
-                $generator = new AIPS_Generator();
-
-                return $generator->generate_post( $template, null, $topic );
-            }
-        );
-
-        $processor->register(
-            'trending_topic_post',
-            function( $item, $job_id, $job ) {
-                if ( ! is_array( $item ) || empty( $item['id'] ) || ! isset( $item['topic'] ) ) {
-                    return new WP_Error(
-                        'invalid_trending_topic_item',
-                        __( 'Item must be an array with id and topic keys.', 'ai-post-scheduler' )
-                    );
-                }
-
-                $template_id = isset( $job->options['history_meta']['template_id'] )
-                    ? (int) $job->options['history_meta']['template_id']
-                    : 0;
-
-                if ( $template_id <= 0 ) {
-                    return new WP_Error(
-                        'trending_topic_post_missing_template',
-                        __( 'trending_topic_post strategy requires a template_id stored in job options.', 'ai-post-scheduler' )
-                    );
-                }
-
-                $template = ( new AIPS_Template_Repository() )->get_by_id( $template_id );
-
-                if ( ! $template || empty( $template->is_active ) ) {
-                    return new WP_Error(
-                        'trending_topic_post_template_not_found',
-                        /* translators: %d: template ID */
-                        sprintf( __( 'Template %d not found or inactive for trending_topic_post strategy.', 'ai-post-scheduler' ), $template_id )
-                    );
-                }
-
-                $context   = new AIPS_Template_Context( $template, null, (string) $item['topic'], 'cron' );
-                $generator = new AIPS_Generator();
-                $post_id   = $generator->generate_post( $context );
-
-                if ( is_wp_error( $post_id ) ) {
-                    return $post_id;
-                }
-
-                update_post_meta( $post_id, '_aips_trending_topic_id',  absint( $item['id'] ) );
-                update_post_meta( $post_id, '_aips_trending_topic_text', sanitize_text_field( (string) $item['topic'] ) );
-
-                return $post_id;
-            }
-        );
-
-        // Daily cleanup of completed/failed bulk-batch job rows.
-        add_action('aips_cleanup_bulk_batch_jobs', function() {
-            $store   = new AIPS_Bulk_Batch_Job_Store();
-            $deleted = $store->cleanup_old_jobs();
-            if ( $deleted > 0 ) {
-                ( new AIPS_Logger() )->log(
-                    sprintf( 'Bulk batch job cleanup: deleted %d old job rows.', $deleted ),
-                    'info'
-                );
-            }
-        });
-
-        // Daily Cache Monitor maintenance (prune expired/orphan index rows + prune old events).
-        add_action('aips_cache_monitor_maintenance', function() {
-            $repository  = new AIPS_Cache_Monitor_Repository();
-            $cache_index = new AIPS_Cache_Index();
-            $service     = new AIPS_Cache_Monitor_Service( $repository, $cache_index );
-            $result      = $service->run_maintenance();
-            ( new AIPS_Logger() )->log(
-                sprintf( 'Cache Monitor maintenance complete: %s', wp_json_encode( $result ) ),
-                'info'
-            );
-        });
-
-        // Lazy-resolve the embeddings worker only when its hook fires.
-        add_action('aips_process_author_embeddings', function($args) {
-            AIPS_Embeddings_Cron::instance()->process_author_embeddings($args);
-        }, 10, 1);
-
-        // Research controller registers the aips_scheduled_research cron hook.
-        new AIPS_Research_Controller();
-
-        // Sources cron: fetch content for sources that have a fetch_interval configured.
-        // AIPS_Sources_Cron::schedule() handles registering the cron event at the
-        // correct recurrence (every_6_hours) during construction.
-        AIPS_Sources_Cron::instance();
-
-        // Notification event handler receives generation-failure/quota alerts from cron.
-        new AIPS_Notifications();
-
-        // Reconciler's save_post hook fires when cron creates or updates posts.
-        new AIPS_Partial_Generation_State_Reconciler();
-
-        // Internal Links indexing cron — construct the controller lazily only
-        // when the cron hook fires to avoid eager instantiation on every cron boot.
-        add_action('aips_index_posts_batch', function($args) {
-            (new AIPS_Internal_Links_Controller())->process_indexing_batch_cron($args);
-        }, 10, 1);
-
-        // Export-file cleanup cron handler.
-        add_action('aips_cleanup_export_files', array('AIPS_Session_To_JSON', 'handle_export_cleanup'));
-    }
-
-    /**
-     * Boot subsystems required only during an admin AJAX request.
-     *
-     * Resolves and instantiates only the single controller class mapped to the
-     * current AJAX action in the registry.
-     *
-     * For plugin-owned actions (those starting with "aips_") that are not yet
-     * registered in the registry, a lazy-resolving fallback is used so that
-     * newly added controllers are still dispatched correctly.
-     *
-     * Non-plugin actions (from other plugins or WordPress core) are ignored
-     * entirely — registering 100+ wp_ajax_* hooks for an action this plugin does
-     * not own would be a performance regression rather than an improvement.
-     *
-     * @return void
-     */
-    private function boot_ajax() {
-        $action = isset($_REQUEST['action']) ? sanitize_key(wp_unslash($_REQUEST['action'])) : '';
-
-        $controller_class = AIPS_Ajax_Registry::get_controller_for($action);
-        if ($controller_class && class_exists($controller_class)) {
-            // Constructing the controller registers its wp_ajax_* hooks; WordPress
-            // will dispatch the matching action automatically after init completes.
-            new $controller_class();
-            return;
-        }
-
-        // Only fall back to lazy-hook registration for plugin-owned actions that
-        // are not yet in the registry (e.g. a newly added controller). Actions
-        // from other plugins or WordPress core are ignored.
-        if (strncmp($action, 'aips_', 5) === 0) {
-            $this->register_lazy_ajax_hooks();
-        }
-    }
-
-    /**
-     * Boot subsystems required for admin (non-AJAX) page views.
-     *
-     * Registers the admin menu, enqueues assets, initializes settings and
-     * onboarding, adds the admin toolbar node, and binds the notification event
-     * handler and partial-generation reconciler. All page-specific AJAX
-     * controllers are intentionally omitted here; they are resolved on demand
-     * via boot_ajax() when an AJAX request arrives.
-     *
-     * @return void
-     */
-    private function boot_admin() {
-        new AIPS_Admin_Menu();
-        new AIPS_Admin_Assets();
-        new AIPS_Settings();
-        new AIPS_Onboarding_Wizard();
-
-        // Toolbar node is visible on WP admin pages as well as the frontend.
-        new AIPS_Admin_Bar();
-
-        // Notification event handler listens for plugin-level events on admin pages.
-        new AIPS_Notifications();
-
-        // Reconciler's save_post hook fires on post-save actions initiated from admin.
-        new AIPS_Partial_Generation_State_Reconciler();
-
-        // Native WordPress post list/editor History links for plugin containers.
-        new AIPS_Post_History_UI();
-
-        // Internal Links controller must be available globally so the admin-menu
-        // render callback can call $controller->render_page() without reconstructing
-        // the object (which would double-register all AJAX hooks).
-        global $aips_internal_links_controller;
-        $aips_internal_links_controller = new AIPS_Internal_Links_Controller();
-    }
-
-    /**
-     * Boot subsystems required only for frontend (non-admin) page loads.
-     *
-     * Creates the admin toolbar node for users with manage_options capability.
-     * No schedulers, controllers, or admin-only subsystems are instantiated here.
-     *
-     * @return void
-     */
-    private function boot_frontend() {
-        new AIPS_Admin_Bar();
-    }
+	private static $instance = null;
+
+	public static function get_cron_events() {
+		return AIPS_Core::get_cron_events();
+	}
+
+	public static function get_instance() {
+		if (null === self::$instance) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	private function __construct() {}
+
+	public function init() {
+		AIPS_Core::get_instance()->init();
+	}
+
+	public function activate() {
+		AIPS_Core::get_instance()->activate();
+	}
+
+	public function deactivate() {
+		AIPS_Core::get_instance()->deactivate();
+	}
 }
 
 /**
@@ -866,7 +70,7 @@ final class AI_Post_Scheduler {
  * @return AI_Post_Scheduler
  */
 function aips_init() {
-    return AI_Post_Scheduler::get_instance();
+	return AI_Post_Scheduler::get_instance();
 }
 
 add_action('plugins_loaded', 'aips_init', 5);
@@ -874,60 +78,42 @@ add_action('plugins_loaded', 'aips_init', 5);
 /**
  * Tell Query Monitor that files under the real (symlink-resolved) plugin
  * directory belong to this plugin, not WordPress Core.
- *
- * When the plugin directory is a symlink, PHP's debug_backtrace() returns the
- * real path (e.g. C:/Projects/.../ai-post-scheduler) which does not start with
- * WP_PLUGIN_DIR, so QM falls back to "WordPress Core".
- *
- * The three companion filters together register the resolved path and map the
- * custom key back to TYPE_PLUGIN with the correct plugin-slug context so that
- * QM shows "Plugin: ai-post-scheduler" in the Component column.
  */
 add_filter('qm/component_dirs', function( array $dirs ) {
-    $real = realpath( AIPS_PLUGIN_DIR );
-    if ( false === $real ) {
-        return $dirs;
-    }
+	$real = realpath( AIPS_PLUGIN_DIR );
+	if ( false === $real ) {
+		return $dirs;
+	}
 
-    $real = rtrim( str_replace( '\\', '/', $real ), '/' );
+	$real = rtrim( str_replace( '\\', '/', $real ), '/' );
+	$expected = rtrim( str_replace( '\\', '/', WP_PLUGIN_DIR . '/ai-post-scheduler' ), '/' );
 
-    // Compare against the canonical WordPress plugins path, not AIPS_PLUGIN_DIR.
-    // In symlinked installs plugin_dir_path(__FILE__) can already be resolved.
-    $expected = rtrim( str_replace( '\\', '/', WP_PLUGIN_DIR . '/ai-post-scheduler' ), '/' );
+	if ( $real !== $expected ) {
+		$dirs['plugin:ai-post-scheduler'] = $real;
+	}
 
-    // Only add when the real path differs from the canonical WP plugin path
-    // (i.e. a symlink is in use). Using a namespaced key avoids overwriting
-    // QM's built-in 'plugin' entry which is appended after this filter runs.
-    if ( $real !== $expected ) {
-        $dirs['plugin:ai-post-scheduler'] = $real;
-    }
-
-    return $dirs;
+	return $dirs;
 });
 
-// Map the custom dir-key type back to TYPE_PLUGIN so QM shows the correct
-// component class and name rather than falling into the "unknown" branch.
 add_filter('qm/component_type/plugin:ai-post-scheduler', function() {
-    return 'plugin';
+	return 'plugin';
 });
 
-// Supply the plugin slug as the context so the component name becomes
-// "Plugin: ai-post-scheduler" instead of "Plugin: plugin:ai-post-scheduler".
 add_filter('qm/component_context/plugin', function( $context, $file ) {
-    $real = realpath( AIPS_PLUGIN_DIR );
-    
-    if ( false === $real || ! is_string( $file ) ) {
-        return $context;
-    }
+	$real = realpath( AIPS_PLUGIN_DIR );
+	
+	if ( false === $real || ! is_string( $file ) ) {
+		return $context;
+	}
 
-    $real = rtrim( str_replace( '\\', '/', $real ), '/' );
-    $file = str_replace( '\\', '/', $file );
+	$real = rtrim( str_replace( '\\', '/', $real ), '/' );
+	$file = str_replace( '\\', '/', $file );
 
-    if ( 0 === strpos( $file, $real . '/' ) || $file === $real ) {
-        return 'ai-post-scheduler';
-    }
+	if ( 0 === strpos( $file, $real . '/' ) || $file === $real ) {
+		return 'ai-post-scheduler';
+	}
 
-    return $context;
+	return $context;
 }, 10, 2);
 
 /**
@@ -936,7 +122,7 @@ add_filter('qm/component_context/plugin', function( $context, $file ) {
  * @return void
  */
 function aips_activate_callback() {
-    AI_Post_Scheduler::get_instance()->activate();
+	AI_Post_Scheduler::get_instance()->activate();
 }
 
 register_activation_hook(__FILE__, 'aips_activate_callback');
@@ -947,7 +133,7 @@ register_activation_hook(__FILE__, 'aips_activate_callback');
  * @return void
  */
 function aips_deactivate_callback() {
-    AI_Post_Scheduler::get_instance()->deactivate();
+	AI_Post_Scheduler::get_instance()->deactivate();
 }
 
 register_deactivation_hook(__FILE__, 'aips_deactivate_callback');

--- a/ai-post-scheduler/includes/class-aips-core.php
+++ b/ai-post-scheduler/includes/class-aips-core.php
@@ -1,0 +1,798 @@
+<?php
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+final class AIPS_Core {
+	
+	/**
+	 * @var AIPS_Core|null Singleton instance
+	 */
+	private static $instance = null;
+
+	/**
+	 * Get plugin cron definitions.
+	 *
+	 * @return array<string,array<string,string>>
+	 */
+	public static function get_cron_events() {
+		return array(
+			'aips_generate_scheduled_posts' => array(
+				'schedule' => 'hourly',
+				'label'   => __( 'Post Generation', 'ai-post-scheduler' ),
+			),
+			'aips_generate_author_topics' => array(
+				'schedule' => 'hourly',
+				'label'   => __( 'Author Topic Generation', 'ai-post-scheduler' ),
+			),
+			'aips_generate_author_posts' => array(
+				'schedule' => 'hourly',
+				'label'   => __( 'Author Post Generation', 'ai-post-scheduler' ),
+			),
+			'aips_scheduled_research' => array(
+				'schedule' => 'daily',
+				'label'   => __( 'Automated Research', 'ai-post-scheduler' ),
+			),
+			'aips_notification_rollups' => array(
+				'schedule' => 'daily',
+				'label'   => __( 'Notification Rollups', 'ai-post-scheduler' ),
+			),
+			'aips_cleanup_export_files' => array(
+				'schedule' => 'daily',
+				'label'   => __( 'Export Cleanup', 'ai-post-scheduler' ),
+			),
+			'aips_fetch_sources' => array(
+				'schedule' => 'daily',
+				'label'   => __( 'Sources Fetch', 'ai-post-scheduler' ),
+			),
+			'aips_cleanup_bulk_batch_jobs' => array(
+				'schedule' => 'daily',
+				'label'   => __( 'Bulk Batch Job Cleanup', 'ai-post-scheduler' ),
+			),
+			'aips_cache_monitor_maintenance' => array(
+				'schedule' => 'daily',
+				'label'   => __( 'Cache Monitor Maintenance', 'ai-post-scheduler' ),
+			),
+		);
+	}
+
+	/**
+	 * Get the singleton instance.
+	 *
+	 * @return AIPS_Core
+	 */
+	public static function get_instance() {
+		if (null === self::$instance) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Construct the plugin core instance.
+	 *
+	 * Registers dependency checks, includes, and runtime hooks.
+	 */
+	private function __construct() {
+		$this->check_dependencies();
+		$this->includes();
+		$this->init_hooks();
+	}
+
+	/**
+	 * Register dependency checks for required runtime plugins.
+	 *
+	 * @return void
+	 */
+	private function check_dependencies() {
+		add_action('admin_init', function() {
+			if (!class_exists('Meow_MWAI_Core')) {
+				add_action('admin_notices', function() {
+					echo '<div class="notice notice-error"><p>';
+					echo esc_html__('AI Post Scheduler requires Meow Apps AI Engine plugin to be installed and activated.', 'ai-post-scheduler');
+					echo '</p></div>';
+				});
+			}
+		});
+	}
+
+	/**
+	 * Load required bootstrap files.
+	 *
+	 * @return void
+	 */
+	private function includes() {
+		// Primary autoloader: Composer-generated classmap (O(1) hash lookup, no filesystem hits).
+		$vendor_autoload = AIPS_PLUGIN_DIR . 'vendor/autoload.php';
+		
+		if ( file_exists( $vendor_autoload ) ) {
+			require_once $vendor_autoload;
+		}
+
+		// Fallback shim: the legacy autoloader handles any AIPS_ class that the
+		// Composer classmap does not resolve (e.g. on installs without a vendor/
+		// directory or after adding a new class before re-running composer dump-autoload).
+		require_once AIPS_PLUGIN_DIR . 'includes/class-aips-autoloader.php';
+		AIPS_Autoloader::register();
+
+		// Helpers
+		require_once AIPS_PLUGIN_DIR . 'includes/class-aips-admin-menu-helper.php';
+	}
+
+	/**
+	 * Register plugin lifecycle and runtime hooks.
+	 *
+	 * @return void
+	 */
+	private function init_hooks() {
+		add_action('plugins_loaded', array($this, 'check_upgrades'));
+		add_action('init', array($this, 'init'));
+	}
+
+	/**
+	 * Handle plugin activation tasks.
+	 *
+	 * Seeds default options, runs upgrades/table checks, schedules cron events,
+	 * and applies onboarding redirect logic for first-time installs.
+	 *
+	 * @return void
+	 */
+	public function activate() {
+		// Ensure logger is available
+		if (!class_exists('AIPS_Logger')) {
+			require_once AIPS_PLUGIN_DIR . 'includes/class-aips-logger.php';
+		}
+
+		$logger = new AIPS_Logger();
+
+		$logger->log('Running plugin activation.');
+
+		// Detect a prior installation before set_default_options() writes defaults.
+		$previously_installed = AIPS_Config::get_instance()->has_option('aips_db_version');
+		$wizard_completed     = (bool) AIPS_Config::get_instance()->get_option('aips_onboarding_completed');
+
+		$this->set_default_options();
+
+		if ($previously_installed || $wizard_completed) {
+			// Plugin already had data or the wizard was already run — mark it
+			// complete so the wizard never surfaces on future reactivations.
+			if (!$wizard_completed) {
+				update_option('aips_onboarding_completed', 1, false);
+			}
+		} else {
+			// Fresh install: redirect admins to the onboarding wizard once.
+			set_transient('aips_onboarding_redirect', 1, MINUTE_IN_SECONDS * 10);
+		}
+		$this->check_upgrades();
+
+		// Ensure tables exist even if version matches (e.g. re-activation after manual deletion or partial install)
+		$install_result = AIPS_DB_Manager::install_tables();
+
+		if (is_wp_error($install_result)) {
+			$logger->log('Table installation failed during activation: ' . $install_result->get_error_message(), 'error');
+
+			$notifications = class_exists('AIPS_Notifications') ? new AIPS_Notifications() : null;
+			if ($notifications instanceof AIPS_Notifications) {
+				$notifications->system_error(array(
+					'title'         => __('Database installation failed', 'ai-post-scheduler'),
+					'error_code'    => $install_result->get_error_code(),
+					'error_message' => $install_result->get_error_message(),
+					'url'           => admin_url('admin.php?page=aips-status'),
+					'dedupe_key'    => 'db_install_failed_activation',
+					'dedupe_window' => 1800,
+				));
+			}
+		}
+		
+		$crons = self::get_cron_events();
+
+		foreach ($crons as $hook => $cron_config) {
+			$schedule = $cron_config['schedule'];
+			$logger->log("Checking cron: $hook");
+
+			if (!wp_next_scheduled($hook)) {
+				$logger->log("Cron '$hook' not scheduled. Scheduling now with schedule: '$schedule'.");
+
+				wp_schedule_event(time(), $schedule, $hook);
+				
+				$next_run = wp_next_scheduled($hook);
+
+				if ($next_run) {
+					$logger->log("Successfully scheduled '$hook'. Next run: " . date('Y-m-d H:i:s', $next_run));
+				} else {
+					$logger->log("Failed to schedule '$hook'. wp_next_scheduled returned false.", 'error');
+				}
+			} else {
+				$logger->log("Cron '$hook' is already scheduled.");
+			}
+		}
+		
+		flush_rewrite_rules();
+
+		$logger->log('Plugin activation finished.');
+	}
+
+	/**
+	 * Run versioned upgrade checks.
+	 *
+	 * Called both on plugin activation (via activate()) and on every page load
+	 * via the plugins_loaded hook. WordPress plugin auto-updates skip activation,
+	 * so this must be self-contained: AIPS_DB_Migrations::check_and_run() runs
+	 * migrations AND install_tables() (dbDelta) when an upgrade is detected,
+	 * ensuring the schema is fully applied regardless of the call path.
+	 *
+	 * Call-order guarantee inside AIPS_DB_Migrations::run_upgrade() (must not change):
+	 *   1. Versioned migrations run first — column renames/type changes/index ops
+	 *      that dbDelta cannot perform. Schema must be consistent before dbDelta.
+	 *   2. AIPS_DB_Manager::install_tables() (dbDelta) runs second — adds any new
+	 *      tables/columns introduced in the current plugin version.
+	 *
+	 * Note: activate() also calls install_tables() directly afterward for the
+	 * fresh-install / re-activation edge case. The double invocation is harmless
+	 * because dbDelta is fully idempotent.
+	 *
+	 * @return void
+	 */
+	public function check_upgrades() {
+		AIPS_DB_Migrations::check_and_run();
+	}
+
+	/**
+	 * Handle plugin deactivation cleanup.
+	 *
+	 * @return void
+	 */
+	public function deactivate() {
+		foreach (array_keys(self::get_cron_events()) as $hook) {
+			wp_clear_scheduled_hook($hook);
+		}
+		flush_rewrite_rules();
+	}
+
+	/**
+	 * Seed plugin options with default values when missing.
+	 *
+	 * Uses AIPS_Config defaults as the source of truth and adds activation-
+	 * specific values where required.
+	 *
+	 * @return void
+	 */
+	private function set_default_options() {
+		$defaults = AIPS_Config::get_instance()->get_default_options();
+
+		// Activation-specific fallback: if unset in defaults, use admin email.
+		if (empty($defaults['aips_review_notifications_email'])) {
+			$defaults['aips_review_notifications_email'] = get_option('admin_email');
+		}
+
+		// Keep DB version initialization during activation.
+		$defaults['aips_db_version'] = AIPS_VERSION;
+		
+		foreach ($defaults as $key => $value) {
+			if (!AIPS_Config::get_instance()->has_option($key)) {
+				add_option($key, $value);
+			}
+		}
+	}
+
+	/**
+	 * Register initial container bindings for core singletons.
+	 *
+	 * Phase 1 registration as described in the container architecture plan:
+	 * Registers the most-duplicated singletons to validate the container works
+	 * correctly before more complex refactors.
+	 *
+	 * @return void
+	 */
+	public function register_container_bindings() {
+		$container = AIPS_Container::get_instance();
+
+		// Register AIPS_Config (uses get_instance() instead of instance())
+		$container->singleton(AIPS_Config::class, function( $container ) {
+			return AIPS_Config::get_instance();
+		});
+
+		// Register AIPS_History_Repository
+		$container->singleton(AIPS_History_Repository::class, function( $container ) {
+			return AIPS_History_Repository::instance();
+		});
+
+		$container->singleton(AIPS_History_Repository_Interface::class, function( $container ) {
+			return $container->make(AIPS_History_Repository::class);
+		});
+
+		// Register AIPS_History_Service
+		$container->singleton(AIPS_History_Service::class, function( $container ) {
+			return AIPS_History_Service::instance();
+		});
+
+		$container->singleton(AIPS_History_Service_Interface::class, function( $container ) {
+			return $container->make(AIPS_History_Service::class);
+		});
+
+		// Register AIPS_Notifications_Repository
+		$container->singleton(AIPS_Notifications_Repository::class, function( $container ) {
+			return AIPS_Notifications_Repository::instance();
+		});
+
+		$container->singleton(AIPS_Notifications_Repository_Interface::class, function( $container ) {
+			return $container->make(AIPS_Notifications_Repository::class);
+		});
+
+		$container->singleton(AIPS_Logger::class, function( $container ) {
+			return AIPS_Logger::instance();
+		});
+
+		$container->singleton(AIPS_Logger_Interface::class, function( $container ) {
+			return $container->make(AIPS_Logger::class);
+		});
+
+		$container->singleton(AIPS_AI_Service::class, function( $container ) {
+			return AIPS_AI_Service::instance();
+		});
+
+		$container->singleton(AIPS_AI_Service_Interface::class, function( $container ) {
+			return $container->make(AIPS_AI_Service::class);
+		});
+
+		$container->singleton(AIPS_Schedule_Repository::class, function( $container ) {
+			return AIPS_Schedule_Repository::instance();
+		});
+
+		$container->singleton(AIPS_Schedule_Repository_Interface::class, function( $container ) {
+			return $container->make(AIPS_Schedule_Repository::class);
+		});
+
+		$container->singleton(AIPS_Telemetry_Repository::class, function( $container ) {
+			return AIPS_Telemetry_Repository::instance();
+		});
+
+		// Register AIPS_Template_Repository
+		$container->singleton(AIPS_Template_Repository::class, function( $container ) {
+			return AIPS_Template_Repository::instance();
+		});
+	}
+
+	/**
+	 * Register thin lazy-resolving wp_ajax_* hooks for all actions in the registry.
+	 *
+	 * Each closure registered at priority 5 removes itself and then constructs the
+	 * correct controller (which registers its own handler at the default priority 10).
+	 * WordPress continues iterating priorities after priority 5 completes, so the
+	 * controller's handler at priority 10 fires automatically on the same request.
+	 *
+	 * This satisfies WordPress's requirement that wp_ajax_* hooks are added during
+	 * the init phase while deferring controller construction to request time, so
+	 * only one controller is constructed per AJAX request.
+	 *
+	 * Used as a fallback in boot_ajax() when an action is not found in the registry.
+	 *
+	 * @return void
+	 */
+	private function register_lazy_ajax_hooks() {
+		foreach (AIPS_Ajax_Registry::all_actions() as $action) {
+			// $resolver is set to null first so the closure can capture it by reference
+			// and call remove_action() on itself — PHP requires the variable to exist
+			// before the closure is assigned.
+			$resolver = null;
+			$resolver = function() use ($action, &$resolver) {
+				// Remove this resolver before constructing the controller so that
+				// if do_action('wp_ajax_' . $action) is re-entered (e.g. via a
+				// recursive call or test scaffolding) the closure does not fire twice.
+				remove_action('wp_ajax_' . $action, $resolver, 5);
+
+				$controller_class = AIPS_Ajax_Registry::get_controller_for($action);
+				if ($controller_class && class_exists($controller_class)) {
+					// Intentionally not capturing the return value: each controller
+					// registers its own wp_ajax_{$action} handler at priority 10 as
+					// a constructor side-effect.  WordPress will invoke that handler
+					// as the next hook priority in this same wp_ajax_{$action} cycle.
+					new $controller_class();
+				}
+			};
+			add_action('wp_ajax_' . $action, $resolver, 5);
+		}
+	}
+
+	/**
+	 * Initialize plugin runtime.
+	 *
+	 * Dispatches to the appropriate context-specific boot method based on the
+	 * current request type, ensuring only the subsystems required for that
+	 * context are instantiated.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		$this->boot_common();
+
+		if (wp_doing_cron()) {
+			$this->boot_cron();
+		} elseif (wp_doing_ajax()) {
+			$this->boot_ajax();
+		} elseif (is_admin()) {
+			$this->boot_admin();
+		} else {
+			$this->boot_frontend();
+		}
+	}
+
+	/**
+	 * Boot subsystems required in every request context.
+	 *
+	 * Loads text domain, registers container bindings, and registers the
+	 * Source Group taxonomy. Called before any context-specific boot method.
+	 *
+	 * @return void
+	 */
+	private function boot_common() {
+		load_plugin_textdomain('ai-post-scheduler', false, dirname(AIPS_PLUGIN_BASENAME) . '/languages');
+
+		// Register initial container bindings for core singletons.
+		$this->register_container_bindings();
+
+		// Boot request-level telemetry if the option is enabled.
+		if (AIPS_Config::get_instance()->get_option('aips_enable_telemetry')) {
+			AIPS_Telemetry::instance()->boot();
+		}
+
+		// Register the Source Group taxonomy (not attached to any post type).
+		register_taxonomy(
+			'aips_source_group',
+			array(),
+			array(
+				'labels'            => array(
+					'name'              => __('Source Groups', 'ai-post-scheduler'),
+					'singular_name'     => __('Source Group', 'ai-post-scheduler'),
+					'add_new_item'      => __('Add New Source Group', 'ai-post-scheduler'),
+					'edit_item'         => __('Edit Source Group', 'ai-post-scheduler'),
+					'new_item'          => __('New Source Group', 'ai-post-scheduler'),
+					'not_found'         => __('No source groups found.', 'ai-post-scheduler'),
+				),
+				'hierarchical'      => false,
+				'show_ui'           => false,
+				'show_in_nav_menus' => false,
+				'show_in_rest'      => false,
+				'public'            => false,
+				'rewrite'           => false,
+				'query_var'         => false,
+			)
+		);
+	}
+
+	/**
+	 * Boot subsystems required only during WP-Cron execution.
+	 *
+	 * Registers cron hook callbacks as closures that resolve the singleton
+	 * instance at runtime (when WordPress fires the event). This means that
+	 * a cron request dispatched for, say, aips_generate_author_topics will only
+	 * ever instantiate AIPS_Author_Topics_Scheduler — the other scheduler
+	 * objects are never constructed unless their own hooks fire in the same run.
+	 *
+	 * Also boots the notification event handler (for generation-failure and quota
+	 * alerts fired from cron) and the partial-generation reconciler
+	 * (save_post fires when cron creates posts).
+	 *
+	 * @return void
+	 */
+	private function boot_cron() {
+		// Lazy-resolve the main template scheduler only when its hook fires.
+		add_action('aips_generate_scheduled_posts', function() {
+			AIPS_Scheduler::instance()->process();
+		});
+		add_filter('cron_schedules', function($schedules) {
+			return AIPS_Scheduler::instance()->add_cron_intervals($schedules);
+		});
+
+		// Batch-queue single events: each call processes one slice of a large schedule.
+		// Args: schedule_id, start_index, batch_size, total_quantity, correlation_id.
+		add_action('aips_process_schedule_batch', function(
+			$schedule_id,
+			$start_index,
+			$batch_size,
+			$total_quantity,
+			$correlation_id = ''
+		) {
+			AIPS_Scheduler::instance()->process_batch(
+				(int) $schedule_id,
+				(int) $start_index,
+				(int) $batch_size,
+				(int) $total_quantity,
+				(string) $correlation_id
+			);
+		}, 10, 5);
+
+		// Lazy-resolve the author-topics scheduler only when its hook fires.
+		add_action('aips_generate_author_topics', function() {
+			AIPS_Author_Topics_Scheduler::instance()->process_topic_generation();
+		});
+
+		// Per-author topic-generation slice: process one author's topics in a dedicated cron event.
+		// Args: author_id, correlation_id.
+		add_action('aips_process_author_topics_slice', function( $author_id, $correlation_id = '' ) {
+			AIPS_Author_Topics_Scheduler::instance()->process_author_slice(
+				(int) $author_id,
+				(string) $correlation_id
+			);
+		}, 10, 2);
+
+		// Retry failed topic-generation slices: re-dispatch authors that failed to schedule.
+		// Args: author_ids_json, correlation_id.
+		add_action('aips_retry_failed_author_slices_topics', function( $author_ids_json, $correlation_id = '' ) {
+			AIPS_Author_Topics_Scheduler::instance()->retry_failed_topic_slices(
+				(string) $author_ids_json,
+				(string) $correlation_id
+			);
+		}, 10, 2);
+
+		// Lazy-resolve the author-post generator only when its hook fires.
+		add_action('aips_generate_author_posts', function() {
+			AIPS_Author_Post_Generator::instance()->process();
+		});
+
+		// Per-author post-generation slice: process one author's post in a dedicated cron event.
+		// Args: author_id, correlation_id.
+		add_action('aips_process_author_post_slice', function( $author_id, $correlation_id = '' ) {
+			AIPS_Author_Post_Generator::instance()->process_author_slice(
+				(int) $author_id,
+				(string) $correlation_id
+			);
+		}, 10, 2);
+
+		// Retry failed post-generation slices: re-dispatch authors that failed to schedule.
+		// Args: author_ids_json, correlation_id.
+		add_action('aips_retry_failed_author_slices_posts', function( $author_ids_json, $correlation_id = '' ) {
+			AIPS_Author_Post_Generator::instance()->retry_failed_post_slices(
+				(string) $author_ids_json,
+				(string) $correlation_id
+			);
+		}, 10, 2);
+
+		// Async bulk-batch processing: each single event processes one slice of a stored job.
+		// Args: job_id, start_index, batch_size, total_quantity, correlation_id.
+		add_action('aips_process_bulk_batch', function(
+			$job_id,
+			$start_index,
+			$batch_size,
+			$total_quantity,
+			$correlation_id = ''
+		) {
+			AIPS_Bulk_Batch_Processor::instance()->process(
+				(string) $job_id,
+				(int)    $start_index,
+				(int)    $batch_size,
+				(int)    $total_quantity,
+				(string) $correlation_id
+			);
+		}, 10, 5);
+
+		// Register bulk-batch strategies for each supported job type.
+		// Strategies are registered directly (not via add_action) so they are
+		// available immediately when boot_cron() runs — before any later cron
+		// hook could fire in the same request.  Closures are safe here because
+		// they are never serialised; only the job_type string goes to the DB.
+		//
+		// Every handler receives ($item, $job_id, $job) so that per-job context
+		// stored in $job->options (e.g. template_id) can be read inside the closure.
+		$processor = AIPS_Bulk_Batch_Processor::instance();
+
+		$processor->register(
+			'author_topic_post',
+			function( $topic_id, $job_id, $job ) {
+				return AIPS_Author_Post_Generator::instance()->generate_now( (int) $topic_id );
+			}
+		);
+
+		$processor->register(
+			'planner_post',
+			function( $item, $job_id, $job ) {
+				$template_id = isset( $job->options['history_meta']['template_id'] )
+					? (int) $job->options['history_meta']['template_id']
+					: 0;
+
+				if ( $template_id <= 0 ) {
+					return new WP_Error(
+						'planner_post_missing_template',
+						__( 'planner_post strategy requires a template_id stored in job options.', 'ai-post-scheduler' )
+					);
+				}
+
+				$template = ( new AIPS_Template_Repository() )->get_by_id( $template_id );
+
+				if ( ! $template || empty( $template->is_active ) ) {
+					return new WP_Error(
+						'planner_post_template_not_found',
+						/* translators: %d: template ID */
+						sprintf( __( 'Template %d not found or inactive for planner_post strategy.', 'ai-post-scheduler' ), $template_id )
+					);
+				}
+
+				$topic     = is_array( $item ) ? ( $item['topic'] ?? (string) $item ) : (string) $item;
+				$generator = new AIPS_Generator();
+
+				return $generator->generate_post( $template, null, $topic );
+			}
+		);
+
+		$processor->register(
+			'trending_topic_post',
+			function( $item, $job_id, $job ) {
+				if ( ! is_array( $item ) || empty( $item['id'] ) || ! isset( $item['topic'] ) ) {
+					return new WP_Error(
+						'invalid_trending_topic_item',
+						__( 'Item must be an array with id and topic keys.', 'ai-post-scheduler' )
+					);
+				}
+
+				$template_id = isset( $job->options['history_meta']['template_id'] )
+					? (int) $job->options['history_meta']['template_id']
+					: 0;
+
+				if ( $template_id <= 0 ) {
+					return new WP_Error(
+						'trending_topic_post_missing_template',
+						__( 'trending_topic_post strategy requires a template_id stored in job options.', 'ai-post-scheduler' )
+					);
+				}
+
+				$template = ( new AIPS_Template_Repository() )->get_by_id( $template_id );
+
+				if ( ! $template || empty( $template->is_active ) ) {
+					return new WP_Error(
+						'trending_topic_post_template_not_found',
+						/* translators: %d: template ID */
+						sprintf( __( 'Template %d not found or inactive for trending_topic_post strategy.', 'ai-post-scheduler' ), $template_id )
+					);
+				}
+
+				$context   = new AIPS_Template_Context( $template, null, (string) $item['topic'], 'cron' );
+				$generator = new AIPS_Generator();
+				$post_id   = $generator->generate_post( $context );
+
+				if ( is_wp_error( $post_id ) ) {
+					return $post_id;
+				}
+
+				update_post_meta( $post_id, '_aips_trending_topic_id',  absint( $item['id'] ) );
+				update_post_meta( $post_id, '_aips_trending_topic_text', sanitize_text_field( (string) $item['topic'] ) );
+
+				return $post_id;
+			}
+		);
+
+		// Daily cleanup of completed/failed bulk-batch job rows.
+		add_action('aips_cleanup_bulk_batch_jobs', function() {
+			$store   = new AIPS_Bulk_Batch_Job_Store();
+			$deleted = $store->cleanup_old_jobs();
+			if ( $deleted > 0 ) {
+				( new AIPS_Logger() )->log(
+					sprintf( 'Bulk batch job cleanup: deleted %d old job rows.', $deleted ),
+					'info'
+				);
+			}
+		});
+
+		// Daily Cache Monitor maintenance (prune expired/orphan index rows + prune old events).
+		add_action('aips_cache_monitor_maintenance', function() {
+			$repository  = new AIPS_Cache_Monitor_Repository();
+			$cache_index = new AIPS_Cache_Index();
+			$service     = new AIPS_Cache_Monitor_Service( $repository, $cache_index );
+			$result      = $service->run_maintenance();
+			( new AIPS_Logger() )->log(
+				sprintf( 'Cache Monitor maintenance complete: %s', wp_json_encode( $result ) ),
+				'info'
+			);
+		});
+
+		// Lazy-resolve the embeddings worker only when its hook fires.
+		add_action('aips_process_author_embeddings', function($args) {
+			AIPS_Embeddings_Cron::instance()->process_author_embeddings($args);
+		}, 10, 1);
+
+		// Research controller registers the aips_scheduled_research cron hook.
+		new AIPS_Research_Controller();
+
+		// Sources cron: fetch content for sources that have a fetch_interval configured.
+		// AIPS_Sources_Cron::schedule() handles registering the cron event at the
+		// correct recurrence (every_6_hours) during construction.
+		AIPS_Sources_Cron::instance();
+
+		// Notification event handler receives generation-failure/quota alerts from cron.
+		new AIPS_Notifications();
+
+		// Reconciler's save_post hook fires when cron creates or updates posts.
+		new AIPS_Partial_Generation_State_Reconciler();
+
+		// Internal Links indexing cron — construct the controller lazily only
+		// when the cron hook fires to avoid eager instantiation on every cron boot.
+		add_action('aips_index_posts_batch', function($args) {
+			(new AIPS_Internal_Links_Controller())->process_indexing_batch_cron($args);
+		}, 10, 1);
+
+		// Export-file cleanup cron handler.
+		add_action('aips_cleanup_export_files', array('AIPS_Session_To_JSON', 'handle_export_cleanup'));
+	}
+
+	/**
+	 * Boot subsystems required only during an admin AJAX request.
+	 *
+	 * Resolves and instantiates only the single controller class mapped to the
+	 * current AJAX action in the registry.
+	 *
+	 * For plugin-owned actions (those starting with "aips_") that are not yet
+	 * registered in the registry, a lazy-resolving fallback is used so that
+	 * newly added controllers are still dispatched correctly.
+	 *
+	 * Non-plugin actions (from other plugins or WordPress core) are ignored
+	 * entirely — registering 100+ wp_ajax_* hooks for an action this plugin does
+	 * not own would be a performance regression rather than an improvement.
+	 *
+	 * @return void
+	 */
+	private function boot_ajax() {
+		$action = isset($_REQUEST['action']) ? sanitize_key(wp_unslash($_REQUEST['action'])) : '';
+
+		$controller_class = AIPS_Ajax_Registry::get_controller_for($action);
+		if ($controller_class && class_exists($controller_class)) {
+			// Constructing the controller registers its wp_ajax_* hooks; WordPress
+			// will dispatch the matching action automatically after init completes.
+			new $controller_class();
+			return;
+		}
+
+		// Only fall back to lazy-hook registration for plugin-owned actions that
+		// are not yet in the registry (e.g. a newly added controller). Actions
+		// from other plugins or WordPress core are ignored.
+		if (strncmp($action, 'aips_', 5) === 0) {
+			$this->register_lazy_ajax_hooks();
+		}
+	}
+
+	/**
+	 * Boot subsystems required for admin (non-AJAX) page views.
+	 *
+	 * Registers the admin menu, enqueues assets, initializes settings and
+	 * onboarding, adds the admin toolbar node, and binds the notification event
+	 * handler and partial-generation reconciler. All page-specific AJAX
+	 * controllers are intentionally omitted here; they are resolved on demand
+	 * via boot_ajax() when an AJAX request arrives.
+	 *
+	 * @return void
+	 */
+	private function boot_admin() {
+		new AIPS_Admin_Menu();
+		new AIPS_Admin_Assets();
+		new AIPS_Settings();
+		new AIPS_Onboarding_Wizard();
+
+		// Toolbar node is visible on WP admin pages as well as the frontend.
+		new AIPS_Admin_Bar();
+
+		// Notification event handler listens for plugin-level events on admin pages.
+		new AIPS_Notifications();
+
+		// Reconciler's save_post hook fires on post-save actions initiated from admin.
+		new AIPS_Partial_Generation_State_Reconciler();
+
+		// Native WordPress post list/editor History links for plugin containers.
+		new AIPS_Post_History_UI();
+
+		// Internal Links controller must be available globally so the admin-menu
+		// render callback can call $controller->render_page() without reconstructing
+		// the object (which would double-register all AJAX hooks).
+		global $aips_internal_links_controller;
+		$aips_internal_links_controller = new AIPS_Internal_Links_Controller();
+	}
+
+	/**
+	 * Boot subsystems required only for frontend (non-admin) page loads.
+	 *
+	 * Creates the admin toolbar node for users with manage_options capability.
+	 * No schedulers, controllers, or admin-only subsystems are instantiated here.
+	 *
+	 * @return void
+	 */
+	private function boot_frontend() {
+		new AIPS_Admin_Bar();
+	}
+}

--- a/ai-post-scheduler/includes/class-aips-db-manager.php
+++ b/ai-post-scheduler/includes/class-aips-db-manager.php
@@ -994,7 +994,7 @@ class AIPS_DB_Manager {
             AIPS_Ajax_Response::error(__('Unauthorized', 'ai-post-scheduler'));
         }
 
-        $cron_events    = AI_Post_Scheduler::get_cron_events();
+        $cron_events    = AIPS_Core::get_cron_events();
         $unscheduled    = array();
         $rescheduled    = array();
         $failed         = array();

--- a/ai-post-scheduler/includes/class-aips-system-status-controller.php
+++ b/ai-post-scheduler/includes/class-aips-system-status-controller.php
@@ -92,7 +92,7 @@ class AIPS_System_Status_Controller {
 			AIPS_Ajax_Response::permission_denied();
 		}
 
-		$cron_events = AI_Post_Scheduler::get_cron_events();
+		$cron_events = AIPS_Core::get_cron_events();
 		$rescheduled = 0;
 		$base_timestamp = AIPS_DateTime::now()->timestamp() + MINUTE_IN_SECONDS;
 		foreach ($cron_events as $hook => $config) {

--- a/ai-post-scheduler/includes/constants.php
+++ b/ai-post-scheduler/includes/constants.php
@@ -1,0 +1,52 @@
+<?php
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+// Capture the request start time as early as possible so AIPS_Telemetry
+// can compute an accurate elapsed-time measurement.
+if (!defined('AIPS_REQUEST_START')) {
+	define('AIPS_REQUEST_START', microtime(true));
+}
+
+// Enable SAVEQUERIES as early as possible for telemetry-enabled requests so
+// slow/duplicate query analysis can inspect the collected query log.
+if (!defined('SAVEQUERIES') && function_exists('get_option') && get_option('aips_enable_telemetry', false)) {
+	define('SAVEQUERIES', true);
+}
+
+if (!defined('AIPS_TELEMETRY_SLOW_QUERY_MS')) {
+	define('AIPS_TELEMETRY_SLOW_QUERY_MS', 100);
+}
+
+if (!defined('AIPS_TELEMETRY_SLOW_REQUEST_MS')) {
+	define('AIPS_TELEMETRY_SLOW_REQUEST_MS', 1500);
+}
+
+if (!defined('AIPS_TELEMETRY_QUERY_SAMPLE_LIMIT')) {
+	define('AIPS_TELEMETRY_QUERY_SAMPLE_LIMIT', 10);
+}
+
+// Define plugin constants
+if (!defined('AIPS_VERSION')) {
+	define('AIPS_VERSION', '2.9.1');
+}
+
+if (!defined('AIPS_PLUGIN_DIR')) {
+	define('AIPS_PLUGIN_DIR', plugin_dir_path(dirname(__FILE__)));
+}
+
+if (!defined('AIPS_PLUGIN_URL')) {
+	define('AIPS_PLUGIN_URL', plugin_dir_url(dirname(__FILE__)));
+}
+
+if (!defined('AIPS_PLUGIN_BASENAME')) {
+	define('AIPS_PLUGIN_BASENAME', plugin_basename(dirname(__DIR__) . '/ai-post-scheduler.php'));
+}
+
+// Prompt-preview logging can expose generated content in logs. Off by default;
+// opt-in by defining the constant to true earlier (e.g. in wp-config.php), or
+// it will automatically enable when WP_DEBUG is true.
+if (!defined('AIPS_AI_DEBUG_LOG_PROMPTS')) {
+	define('AIPS_AI_DEBUG_LOG_PROMPTS', defined('WP_DEBUG') && WP_DEBUG);
+}

--- a/ai-post-scheduler/includes/diagnostics/class-aips-system-diagnostics-scheduler-provider.php
+++ b/ai-post-scheduler/includes/diagnostics/class-aips-system-diagnostics-scheduler-provider.php
@@ -37,7 +37,7 @@ class AIPS_System_Diagnostics_Scheduler_Provider implements AIPS_System_Diagnost
 	 * @return array<string, array<string, mixed>>
 	 */
 	private function check_cron() {
-		$cron_events = AI_Post_Scheduler::get_cron_events();
+		$cron_events = AIPS_Core::get_cron_events();
 		$status      = array();
 
 		foreach ( $cron_events as $event_hook => $event_config ) {
@@ -62,7 +62,7 @@ class AIPS_System_Diagnostics_Scheduler_Provider implements AIPS_System_Diagnost
 		$checks = array();
 
 		// --- Per-hook cron diagnostics ---
-		$cron_events     = AI_Post_Scheduler::get_cron_events();
+		$cron_events     = AIPS_Core::get_cron_events();
 		$expected_total  = count( $cron_events );
 		$actual_total    = 0;
 		$hooks_missing   = array();

--- a/ai-post-scheduler/tests/Test_AIPS_Container_Bindings.php
+++ b/ai-post-scheduler/tests/Test_AIPS_Container_Bindings.php
@@ -5,7 +5,7 @@
  * Verifies that core singletons are properly registered in the container
  * during plugin initialization.
  *
- * @package AI_Post_Scheduler
+ * @package AIPS_Core
  * @since 2.4.0
  */
 class Test_AIPS_Container_Bindings extends WP_UnitTestCase {
@@ -37,7 +37,7 @@ class Test_AIPS_Container_Bindings extends WP_UnitTestCase {
 	 */
 	public function test_core_singletons_are_registered() {
 		// Simulate what the plugin does during init
-		$plugin = AI_Post_Scheduler::get_instance();
+		$plugin = AIPS_Core::get_instance();
 
 		// Use reflection to call the private method
 		$reflection = new ReflectionClass($plugin);
@@ -68,7 +68,7 @@ class Test_AIPS_Container_Bindings extends WP_UnitTestCase {
 	 */
 	public function test_registered_bindings_return_singletons() {
 		// Simulate what the plugin does during init
-		$plugin = AI_Post_Scheduler::get_instance();
+		$plugin = AIPS_Core::get_instance();
 
 		$reflection = new ReflectionClass($plugin);
 		$method = $reflection->getMethod('register_container_bindings');
@@ -116,7 +116,7 @@ class Test_AIPS_Container_Bindings extends WP_UnitTestCase {
 	 */
 	public function test_all_registered_bindings_have_singleton_scope() {
 		// Simulate what the plugin does during init
-		$plugin = AI_Post_Scheduler::get_instance();
+		$plugin = AIPS_Core::get_instance();
 
 		$reflection = new ReflectionClass($plugin);
 		$method = $reflection->getMethod('register_container_bindings');
@@ -148,7 +148,7 @@ class Test_AIPS_Container_Bindings extends WP_UnitTestCase {
 	 */
 	public function test_binding_count_is_correct() {
 		// Simulate what the plugin does during init
-		$plugin = AI_Post_Scheduler::get_instance();
+		$plugin = AIPS_Core::get_instance();
 
 		$reflection = new ReflectionClass($plugin);
 		$method = $reflection->getMethod('register_container_bindings');

--- a/ai-post-scheduler/tests/Test_AIPS_Context_Boot.php
+++ b/ai-post-scheduler/tests/Test_AIPS_Context_Boot.php
@@ -2,13 +2,13 @@
 /**
  * Tests for context-aware bootstrap dispatcher (Step 15).
  *
- * Verifies that AI_Post_Scheduler::init() dispatches to the correct boot method
+ * Verifies that AIPS_Core::init() dispatches to the correct boot method
  * based on the current request context (cron, AJAX, admin, or frontend), and
  * that each boot method registers only the subsystems appropriate for its context.
  *
  * These tests run in limited mode (no full WordPress environment).
  *
- * @package AI_Post_Scheduler
+ * @package AIPS_Core
  */
 
 class Test_AIPS_Context_Boot extends WP_UnitTestCase {
@@ -78,8 +78,8 @@ class Test_AIPS_Context_Boot extends WP_UnitTestCase {
 	 */
 	public function test_plugin_class_has_init_method() {
 		$this->assertTrue(
-			method_exists( 'AI_Post_Scheduler', 'init' ),
-			'AI_Post_Scheduler must have an init() method'
+			method_exists( 'AIPS_Core', 'init' ),
+			'AIPS_Core must have an init() method'
 		);
 	}
 
@@ -89,12 +89,12 @@ class Test_AIPS_Context_Boot extends WP_UnitTestCase {
 	 * They are private but PHP Reflection can confirm their presence.
 	 */
 	public function test_plugin_class_has_all_five_boot_methods() {
-		$rc = new ReflectionClass( 'AI_Post_Scheduler' );
+		$rc = new ReflectionClass( 'AIPS_Core' );
 
 		foreach ( array( 'boot_common', 'boot_cron', 'boot_ajax', 'boot_admin', 'boot_frontend' ) as $method ) {
 			$this->assertTrue(
 				$rc->hasMethod( $method ),
-				"AI_Post_Scheduler must have a private {$method}() method"
+				"AIPS_Core must have a private {$method}() method"
 			);
 		}
 	}
@@ -103,7 +103,7 @@ class Test_AIPS_Context_Boot extends WP_UnitTestCase {
 	 * All five boot methods must be declared private.
 	 */
 	public function test_all_boot_methods_have_private_visibility() {
-		$rc = new ReflectionClass( 'AI_Post_Scheduler' );
+		$rc = new ReflectionClass( 'AIPS_Core' );
 
 		foreach ( array( 'boot_common', 'boot_cron', 'boot_ajax', 'boot_admin', 'boot_frontend' ) as $method ) {
 			$this->assertTrue(
@@ -130,7 +130,7 @@ class Test_AIPS_Context_Boot extends WP_UnitTestCase {
 
 		$GLOBALS['aips_test_doing_cron'] = true;
 
-		$plugin = AI_Post_Scheduler::get_instance();
+		$plugin = AIPS_Core::get_instance();
 		$plugin->init();
 
 		$this->assertGreaterThan(
@@ -150,7 +150,7 @@ class Test_AIPS_Context_Boot extends WP_UnitTestCase {
 
 		$GLOBALS['aips_test_doing_cron'] = true;
 
-		$plugin = AI_Post_Scheduler::get_instance();
+		$plugin = AIPS_Core::get_instance();
 		$plugin->init();
 
 		$this->assertGreaterThan(
@@ -170,7 +170,7 @@ class Test_AIPS_Context_Boot extends WP_UnitTestCase {
 
 		$GLOBALS['aips_test_doing_cron'] = true;
 
-		$plugin = AI_Post_Scheduler::get_instance();
+		$plugin = AIPS_Core::get_instance();
 		$plugin->init();
 
 		$this->assertGreaterThan(
@@ -192,7 +192,7 @@ class Test_AIPS_Context_Boot extends WP_UnitTestCase {
 
 		$GLOBALS['aips_test_doing_cron'] = true;
 
-		$plugin = AI_Post_Scheduler::get_instance();
+		$plugin = AIPS_Core::get_instance();
 		$plugin->init();
 
 		$this->assertSame(
@@ -213,7 +213,7 @@ class Test_AIPS_Context_Boot extends WP_UnitTestCase {
 		}
 
 		// All context globals default to false (frontend).
-		$plugin = AI_Post_Scheduler::get_instance();
+		$plugin = AIPS_Core::get_instance();
 		$plugin->init();
 
 		$this->assertSame(
@@ -234,7 +234,7 @@ class Test_AIPS_Context_Boot extends WP_UnitTestCase {
 		}
 
 		// All context globals default to false (frontend).
-		$plugin = AI_Post_Scheduler::get_instance();
+		$plugin = AIPS_Core::get_instance();
 		$plugin->init();
 
 		$this->assertSame(
@@ -256,7 +256,7 @@ class Test_AIPS_Context_Boot extends WP_UnitTestCase {
 
 		$GLOBALS['aips_test_is_admin'] = true;
 
-		$plugin = AI_Post_Scheduler::get_instance();
+		$plugin = AIPS_Core::get_instance();
 		$plugin->init();
 
 		$this->assertGreaterThan(
@@ -278,7 +278,7 @@ class Test_AIPS_Context_Boot extends WP_UnitTestCase {
 
 		$GLOBALS['aips_test_is_admin'] = true;
 
-		$plugin = AI_Post_Scheduler::get_instance();
+		$plugin = AIPS_Core::get_instance();
 		$plugin->init();
 
 		$this->assertSame(
@@ -341,7 +341,7 @@ class Test_AIPS_Context_Boot extends WP_UnitTestCase {
 		$GLOBALS['aips_test_doing_cron'] = true;
 		$GLOBALS['aips_test_is_admin']   = true;
 
-		$plugin = AI_Post_Scheduler::get_instance();
+		$plugin = AIPS_Core::get_instance();
 		$plugin->init();
 
 		// Cron path must be taken: scheduler hook present, admin_menu absent.
@@ -420,7 +420,7 @@ class Test_AIPS_Context_Boot extends WP_UnitTestCase {
 
 		$GLOBALS['aips_test_is_admin'] = true;
 
-		$plugin = AI_Post_Scheduler::get_instance();
+		$plugin = AIPS_Core::get_instance();
 		$plugin->init();
 
 		$this->assertNull(
@@ -440,7 +440,7 @@ class Test_AIPS_Context_Boot extends WP_UnitTestCase {
 		$this->reset_singleton_instance( 'AIPS_Scheduler' );
 
 		// All context globals default to false — frontend context.
-		$plugin = AI_Post_Scheduler::get_instance();
+		$plugin = AIPS_Core::get_instance();
 		$plugin->init();
 
 		$this->assertNull(
@@ -461,7 +461,7 @@ class Test_AIPS_Context_Boot extends WP_UnitTestCase {
 
 		$GLOBALS['aips_test_is_admin'] = true;
 
-		$plugin = AI_Post_Scheduler::get_instance();
+		$plugin = AIPS_Core::get_instance();
 		$plugin->init();
 
 		$this->assertNull(
@@ -482,7 +482,7 @@ class Test_AIPS_Context_Boot extends WP_UnitTestCase {
 
 		$GLOBALS['aips_test_is_admin'] = true;
 
-		$plugin = AI_Post_Scheduler::get_instance();
+		$plugin = AIPS_Core::get_instance();
 		$plugin->init();
 
 		$this->assertNull(
@@ -503,7 +503,7 @@ class Test_AIPS_Context_Boot extends WP_UnitTestCase {
 
 		$GLOBALS['aips_test_is_admin'] = true;
 
-		$plugin = AI_Post_Scheduler::get_instance();
+		$plugin = AIPS_Core::get_instance();
 		$plugin->init();
 
 		$this->assertNull(


### PR DESCRIPTION
This PR refactors the main plugin bootstrap file (`ai-post-scheduler.php`) to reduce code clutter, improve separation of concerns, and make the bootstrap process easier to maintain. 

The main file has been simplified from nearly 1,000 lines to a clean loader script by extracting the global constants and core initialization logic into separate files:
1. **Global Constants**: Moved to a new dedicated file [constants.php](file:///c:/Projects/NunezScheduler/wp-ai-scheduler/ai-post-scheduler/includes/constants.php).
2. **Core Bootstrap & Lifecycle**: Extracted all context-aware boot routines (`boot_common`, `boot_cron`, `boot_ajax`, `boot_admin`, `boot_frontend`), activation/deactivation callbacks, container bindings, and event definitions into the new `AIPS_Core` singleton class in [class-aips-core.php](file:///c:/Projects/NunezScheduler/wp-ai-scheduler/ai-post-scheduler/includes/class-aips-core.php).
3. **Backward Compatibility**: Kept a thin `AI_Post_Scheduler` class delegate wrapper in [ai-post-scheduler.php](file:///c:/Projects/NunezScheduler/wp-ai-scheduler/ai-post-scheduler/ai-post-scheduler.php) forwarding calls to `AIPS_Core` to ensure third-party integrations, theme callbacks, or other tools continue to function without breaking.