### PR TITLE
⚡ Bolt: Fix N+1 queries in schedule controller modal generation

### DIFF
--- a/ai-post-scheduler/.build/bolt.md
+++ b/ai-post-scheduler/.build/bolt.md
@@ -4,3 +4,10 @@
 **PR:** ⚡ Bolt: Hoist date and time format options outside of loops in generated posts controller
 **Learning:** Hoisting get_option('date_format') and get_option('time_format') out of loops reduces redundant DB queries and function calls.
 **Action:** Always check loops for repeated WP option calls and extract them into variables.
+
+## 2026-06-26 - Pre-fetch posts in schedule modal data
+**Area:** ai-post-scheduler/includes/class-aips-schedule-controller.php
+**Status:** opened PR
+**PR:** ⚡ Bolt: Fix N+1 queries in schedule controller modal generation
+**Learning:** Pre-fetching posts using `_prime_post_caches()` before a loop prevents N+1 queries when loading preview payloads.
+**Action:** Always pre-fetch posts into cache before iterating over a list of post IDs.

--- a/ai-post-scheduler/includes/class-aips-schedule-controller.php
+++ b/ai-post-scheduler/includes/class-aips-schedule-controller.php
@@ -199,6 +199,10 @@ class AIPS_Schedule_Controller {
     private function get_generated_post_modal_data($post_ids) {
         $posts = array();
 
+        if (function_exists('_prime_post_caches')) {
+            _prime_post_caches(array_unique(array_filter(array_map('absint', $post_ids))), false, true);
+        }
+
         foreach ($post_ids as $post_id) {
             $post_id = absint($post_id);
 


### PR DESCRIPTION
**What:** Pre-fetches posts in `get_generated_post_modal_data` using `_prime_post_caches` before looping.
**Why:** Prevents N+1 database queries when iterating through multiple post IDs in the frontend schedule modal.
**Impact:** Faster loading time and reduced database load for the schedule run history modal.
**Measurement:** Database query count during schedule modal load should be reduced significantly for schedules with multiple generated posts.

---
*PR created automatically by Jules for task [15795763873105069967](https://jules.google.com/task/15795763873105069967) started by @rpnunez*