### PR TITLE
Reduce per-request overhead introduced by devstacktips setup script

### DIFF
--- a/ai-post-scheduler/ai-post-scheduler.php
+++ b/ai-post-scheduler/ai-post-scheduler.php
@@ -3,7 +3,7 @@
  * Plugin Name: AI Post Scheduler
  * Plugin URI: https://nunezserver.com/nunezscheduler
  * Description: Schedule AI-generated posts using advanced features & scheduling options.
- * Version: 3.0.0
+ * Version: 3.0.1
  * Author: Raymond Nunez
  * Author URI: https://nunezserver.com
  * License: GPL v2 or later
@@ -24,10 +24,17 @@ if (!defined('AIPS_REQUEST_START')) {
     define('AIPS_REQUEST_START', microtime(true));
 }
 
-// Enable SAVEQUERIES as early as possible for telemetry-enabled requests so
-// slow/duplicate query analysis can inspect the collected query log.
+// Enable SAVEQUERIES for telemetry-enabled admin and cron requests only.
+// Enabling it on frontend page loads forces WordPress to keep every query in
+// memory for every visitor request, which is the single biggest per-request
+// overhead when telemetry is on.
 if (!defined('SAVEQUERIES') && function_exists('get_option') && get_option('aips_enable_telemetry', false)) {
-    define('SAVEQUERIES', true);
+    $aips_is_admin_or_cron = (defined('WP_ADMIN') && WP_ADMIN)
+                           || (defined('DOING_CRON') && DOING_CRON);
+    if ($aips_is_admin_or_cron) {
+        define('SAVEQUERIES', true);
+    }
+    unset($aips_is_admin_or_cron);
 }
 
 if (!defined('AIPS_TELEMETRY_SLOW_QUERY_MS')) {
@@ -44,7 +51,7 @@ if (!defined('AIPS_TELEMETRY_QUERY_SAMPLE_LIMIT')) {
 
 // Define plugin constants
 if (!defined('AIPS_VERSION')) {
-    define('AIPS_VERSION', '3.0.0');
+    define('AIPS_VERSION', '3.0.1');
 }
 
 if (!defined('AIPS_PLUGIN_DIR')) {
@@ -331,9 +338,25 @@ final class AI_Post_Scheduler {
         // Keep DB version initialization during activation.
         $defaults['aips_db_version'] = AIPS_VERSION;
         
+        // Large/complex options only needed during admin or cron — not on every
+        // frontend page load.  Marking them non-autoload prevents WordPress from
+        // pulling them into memory on each visitor request.
+        $no_autoload_keys = array(
+            'aips_notification_preferences',
+            'aips_research_niches',
+            'aips_site_niche',
+            'aips_site_target_audience',
+            'aips_site_content_goals',
+            'aips_site_brand_voice',
+            'aips_site_content_guidelines',
+            'aips_site_excluded_topics',
+            'aips_feature_flags',
+        );
+
         foreach ($defaults as $key => $value) {
             if (!AIPS_Config::get_instance()->has_option($key)) {
-                add_option($key, $value);
+                $autoload = in_array($key, $no_autoload_keys, true) ? false : null;
+                add_option($key, $value, '', $autoload);
             }
         }
     }
@@ -752,13 +775,26 @@ final class AI_Post_Scheduler {
             AIPS_Embeddings_Cron::instance()->process_author_embeddings($args);
         }, 10, 1);
 
-        // Research controller registers the aips_scheduled_research cron hook.
-        new AIPS_Research_Controller();
+        // Research controller: lazy-resolve only when its hook fires, using the
+        // same self-removing priority-5 resolver pattern as the other cron handlers
+        // above. Avoids constructing AIPS_Research_Service, the trending-topics
+        // repository, history service, etc. on every unrelated cron dispatch.
+        $research_resolver = null;
+        $research_resolver = function() use (&$research_resolver) {
+            remove_action('aips_scheduled_research', $research_resolver, 5);
+            AIPS_Research_Controller::instance();
+        };
+        add_action('aips_scheduled_research', $research_resolver, 5);
 
-        // Sources cron: fetch content for sources that have a fetch_interval configured.
-        // AIPS_Sources_Cron::schedule() handles registering the cron event at the
-        // correct recurrence (every_6_hours) during construction.
-        AIPS_Sources_Cron::instance();
+        // Sources cron: same lazy pattern — only construct the fetcher stack when
+        // the aips_fetch_sources hook actually fires. The cron event itself is
+        // already guaranteed to exist (registered at activation via get_cron_events()).
+        $sources_resolver = null;
+        $sources_resolver = function() use (&$sources_resolver) {
+            remove_action('aips_fetch_sources', $sources_resolver, 5);
+            AIPS_Sources_Cron::instance();
+        };
+        add_action('aips_fetch_sources', $sources_resolver, 5);
 
         // Notification event handler receives generation-failure/quota alerts from cron.
         new AIPS_Notifications();
@@ -840,11 +876,18 @@ final class AI_Post_Scheduler {
         // Native WordPress post list/editor History links for plugin containers.
         new AIPS_Post_History_UI();
 
-        // Internal Links controller must be available globally so the admin-menu
-        // render callback can call $controller->render_page() without reconstructing
-        // the object (which would double-register all AJAX hooks).
-        global $aips_internal_links_controller;
-        $aips_internal_links_controller = new AIPS_Internal_Links_Controller();
+        // Internal Links controller: only construct when on its admin page. The
+        // current_screen hook fires before the admin-menu page callback, so the
+        // global is set in time for render_internal_links_page(). AJAX requests
+        // from the internal links page are already routed via AIPS_Ajax_Registry
+        // in boot_ajax() and do not rely on this global.
+        add_action('current_screen', function() {
+            $screen = get_current_screen();
+            if ($screen && false !== strpos($screen->id, 'aips-internal-links')) {
+                global $aips_internal_links_controller;
+                $aips_internal_links_controller = new AIPS_Internal_Links_Controller();
+            }
+        });
     }
 
     /**

--- a/ai-post-scheduler/ai-post-scheduler.php
+++ b/ai-post-scheduler/ai-post-scheduler.php
@@ -355,7 +355,7 @@ final class AI_Post_Scheduler {
 
         foreach ($defaults as $key => $value) {
             if (!AIPS_Config::get_instance()->has_option($key)) {
-                $autoload = in_array($key, $no_autoload_keys, true) ? false : null;
+                $autoload = in_array($key, $no_autoload_keys, true) ? 'no' : 'yes';
                 add_option($key, $value, '', $autoload);
             }
         }
@@ -775,26 +775,18 @@ final class AI_Post_Scheduler {
             AIPS_Embeddings_Cron::instance()->process_author_embeddings($args);
         }, 10, 1);
 
-        // Research controller: lazy-resolve only when its hook fires, using the
-        // same self-removing priority-5 resolver pattern as the other cron handlers
-        // above. Avoids constructing AIPS_Research_Service, the trending-topics
-        // repository, history service, etc. on every unrelated cron dispatch.
-        $research_resolver = null;
-        $research_resolver = function() use (&$research_resolver) {
-            remove_action('aips_scheduled_research', $research_resolver, 5);
-            AIPS_Research_Controller::instance();
-        };
-        add_action('aips_scheduled_research', $research_resolver, 5);
+        // Research controller: lazy — only instantiate when hook fires. Direct closure
+        // avoids the priority-snapshotting pitfall: WordPress snapshots priorities at the
+        // start of do_action(), so a resolver that registers at priority 10 mid-dispatch
+        // would never execute in that cycle.
+        add_action('aips_scheduled_research', function() {
+            AIPS_Research_Controller::instance()->run_scheduled_research();
+        });
 
-        // Sources cron: same lazy pattern — only construct the fetcher stack when
-        // the aips_fetch_sources hook actually fires. The cron event itself is
-        // already guaranteed to exist (registered at activation via get_cron_events()).
-        $sources_resolver = null;
-        $sources_resolver = function() use (&$sources_resolver) {
-            remove_action('aips_fetch_sources', $sources_resolver, 5);
-            AIPS_Sources_Cron::instance();
-        };
-        add_action('aips_fetch_sources', $sources_resolver, 5);
+        // Sources cron: same direct-closure lazy pattern.
+        add_action('aips_fetch_sources', function() {
+            AIPS_Sources_Cron::instance()->run();
+        });
 
         // Notification event handler receives generation-failure/quota alerts from cron.
         new AIPS_Notifications();

--- a/ai-post-scheduler/includes/class-aips-cache.php
+++ b/ai-post-scheduler/includes/class-aips-cache.php
@@ -116,6 +116,14 @@ class AIPS_Cache {
 		}
 		$this->cache_index_checked = true;
 
+		// No value in recording cache-monitor events when the cache system is
+		// disabled — the array driver is ephemeral and the index entries would
+		// be noise.  Skip construction to avoid two extra DB writes per cache
+		// operation on sites where aips_enable_cache_system = false.
+		if (!self::is_system_enabled()) {
+			return null;
+		}
+
 		$enabled = get_option('aips_cache_monitor_index_enabled', '1');
 		if ($enabled === '0' || $enabled === 0 || $enabled === false) {
 			return null;

--- a/ai-post-scheduler/includes/class-aips-db-migrations.php
+++ b/ai-post-scheduler/includes/class-aips-db-migrations.php
@@ -154,6 +154,10 @@ class AIPS_DB_Migrations {
 			$this->migrate_to_2_9_1();
 		}
 
+		if ( version_compare( $from_version, '3.0.1', '<' ) ) {
+			$this->migrate_to_3_0_1();
+		}
+
 		// Use AIPS_Config::set_option() so the per-request option cache is
 		// invalidated immediately; bare update_option() would leave the cache
 		// stale for the rest of this request.
@@ -787,6 +791,43 @@ class AIPS_DB_Migrations {
 		// Step 3: Change the column type from BIGINT to TEXT.
 		$wpdb->query(
 			"ALTER TABLE `{$table}` MODIFY COLUMN post_category text DEFAULT NULL" // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		);
+	}
+
+	/**
+	 * Migration for version 3.0.1.
+	 *
+	 * Updates large/complex plugin options to autoload = false so they are not
+	 * pulled into memory on every WordPress page load. These options are only
+	 * needed during admin or cron requests, not on frontend page views.
+	 */
+	private function migrate_to_3_0_1() {
+		$no_autoload_keys = array(
+			'aips_notification_preferences',
+			'aips_research_niches',
+			'aips_site_niche',
+			'aips_site_target_audience',
+			'aips_site_content_goals',
+			'aips_site_brand_voice',
+			'aips_site_content_guidelines',
+			'aips_site_excluded_topics',
+			'aips_feature_flags',
+		);
+
+		$not_set = new stdClass();
+		$updated = 0;
+
+		foreach ( $no_autoload_keys as $key ) {
+			$value = get_option( $key, $not_set );
+			if ( $value !== $not_set ) {
+				update_option( $key, $value, false );
+				$updated++;
+			}
+		}
+
+		$this->logger->log(
+			sprintf( 'Migration 3.0.1: set autoload=no for %d plugin options.', $updated ),
+			'info'
 		);
 	}
 

--- a/ai-post-scheduler/includes/class-aips-db-migrations.php
+++ b/ai-post-scheduler/includes/class-aips-db-migrations.php
@@ -820,7 +820,7 @@ class AIPS_DB_Migrations {
 		foreach ( $no_autoload_keys as $key ) {
 			$value = get_option( $key, $not_set );
 			if ( $value !== $not_set ) {
-				update_option( $key, $value, false );
+				update_option( $key, $value, 'no' );
 				$updated++;
 			}
 		}

--- a/ai-post-scheduler/includes/class-aips-telemetry.php
+++ b/ai-post-scheduler/includes/class-aips-telemetry.php
@@ -180,9 +180,19 @@ class AIPS_Telemetry {
 			return;
 		}
 
+		$elapsed_ms = round((microtime(true) - $this->start_time) * 1000, 2);
+
+		// Skip ordinary frontend page loads. Recording every visitor request adds
+		// a DB write and JSON-serialisation cost per page view with minimal
+		// diagnostic value. Slow frontend requests still get recorded so outliers
+		// are not missed.
+		if ('frontend' === $this->resolve_request_type() && $elapsed_ms < (float) AIPS_TELEMETRY_SLOW_REQUEST_MS) {
+			$this->flushed = true;
+			return;
+		}
+
 		global $wpdb;
 
-		$elapsed_ms     = round((microtime(true) - $this->start_time) * 1000, 2);
 		$num_queries    = isset($wpdb) ? (int) $wpdb->num_queries : 0;
 		$peak_memory    = memory_get_peak_usage(true);
 		$user_id        = function_exists('is_user_logged_in') && is_user_logged_in() ? (int) get_current_user_id() : 0;


### PR DESCRIPTION
- Scope SAVEQUERIES to admin/cron only: the telemetry check at plugin
  header was enabling SAVEQUERIES on every frontend request, storing all
  DB queries in memory for every visitor page load.

- Skip telemetry flush for fast frontend requests: ordinary visitor
  pages no longer write a telemetry row unless they exceed the slow-
  request threshold, removing a DB INSERT + JSON serialisation from the
  shutdown path on every page view.

- Mark large plugin options non-autoload: aips_notification_preferences,
  aips_research_niches, and content-strategy strings are now stored with
  autoload=false so WordPress does not pull them into every request. A
  3.0.1 DB migration applies the change to existing installs.

- Lazy-load AIPS_Research_Controller and AIPS_Sources_Cron in boot_cron:
  both are now resolved only when their specific hook fires, matching the
  pattern used by the other cron handlers and avoiding eager construction
  of 6+ objects on every unrelated cron dispatch.

- Lazy-load AIPS_Internal_Links_Controller in boot_admin: the controller
  is now constructed only when the internal-links admin screen is
  detected via current_screen; AJAX actions were already routed through
  AIPS_Ajax_Registry independently.

- Skip cache-monitor index when cache system is disabled: AIPS_Cache now
  returns null from get_cache_index() when aips_enable_cache_system is
  false, preventing index DB writes for ephemeral array-driver operations.

- Bump version to 3.0.1.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RbwP4d29M4dG4PxHrJgkQU