### PR TITLE
🎨 Palette: [UX improvement] Add aria-label to icon-only remove buttons

### DIFF
--- a/.build/palette.md
+++ b/.build/palette.md
@@ -4,3 +4,9 @@
 ## 2026-05-30 - Added loading indicator when editing authors
 **Learning:** AJAX-driven edit modals within this repo can sometimes appear with empty fields while data is still loading, creating a confusing user experience. The standard pattern to solve this is to use the existing WordPress admin `.spinner` element within a loader container.
 **Action:** For future modal-based edit features, ensure a loader container is added alongside the form, and use JavaScript to hide the form and show the loader during the AJAX fetch phase. Only reveal the form when the data has successfully populated.
+## 2026-06-03 - Icon Button Accessibility
+**Area:** Admin Templates (`templates/admin/taxonomy.php`, `templates/admin/campaign-wizard.php`)
+**Status:** opened PR
+**PR:** 🎨 Palette: [UX improvement] Add aria-label to icon-only remove buttons
+**Learning:** Icon-only buttons (like those containing just `&times;` or a Dashicon trash icon) must have an explicit `aria-label` to provide an accessible name for screen reader users. The WCAG 2.5.3 (Label in Name) rule does not apply since these buttons do not have visible text.
+**Action:** Always add `aria-label="<?php esc_attr_e('Remove', 'ai-post-scheduler'); ?>"` to icon-only removal buttons.

--- a/ai-post-scheduler/templates/admin/campaign-wizard.php
+++ b/ai-post-scheduler/templates/admin/campaign-wizard.php
@@ -215,7 +215,7 @@ $authors = get_users(array(
 											<input type="number" name="post_type_rules[<?php echo esc_attr($index); ?>][quantity]" min="1" max="100" value="<?php echo esc_attr($rule['quantity'] ?? 1); ?>" style="width: 100%;">
 										</div>
 										<div style="padding-top: 20px;">
-											<button type="button" class="button button-small aips-remove-post-type-rule" title="<?php esc_attr_e('Remove', 'ai-post-scheduler'); ?>">
+											<button type="button" class="button button-small aips-remove-post-type-rule" aria-label="<?php esc_attr_e('Remove rule', 'ai-post-scheduler'); ?>" title="<?php esc_attr_e('Remove', 'ai-post-scheduler'); ?>">
 												<span class="dashicons dashicons-no-alt" style="margin-top: 2px;"></span>
 											</button>
 										</div>

--- a/ai-post-scheduler/templates/admin/taxonomy.php
+++ b/ai-post-scheduler/templates/admin/taxonomy.php
@@ -234,6 +234,6 @@ $is_embedded_taxonomy_view = !empty($embedded);
 <script type="text/html" id="aips-tmpl-selected-post">
 <div class="aips-selected-post" data-post-id="{{id}}">
 	<span>{{title}}</span>
-	<button type="button" class="aips-remove-post" data-post-id="{{id}}">&times;</button>
+	<button type="button" class="aips-remove-post" data-post-id="{{id}}" aria-label="<?php esc_attr_e('Remove selected post', 'ai-post-scheduler'); ?>">&times;</button>
 </div>
 </script>


### PR DESCRIPTION
**What:** 
Added `aria-label` to icon-only remove buttons in the taxonomy template and campaign wizard template.

**Why:** 
Buttons that only contain an icon (like `&times;` or a trash Dashicon) and lack visible text require an explicit accessible name for screen reader users to understand their function.

**Accessibility:** 
Improves screen reader clarity by providing an accessible name ("Remove selected post" or "Remove rule") to icon-only buttons. This change avoids WCAG 2.5.3 (Label in Name) issues because the buttons have no visible text.

**Verification:** 
Inspect the "Remove" button in the Taxonomy modal (when a post is selected) and the "Remove" button in the Campaign Wizard (when a post type rule is added). Confirm the `aria-label` attribute is present.

**Before/After:** 
No visual UI changes. This is purely an HTML accessibility improvement.

---
*PR created automatically by Jules for task [5815706397002569810](https://jules.google.com/task/5815706397002569810) started by @rpnunez*