### PR TITLE
⚡ Bolt: Optimize history CSV export query payload

### DIFF
--- a/.build/bolt.md
+++ b/.build/bolt.md
@@ -26,3 +26,9 @@
 ## 2026-03-24 - [Optimize Dashboard History Retrieval]
 **Learning:** Replacing `SELECT *` with hardcoded columns in a core repository method (like `get_history`) as a default fallback is an anti-pattern in this architecture. It creates high regression risks by starving callers of expected data (like `longtext` fields) and breaks forward compatibility when new columns are added. The safest performance optimization is to update the call sites (like list views or dashboard widgets) to explicitly request a lighter payload (e.g. `fields => 'list'`) when heavy data is unnecessary.
 **Action:** When optimizing database queries, prefer passing explicit optimization parameters from the caller rather than blindly altering default fallback behaviors in the underlying repository.
+## 2026-06-28 - Optimize CSV Export Query Payload
+**Area:** `AIPS_History::ajax_export_history`
+**Status:** opened PR
+**PR:** ⚡ Bolt: Optimize history CSV export query payload
+**Learning:** The CSV export was loading up to 10,000 history records with `fields => 'all'`, which included large `longtext` columns (`prompt`, `generated_content`, `generation_log`) that are never output in the CSV.
+**Action:** Explicitly pass `'fields' => 'list'` when querying history records for CSV export to reduce memory usage and query payload size.

--- a/ai-post-scheduler/includes/class-aips-history.php
+++ b/ai-post-scheduler/includes/class-aips-history.php
@@ -126,6 +126,7 @@ class AIPS_History {
             'correlation_id' => $correlation_id,
             'date_from' => $date_from,
             'date_to' => $date_to,
+            'fields' => 'list',
         ));
 
         $filename = 'aips-history-export-' . date('Y-m-d-H-i-s') . '.csv';


### PR DESCRIPTION
**What:** Explicitly requested `'fields' => 'list'` when fetching records for the history CSV export in `AIPS_History::ajax_export_history()`.

**Why:** The default `get_history` query retrieves `'all'` fields, including massive `longtext` columns like `prompt`, `generated_content`, and `generation_log`. Since the CSV export only includes metadata columns (ID, Title, Status, Dates, etc.), fetching `longtext` fields for up to 10,000 records wastes significant memory and database bandwidth.

**Impact:** Drastically reduces the memory footprint and database query time for history CSV exports, especially on large sites.

**Measurement:** Exporting a large history log will consume significantly less PHP memory, preventing OOM errors on heavy exports.

**Files:** `ai-post-scheduler/includes/class-aips-history.php`

**Testing:** Ran PHPUnit test suite.

---
*PR created automatically by Jules for task [16250208420543685015](https://jules.google.com/task/16250208420543685015) started by @rpnunez*