### PR TITLE
Add "View Source Data" header action to Trusted Sources page

### DIFF
--- a/ai-post-scheduler/templates/admin/sources.php
+++ b/ai-post-scheduler/templates/admin/sources.php
@@ -50,6 +50,10 @@ $is_embedded_sources_view = !empty($embedded);
 					<p class="aips-page-description"><?php esc_html_e('Add URLs that the AI should reference and cite when generating post content. Assign Sources to Source Groups to allow Authors and Templates to selectively include them in their prompts.', 'ai-post-scheduler'); ?></p>
 				</div>
 				<div class="aips-page-actions">
+					<a class="aips-btn aips-btn-secondary" href="<?php echo esc_url(AIPS_Admin_Menu_Helper::get_page_url('aips-source-data')); ?>">
+						<span class="dashicons dashicons-archive"></span>
+						<?php esc_html_e('View Source Data', 'ai-post-scheduler'); ?>
+					</a>
 					<button type="button" class="aips-btn aips-btn-secondary" id="aips-manage-source-groups-btn">
 						<span class="dashicons dashicons-category"></span>
 						<?php esc_html_e('Manage Groups', 'ai-post-scheduler'); ?>


### PR DESCRIPTION
### Motivation
- Provide a quick header action on the Trusted Sources admin page that links to the all-source-data view so admins can inspect all fetched source snapshots without losing the per-source "Manage Data" action.

### Description
- Inserted a header action anchor in `ai-post-scheduler/templates/admin/sources.php` that links to `AIPS_Admin_Menu_Helper::get_page_url('aips-source-data')` and is labeled `View Source Data`, while keeping the existing per-row `Manage Data` links unchanged.

### Testing
- Ran `php -l ai-post-scheduler/templates/admin/sources.php` and the file reported no syntax errors (success). 
- Attempted to run `gh pr list --limit 20` to verify existing PRs as required, but the GitHub CLI is not installed in this environment so that pre-check could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a381fbdcf80832183adc75a2a9043b9)