### PR TITLE
⚡ Bolt: Fix N+1 post queries by priming post cache

### DIFF
--- a/ai-post-scheduler/.build/bolt.md
+++ b/ai-post-scheduler/.build/bolt.md
@@ -4,3 +4,9 @@
 **PR:** ⚡ Bolt: Hoist date and time format options outside of loops in generated posts controller
 **Learning:** Hoisting get_option('date_format') and get_option('time_format') out of loops reduces redundant DB queries and function calls.
 **Action:** Always check loops for repeated WP option calls and extract them into variables.
+## 2026-06-20 - Fix N+1 post queries by priming post cache
+**Area:** ai-post-scheduler/includes (Multiple Controllers)
+**Status:** opened PR
+**PR:** ⚡ Bolt: Fix N+1 post queries by priming post cache
+**Learning:** In loops where `get_post($id)` is repeatedly called for various arrays, doing a single `_prime_post_caches()` with all the IDs ensures that they are fetched from the database in a single batched query instead of one query per post.
+**Action:** Identify `get_post()` calls inside loops processing multiple objects or IDs, pre-fetch IDs into an array, and use `_prime_post_caches()` outside the loop.

--- a/ai-post-scheduler/includes/class-aips-admin-flow-controller.php
+++ b/ai-post-scheduler/includes/class-aips-admin-flow-controller.php
@@ -13,7 +13,7 @@ class AIPS_Admin_Flow_Controller extends AIPS_Campaigns_Controller {
 
 	const PAGE_SLUG = AIPS_Campaigns_Controller::PAGE_SLUG;
 
-	public function render_page() {
+	public function render_page($embedded = false) {
 		$this->render_wizard_page();
 	}
 }

--- a/ai-post-scheduler/includes/class-aips-authors-controller.php
+++ b/ai-post-scheduler/includes/class-aips-authors-controller.php
@@ -366,6 +366,18 @@ class AIPS_Authors_Controller {
 		$posts = $this->logs_repository->get_generated_posts_by_author($author_id);
 		
 		// Enrich with WordPress post data
+		if (function_exists('_prime_post_caches')) {
+			$post_ids = array();
+			foreach ($posts as $post) {
+				if ($post->post_id) {
+					$post_ids[] = $post->post_id;
+				}
+			}
+			if (!empty($post_ids)) {
+				_prime_post_caches(array_unique($post_ids), false, true);
+			}
+		}
+
 		foreach ($posts as &$post) {
 			if ($post->post_id) {
 				$wp_post = get_post($post->post_id);
@@ -478,6 +490,18 @@ class AIPS_Authors_Controller {
 		// Get logs for this topic (UI display only — capped at 200 entries).
 		$logs = $this->logs_repository->get_by_topic($topic_id, 200);
 		
+		if (function_exists('_prime_post_caches')) {
+			$post_ids = array();
+			foreach ($logs as $log) {
+				if ($log->action === 'post_generated' && $log->post_id) {
+					$post_ids[] = $log->post_id;
+				}
+			}
+			if (!empty($post_ids)) {
+				_prime_post_caches(array_unique($post_ids), false, true);
+			}
+		}
+
 		$posts = array();
 		foreach ($logs as $log) {
 			// Only include post_generated logs with valid post IDs.

--- a/ai-post-scheduler/includes/class-aips-generated-posts-controller.php
+++ b/ai-post-scheduler/includes/class-aips-generated-posts-controller.php
@@ -97,6 +97,20 @@ class AIPS_Generated_Posts_Controller {
 
 		// Get schedule data for each post
 		$posts_data = array();
+
+		// Pre-fetch post caches for Generated Posts
+		if (function_exists('_prime_post_caches')) {
+			$post_ids = array();
+			foreach ($history['items'] as $item) {
+				if ($item->post_id) {
+					$post_ids[] = $item->post_id;
+				}
+			}
+			if (!empty($post_ids)) {
+				_prime_post_caches(array_unique($post_ids), false, true);
+			}
+		}
+
 		foreach ($history['items'] as $item) {
 			if (!$item->post_id) {
 				continue;
@@ -156,6 +170,20 @@ class AIPS_Generated_Posts_Controller {
 		));
 
 		$partial_posts_data = array();
+
+		// Pre-fetch post caches for Partial Generations
+		if (function_exists('_prime_post_caches')) {
+			$partial_post_ids = array();
+			foreach ($partial_generations['items'] as $item) {
+				if ($item->post_id) {
+					$partial_post_ids[] = $item->post_id;
+				}
+			}
+			if (!empty($partial_post_ids)) {
+				_prime_post_caches(array_unique($partial_post_ids), false, true);
+			}
+		}
+
 		foreach ($partial_generations['items'] as $item) {
 			if (!$item->post_id) {
 				continue;

--- a/ai-post-scheduler/includes/class-aips-internal-links-controller.php
+++ b/ai-post-scheduler/includes/class-aips-internal-links-controller.php
@@ -462,6 +462,18 @@ class AIPS_Internal_Links_Controller {
 		// Fetch all accepted suggestions for this source post.
 		$accepted = $this->links_repo->get_by_source_post($suggestion->source_post_id, 'accepted');
 
+		if (function_exists('_prime_post_caches')) {
+			$post_ids = array();
+			foreach ($accepted as $s) {
+				if ($s->target_post_id) {
+					$post_ids[] = $s->target_post_id;
+				}
+			}
+			if (!empty($post_ids)) {
+				_prime_post_caches(array_unique($post_ids), false, true);
+			}
+		}
+
 		$suggestions_data = array();
 		foreach ($accepted as $s) {
 			$target_post = get_post($s->target_post_id);

--- a/ai-post-scheduler/includes/class-aips-internal-links-service.php
+++ b/ai-post-scheduler/includes/class-aips-internal-links-service.php
@@ -298,6 +298,18 @@ class AIPS_Internal_Links_Service {
 
 		$created_ids = array();
 
+		if (function_exists('_prime_post_caches')) {
+			$post_ids = array();
+			foreach ($neighbors as $neighbor) {
+				if (!empty($neighbor['id'])) {
+					$post_ids[] = (int) $neighbor['id'];
+				}
+			}
+			if (!empty($post_ids)) {
+				_prime_post_caches(array_unique($post_ids), false, true);
+			}
+		}
+
 		foreach ($neighbors as $neighbor) {
 			$target_post_id  = (int) $neighbor['id'];
 			$similarity      = (float) $neighbor['similarity'];

--- a/ai-post-scheduler/includes/class-aips-post-review.php
+++ b/ai-post-scheduler/includes/class-aips-post-review.php
@@ -310,6 +310,10 @@ class AIPS_Post_Review {
 		
 		$success_count = 0;
 		$failed_count = 0;
+
+		if (function_exists('_prime_post_caches') && !empty($post_ids)) {
+			_prime_post_caches(array_unique($post_ids), false, true);
+		}
 		
 		foreach ($post_ids as $post_id) {
 			// Verify the post exists and is a draft

--- a/ai-post-scheduler/includes/class-aips-schedule-controller.php
+++ b/ai-post-scheduler/includes/class-aips-schedule-controller.php
@@ -199,6 +199,19 @@ class AIPS_Schedule_Controller {
     private function get_generated_post_modal_data($post_ids) {
         $posts = array();
 
+        if (function_exists('_prime_post_caches') && !empty($post_ids)) {
+            $valid_ids = array();
+            foreach ($post_ids as $pid) {
+                $pid = absint($pid);
+                if ($pid) {
+                    $valid_ids[] = $pid;
+                }
+            }
+            if (!empty($valid_ids)) {
+                _prime_post_caches(array_unique($valid_ids), false, true);
+            }
+        }
+
         foreach ($post_ids as $post_id) {
             $post_id = absint($post_id);
 

--- a/ai-post-scheduler/includes/class-aips-taxonomy-controller.php
+++ b/ai-post-scheduler/includes/class-aips-taxonomy-controller.php
@@ -182,6 +182,11 @@ class AIPS_Taxonomy_Controller {
 
 		// Build post content summary
 		$post_contents = array();
+
+		if (function_exists('_prime_post_caches') && !empty($post_ids)) {
+			_prime_post_caches(array_unique($post_ids), false, true);
+		}
+
 		foreach ($post_ids as $post_id) {
 			$post = get_post($post_id);
 			if ($post) {


### PR DESCRIPTION
**What:** In loops iterating over history records, authors, links, schedules, and taxonomy lists that eventually query `get_post($id)`, we've added a pre-fetch cache primer step outside the loop by extracting post IDs into an array and using `_prime_post_caches()`. 
**Why:** Directly querying `get_post()` within a `foreach` loop repeatedly triggers single database hits per ID, resulting in N+1 query bottlenecks that dramatically slow down admin dashboards as history items accumulate. Using `_prime_post_caches()` batches them efficiently.
**Impact:** Significantly faster load times in the generated posts lists, authors list, partial generations, post reviews list, and history records list by saving potentially hundreds of DB reads during formatting.
**Measurement:** View query counts via Query Monitor or equivalent logging in the admin interface before/after these changes across the affected dashboards. Query times and DB hit count should measurably drop.

---
*PR created automatically by Jules for task [14906734252246795468](https://jules.google.com/task/14906734252246795468) started by @rpnunez*