### PR TITLE
🎨 Palette: Taxonomy Admin Template Accessibility Improvements

### DIFF
--- a/ai-post-scheduler/.build/palette.md
+++ b/ai-post-scheduler/.build/palette.md
@@ -4,3 +4,9 @@
 **PR:** 🎨 Palette: Standardize Admin Modals Structure and Button Classes
 **Learning:** Inconsistent HTML structure in modals (missing headers, unstructured buttons) degrades both visual consistency and codebase maintainability.
 **Action:** Always ensure modals follow the `.aips-modal-header`, `.aips-modal-body`, `.aips-modal-footer` structure and use standardized `.aips-btn` classes for primary/secondary actions. Avoid redundant ID mapping when a standard class (`.aips-modal-title`, `.aips-modal-content-body`) provides sufficient hooks for dynamic JS updates.
+## 2024-06-26 - Taxonomy Screen Accessibility
+**Area:** Admin Templates (`templates/admin/taxonomy.php`)
+**Status:** opened PR
+**PR:** 🎨 Palette: Taxonomy Admin Template Accessibility Improvements
+**Learning:** Decorative icons and 'x' remove buttons in JS templates often lack appropriate ARIA attributes.
+**Action:** Add `aria-hidden="true"` to purely decorative `dashicons` spans, and ensure JS template buttons (like `&times;` remove actions) have an `aria-label` attribute (with proper translation via `esc_attr_e`) for screen reader support.

--- a/ai-post-scheduler/templates/admin/taxonomy.php
+++ b/ai-post-scheduler/templates/admin/taxonomy.php
@@ -33,7 +33,7 @@ $is_embedded_taxonomy_view = !empty($embedded);
 				</div>
 				<div class="aips-page-actions">
 					<button class="aips-btn aips-btn-primary aips-generate-taxonomy" id="aips-open-generate-modal">
-						<span class="dashicons dashicons-update"></span>
+						<span class="dashicons dashicons-update" aria-hidden="true"></span>
 						<?php esc_html_e('Generate Taxonomy', 'ai-post-scheduler'); ?>
 					</button>
 				</div>
@@ -234,6 +234,6 @@ $is_embedded_taxonomy_view = !empty($embedded);
 <script type="text/html" id="aips-tmpl-selected-post">
 <div class="aips-selected-post" data-post-id="{{id}}">
 	<span>{{title}}</span>
-	<button type="button" class="aips-remove-post" data-post-id="{{id}}">&times;</button>
+	<button type="button" class="aips-remove-post" data-post-id="{{id}}" aria-label="<?php esc_attr_e('Remove post', 'ai-post-scheduler'); ?>">&times;</button>
 </div>
 </script>


### PR DESCRIPTION
**What:** 
- Added `aria-hidden="true"` to a purely decorative `<span class="dashicons dashicons-update">` icon in the Taxonomy admin template.
- Added `aria-label="<?php esc_attr_e('Remove post', 'ai-post-scheduler'); ?>"` to the `.aips-remove-post` button in the JS template (`aips-tmpl-selected-post`), as it only contained a visual `&times;` symbol.

**Why:** 
Buttons and icons in JS templates often lack appropriate ARIA attributes, making them difficult to use or understand for users relying on screen readers.

**Accessibility:** 
- Screen readers will now ignore the decorative update icon, reducing unnecessary noise.
- Screen readers will now announce "Remove post" (localized) when focusing on the remove button, instead of attempting to read the HTML entity `&times;` (often read as "times" or "multiplication").

**Verification:** 
- Ensure the plugin loads without PHP errors (verified via `php -l`).
- Check the Taxonomy screen in the WordPress admin to ensure visual rendering is unaffected.
- Inspect the update icon and the selected post remove button to confirm the new attributes are present.

**Before/After:**
*(No visual UI changes, DOM attribute changes only)*

---
*PR created automatically by Jules for task [3396101826790167075](https://jules.google.com/task/3396101826790167075) started by @rpnunez*