### PR TITLE
Address content enhancement review feedback

### DIFF
--- a/ai-post-scheduler/includes/class-aips-content-enhancement-repository.php
+++ b/ai-post-scheduler/includes/class-aips-content-enhancement-repository.php
@@ -165,12 +165,12 @@ class AIPS_Content_Enhancement_Repository {
 	private function normalize( array $data, string $id, int $now ): array {
 		$config     = AIPS_Config::get_instance();
 		$allowlist  = $config->get_option( 'aips_content_enhancement_provider_allowlist', array() );
-		$provider   = sanitize_key( $data['provider'] ?? 'custom' );
+		$provider   = sanitize_key( ! empty( $data['provider'] ) ? $data['provider'] : 'custom' );
 		$is_allowed = empty( $allowlist ) || in_array( $provider, $allowlist, true );
-		$type       = sanitize_key( $data['type'] ?? $provider );
-		$types      = array( 'embed', 'calculator', 'ticker', 'code_playground', 'cta_card', 'comparison_table', 'shortcode' );
+		$type       = sanitize_key( ! empty( $data['type'] ) ? $data['type'] : $provider );
+		$types      = array_keys( AIPS_Content_Enhancement::get_types() );
 		$name       = sanitize_text_field( $data['name'] ?? '' );
-		$slug       = sanitize_title( $data['slug'] ?? $name );
+		$slug       = ! empty( $data['slug'] ) ? sanitize_title( $data['slug'] ) : sanitize_title( $name );
 
 		return array(
 			'id'              => $id,

--- a/ai-post-scheduler/includes/class-aips-content-enhancement.php
+++ b/ai-post-scheduler/includes/class-aips-content-enhancement.php
@@ -22,14 +22,14 @@ class AIPS_Content_Enhancement {
 	 */
 	public static function from_array( array $data ): array {
 		$name = sanitize_text_field( $data['name'] ?? '' );
-		$slug = sanitize_title( $data['slug'] ?? $name );
+		$slug = ! empty( $data['slug'] ) ? sanitize_title( $data['slug'] ) : sanitize_title( $name );
 
 		return array(
 			'id'              => sanitize_key( $data['id'] ?? '' ),
 			'slug'            => $slug ? $slug : sanitize_key( $data['id'] ?? '' ),
 			'name'            => $name,
-			'type'            => sanitize_key( $data['type'] ?? $data['provider'] ?? 'embed' ),
-			'provider'        => sanitize_key( $data['provider'] ?? 'custom' ),
+			'type'            => sanitize_key( ! empty( $data['type'] ) ? $data['type'] : ( ! empty( $data['provider'] ) ? $data['provider'] : 'embed' ) ),
+			'provider'        => sanitize_key( ! empty( $data['provider'] ) ? $data['provider'] : 'custom' ),
 			'use_case'        => sanitize_textarea_field( $data['use_case'] ?? $data['description'] ?? '' ),
 			'disclosure_text' => sanitize_textarea_field( $data['disclosure_text'] ?? '' ),
 			'cta_text'        => sanitize_text_field( $data['cta_text'] ?? '' ),
@@ -37,6 +37,23 @@ class AIPS_Content_Enhancement {
 			'is_active'       => ! empty( $data['is_active'] ),
 			'created_at'      => absint( $data['created_at'] ?? 0 ),
 			'updated_at'      => absint( $data['updated_at'] ?? 0 ),
+		);
+	}
+
+	/**
+	 * Get supported enhancement types and labels.
+	 *
+	 * @return array<string, string>
+	 */
+	public static function get_types(): array {
+		return array(
+			'embed'            => __( 'Embed', 'ai-post-scheduler' ),
+			'calculator'       => __( 'Calculator', 'ai-post-scheduler' ),
+			'ticker'           => __( 'Ticker', 'ai-post-scheduler' ),
+			'code_playground'  => __( 'Code Playground', 'ai-post-scheduler' ),
+			'cta_card'         => __( 'CTA Card', 'ai-post-scheduler' ),
+			'comparison_table' => __( 'Comparison Table', 'ai-post-scheduler' ),
+			'shortcode'        => __( 'Shortcode', 'ai-post-scheduler' ),
 		);
 	}
 }

--- a/ai-post-scheduler/includes/class-aips-content-enhancements-controller.php
+++ b/ai-post-scheduler/includes/class-aips-content-enhancements-controller.php
@@ -57,12 +57,24 @@ class AIPS_Content_Enhancements_Controller {
 			return;
 		}
 
+		$slug = sanitize_title( wp_unslash( $_POST['slug'] ?? '' ) );
+		if ( empty( $slug ) ) {
+			$slug = sanitize_title( $name );
+		}
+
+		$id       = sanitize_key( wp_unslash( $_POST['enhancement_id'] ?? '' ) );
+		$existing = $this->repository->find_by_slug( $slug );
+		if ( $existing && ( empty( $id ) || $existing['id'] !== $id ) ) {
+			AIPS_Ajax_Response::invalid_request( __( 'An enhancement with this slug already exists.', 'ai-post-scheduler' ) );
+			return;
+		}
+
 		$record = $this->repository->save( array(
-			'id'              => sanitize_key( wp_unslash( $_POST['enhancement_id'] ?? '' ) ),
+			'id'              => $id,
 			'name'            => $name,
 			'provider'        => $provider,
 			'type'            => $type,
-			'slug'            => sanitize_title( wp_unslash( $_POST['slug'] ?? '' ) ),
+			'slug'            => $slug,
 			'use_case'        => sanitize_textarea_field( wp_unslash( $_POST['use_case'] ?? '' ) ),
 			'disclosure_text' => sanitize_textarea_field( wp_unslash( $_POST['disclosure_text'] ?? '' ) ),
 			'cta_text'        => sanitize_text_field( wp_unslash( $_POST['cta_text'] ?? '' ) ),

--- a/ai-post-scheduler/includes/class-aips-prompt-builder-content-enhancement.php
+++ b/ai-post-scheduler/includes/class-aips-prompt-builder-content-enhancement.php
@@ -35,14 +35,11 @@ class AIPS_Prompt_Builder_Content_Enhancement {
 		);
 
 		foreach ( $enhancements as $enhancement ) {
-			$lines[] = sprintf(
-				'- %s (slug: %s, type: %s, provider: %s) Use when: %s',
-				$enhancement['name'] ?? '',
-				$enhancement['slug'] ?? '',
-				$enhancement['type'] ?? 'embed',
-				$enhancement['provider'] ?? 'custom',
-				$enhancement['use_case'] ?? ''
-			);
+			$lines[] = '- ' . ( $enhancement['name'] ?? '' ) .
+				' (slug: ' . ( $enhancement['slug'] ?? '' ) .
+				', type: ' . ( $enhancement['type'] ?? 'embed' ) .
+				', provider: ' . ( $enhancement['provider'] ?? 'custom' ) .
+				') Use when: ' . ( $enhancement['use_case'] ?? '' );
 		}
 
 		return implode( "\n", $lines );

--- a/ai-post-scheduler/templates/admin/dev-tools.php
+++ b/ai-post-scheduler/templates/admin/dev-tools.php
@@ -104,8 +104,8 @@ $content_enhancement_default_cta = $config->get_option('aips_content_enhancement
                     <div class="aips-form-row">
                         <label for="content_enhancement_type"><?php esc_html_e('Type', 'ai-post-scheduler'); ?></label>
                         <select id="content_enhancement_type" name="type" class="aips-form-input">
-                            <?php foreach (array('embed', 'calculator', 'ticker', 'code_playground', 'cta_card', 'comparison_table', 'shortcode') as $type) : ?>
-                                <option value="<?php echo esc_attr($type); ?>"><?php echo esc_html(ucwords(str_replace('_', ' ', $type))); ?></option>
+                            <?php foreach ( AIPS_Content_Enhancement::get_types() as $type => $label ) : ?>
+                                <option value="<?php echo esc_attr($type); ?>"><?php echo esc_html($label); ?></option>
                             <?php endforeach; ?>
                         </select>
                     </div>


### PR DESCRIPTION
### Motivation
- Fix several review-flagged issues in the Content Enhancements subsystem to improve safety, input normalization, and maintainability. 
- Prevent runtime crashes or malformed prompt output when user-supplied fields contain `%` characters and avoid ambiguous empty-field fallbacks. 
- Ensure the admin UI and AJAX save flow use a single source of truth for enhancement types and prevent slug collisions.

### Description
- Replaced `sprintf()` usage in `AIPS_Prompt_Builder_Content_Enhancement::build_content_enhancement_block` with safe string concatenation to avoid `sprintf` format-specifier issues with user-controlled text. 
- Normalized empty `slug`, `type`, and `provider` handling in `AIPS_Content_Enhancement::from_array` and `AIPS_Content_Enhancement_Repository::normalize` by using `! empty()` checks and explicit fallbacks. 
- Added `AIPS_Content_Enhancement::get_types()` to centralize enhancement type metadata and switched the repository to use `array_keys( AIPS_Content_Enhancement::get_types() )` for validation. 
- Added duplicate-slug validation to the AJAX save flow in `AIPS_Content_Enhancements_Controller::ajax_save` to reject saves when another enhancement already uses the slug, and updated the Dev Tools form to render type options from `AIPS_Content_Enhancement::get_types()`.

### Testing
- Ran PHP lint on modified files using `php -l` for `ai-post-scheduler/includes/class-aips-content-enhancement.php`, `ai-post-scheduler/includes/class-aips-content-enhancements-controller.php`, `ai-post-scheduler/includes/class-aips-content-enhancement-repository.php`, `ai-post-scheduler/includes/class-aips-prompt-builder-content-enhancement.php`, and `ai-post-scheduler/templates/admin/dev-tools.php`, all of which returned no syntax errors. 
- Ran `git diff --check` to ensure no diff whitespace or check errors were introduced and it reported clean. 
- No full PHPUnit test suite was executed per repository testing policy; only focused static/syntax checks listed above were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38828851e083218be3a2bd9dbe4ecd)