### PR TITLE
🏗️ Atlas: Refactor admin assets routing map to enforce Separation of Concerns

### DIFF
--- a/.build/atlas-journal.md
+++ b/.build/atlas-journal.md
@@ -1438,3 +1438,9 @@ This refactoring resolves the "unexpected title prompts" issue by eliminating du
 **Decision:** Extracted post-execution cleanup, failure logging, success logging, and history container logic into a dedicated `AIPS_Schedule_Result_Handler` class.
 **Consequence:** `AIPS_Schedule_Processor` is now strictly focused on the execution logic. Reduced the class size significantly and decoupled the specific handling of success and error states.
 **Tests:** Created `test-schedule-result-handler.php` to verify result handling. Test execution skipped per user request.
+
+## 2024-07-01 - Extract Routing Map for Admin Assets
+**Context:** `AIPS_Admin_Assets::enqueue_admin_assets()` functioned as a God Object with over 100 lines of if-else statements to map page hooks to their respective enqueuing scripts, violating the Open/Closed Principle.
+**Decision:** Extracted the routing logic into a protected `get_asset_routes($hook, $page)` method, returning a map of conditions and callbacks to dynamically invoke the correct asset scripts.
+**Consequence:** Increased abstraction slightly, but vastly improved maintainability and decoupled the mapping structure from the execution logic.
+**Tests:** Added `Test_AIPS_Admin_Assets.php` leveraging `ReflectionClass` to test the protected mapping method and ensure it correctly returns valid structures.

--- a/ai-post-scheduler/includes/class-aips-admin-assets.php
+++ b/ai-post-scheduler/includes/class-aips-admin-assets.php
@@ -70,7 +70,7 @@ class AIPS_Admin_Assets {
      * @param string $hook The current admin page hook.
 	 * @return void
 	 */
-	public function enqueue_admin_assets($hook) {
+		public function enqueue_admin_assets($hook) {
         $page = $this->get_current_page_slug();
 
         if (!$this->is_plugin_admin_page($hook, $page)) {
@@ -82,100 +82,199 @@ class AIPS_Admin_Assets {
 
 		$this->enqueue_global_assets();
 
-        if ($this->hook_contains($hook, self::HOOK_DASHBOARD) || self::PAGE_DASHBOARD === $page) {
-			$this->enqueue_dashboard_assets();
-		}
+		$routes = $this->get_asset_routes($hook, $page);
 
-        if (self::PAGE_AUTHORS === $page || self::PAGE_AUTHOR_TOPICS === $page || $this->hook_contains($hook, self::PAGE_AUTHORS) || $this->hook_contains($hook, self::PAGE_AUTHOR_TOPICS) || $this->is_automations_tab($page, 'authors') || $this->is_automations_tab($page, AIPS_Automations_Controller::TAB_AUTHOR_TOPICS)) {
-			$this->enqueue_authors_assets($hook);
-		}
+		foreach ($routes as $route) {
+			$is_match = false;
+			foreach ($route['conditions'] as $condition) {
+				if ($condition === true) {
+					$is_match = true;
+					break;
+				}
+			}
 
-        if (self::PAGE_POST_SLICES === $page || $this->hook_contains($hook, self::PAGE_POST_SLICES)) {
-			$this->enqueue_post_slices_assets();
+			if ($is_match) {
+				foreach ($route['methods'] as $method) {
+					call_user_func(array($this, $method), $hook);
+				}
+			}
 		}
+	}
 
-        if (self::PAGE_TEMPLATES === $page || $this->hook_contains($hook, self::PAGE_TEMPLATES) || $this->is_automations_tab($page, 'templates')) {
-			$this->enqueue_templates_assets();
-		}
-
-        if (self::PAGE_VOICES === $page || $this->hook_contains($hook, self::PAGE_VOICES)) {
-			$this->enqueue_voices_assets();
-		}
-
-        if (self::PAGE_STRUCTURES === $page || $this->hook_contains($hook, self::PAGE_STRUCTURES)) {
-			$this->enqueue_structures_assets();
-		}
-
-        if ((self::PAGE_SCHEDULE === $page || $this->hook_contains($hook, self::PAGE_SCHEDULE) || $this->is_automations_tab($page, 'schedules')) && self::PAGE_SCHEDULE_CALENDAR !== $page && !$this->hook_contains($hook, self::PAGE_SCHEDULE_CALENDAR)) {
-			$this->enqueue_schedule_assets($hook);
-		}
-
-        if (
-            self::PAGE_CAMPAIGNS === $page
-            || AIPS_Campaigns_Controller::DETAIL_PAGE_SLUG === $page
-            || $this->hook_contains($hook, self::PAGE_CAMPAIGNS)
-            || $this->hook_contains($hook, AIPS_Campaigns_Controller::DETAIL_PAGE_SLUG)
-            || $this->is_automations_tab($page, 'campaigns')
-        ) {
-			$this->enqueue_campaigns_assets();
-		}
-
-        if (self::PAGE_CAMPAIGN_WIZARD === $page || $this->hook_contains($hook, self::PAGE_CAMPAIGN_WIZARD)) {
-			$this->enqueue_campaign_wizard_assets();
-		}
-        if (self::PAGE_RESEARCH === $page || $this->hook_contains($hook, self::PAGE_RESEARCH)) {
-			$this->enqueue_research_assets();
-		}
-
-        if (self::PAGE_GENERATED_POSTS === $page || $this->hook_contains($hook, self::PAGE_GENERATED_POSTS)) {
-			$this->enqueue_generated_posts_assets();
-		}
-
-        if (self::PAGE_SCHEDULE_CALENDAR === $page || $this->hook_contains($hook, self::PAGE_SCHEDULE_CALENDAR)) {
-			$this->enqueue_schedule_calendar_assets();
-		}
-
-        if (self::PAGE_HISTORY === $page || $this->hook_contains($hook, self::PAGE_HISTORY)) {
-			$this->enqueue_history_assets();
-		}
-
-        if (self::PAGE_ONBOARDING === $page || $this->hook_contains($hook, self::PAGE_ONBOARDING)) {
-			$this->enqueue_onboarding_assets();
-		}
-
-		if ((self::PAGE_DEV_TOOLS === $page || $this->hook_contains($hook, self::PAGE_DEV_TOOLS) || $this->is_diagnostics_tab($page, 'dev-tools')) && AIPS_Config::get_instance()->get_option('aips_developer_mode')) {
-			$this->enqueue_dev_tools_assets();
-		}
-
-		if (self::PAGE_STATUS === $page || $this->hook_contains($hook, self::PAGE_STATUS) || $this->is_diagnostics_tab($page, 'status')) {
-			$this->enqueue_status_1_assets();
-			$this->enqueue_status_2_assets();
-		}
-
-        if (self::PAGE_TAXONOMY === $page || $this->hook_contains($hook, self::PAGE_TAXONOMY) || $this->is_automations_tab($page, 'taxonomy')) {
-			$this->enqueue_taxonomy_assets();
-		}
-
-        if (self::PAGE_SOURCES === $page || $this->hook_contains($hook, self::PAGE_SOURCES) || $this->is_automations_tab($page, 'sources')) {
-			$this->enqueue_sources_assets();
-		}
-
-        if (self::PAGE_SETTINGS === $page || $this->hook_contains($hook, self::PAGE_SETTINGS)) {
-			$this->enqueue_settings_assets();
-		}
-
-		if ((self::PAGE_TELEMETRY === $page || $this->hook_contains($hook, self::PAGE_TELEMETRY) || $this->is_diagnostics_tab($page, 'telemetry')) && AIPS_Config::get_instance()->get_option('aips_enable_telemetry')) {
-			$this->enqueue_telemetry_assets();
-		}
-
-        if (self::PAGE_INTERNAL_LINKS === $page || $this->hook_contains($hook, self::PAGE_INTERNAL_LINKS) || $this->is_automations_tab($page, 'internal-links')) {
-			$this->enqueue_internal_links_assets();
-		}
-
-        if (self::PAGE_CACHE_MONITOR === $page || $this->hook_contains($hook, self::PAGE_CACHE_MONITOR) || $this->is_diagnostics_tab($page, 'cache-monitor')) {
-			$this->enqueue_cache_monitor_assets();
-		}
-
+	/**
+	 * Get the routing map for admin assets.
+	 *
+	 * @param string $hook The current admin page hook.
+	 * @param string $page The current sanitized page slug.
+	 * @return array[] Routing map configuration.
+	 */
+	protected function get_asset_routes($hook, $page) {
+		return array(
+			array(
+				'conditions' => array(
+					$this->hook_contains($hook, self::HOOK_DASHBOARD),
+					self::PAGE_DASHBOARD === $page,
+				),
+				'methods'    => array('enqueue_dashboard_assets'),
+			),
+			array(
+				'conditions' => array(
+					self::PAGE_AUTHORS === $page,
+					self::PAGE_AUTHOR_TOPICS === $page,
+					$this->hook_contains($hook, self::PAGE_AUTHORS),
+					$this->hook_contains($hook, self::PAGE_AUTHOR_TOPICS),
+					$this->is_automations_tab($page, 'authors'),
+					$this->is_automations_tab($page, AIPS_Automations_Controller::TAB_AUTHOR_TOPICS),
+				),
+				'methods'    => array('enqueue_authors_assets'),
+			),
+			array(
+				'conditions' => array(
+					self::PAGE_POST_SLICES === $page,
+					$this->hook_contains($hook, self::PAGE_POST_SLICES),
+				),
+				'methods'    => array('enqueue_post_slices_assets'),
+			),
+			array(
+				'conditions' => array(
+					self::PAGE_TEMPLATES === $page,
+					$this->hook_contains($hook, self::PAGE_TEMPLATES),
+					$this->is_automations_tab($page, 'templates'),
+				),
+				'methods'    => array('enqueue_templates_assets'),
+			),
+			array(
+				'conditions' => array(
+					self::PAGE_VOICES === $page,
+					$this->hook_contains($hook, self::PAGE_VOICES),
+				),
+				'methods'    => array('enqueue_voices_assets'),
+			),
+			array(
+				'conditions' => array(
+					self::PAGE_STRUCTURES === $page,
+					$this->hook_contains($hook, self::PAGE_STRUCTURES),
+				),
+				'methods'    => array('enqueue_structures_assets'),
+			),
+			array(
+				'conditions' => array(
+					(self::PAGE_SCHEDULE === $page || $this->hook_contains($hook, self::PAGE_SCHEDULE) || $this->is_automations_tab($page, 'schedules')) && self::PAGE_SCHEDULE_CALENDAR !== $page && !$this->hook_contains($hook, self::PAGE_SCHEDULE_CALENDAR),
+				),
+				'methods'    => array('enqueue_schedule_assets'),
+			),
+			array(
+				'conditions' => array(
+					self::PAGE_CAMPAIGNS === $page,
+					AIPS_Campaigns_Controller::DETAIL_PAGE_SLUG === $page,
+					$this->hook_contains($hook, self::PAGE_CAMPAIGNS),
+					$this->hook_contains($hook, AIPS_Campaigns_Controller::DETAIL_PAGE_SLUG),
+					$this->is_automations_tab($page, 'campaigns'),
+				),
+				'methods'    => array('enqueue_campaigns_assets'),
+			),
+			array(
+				'conditions' => array(
+					self::PAGE_CAMPAIGN_WIZARD === $page,
+					$this->hook_contains($hook, self::PAGE_CAMPAIGN_WIZARD),
+				),
+				'methods'    => array('enqueue_campaign_wizard_assets'),
+			),
+			array(
+				'conditions' => array(
+					self::PAGE_RESEARCH === $page,
+					$this->hook_contains($hook, self::PAGE_RESEARCH),
+				),
+				'methods'    => array('enqueue_research_assets'),
+			),
+			array(
+				'conditions' => array(
+					self::PAGE_GENERATED_POSTS === $page,
+					$this->hook_contains($hook, self::PAGE_GENERATED_POSTS),
+				),
+				'methods'    => array('enqueue_generated_posts_assets'),
+			),
+			array(
+				'conditions' => array(
+					self::PAGE_SCHEDULE_CALENDAR === $page,
+					$this->hook_contains($hook, self::PAGE_SCHEDULE_CALENDAR),
+				),
+				'methods'    => array('enqueue_schedule_calendar_assets'),
+			),
+			array(
+				'conditions' => array(
+					self::PAGE_HISTORY === $page,
+					$this->hook_contains($hook, self::PAGE_HISTORY),
+				),
+				'methods'    => array('enqueue_history_assets'),
+			),
+			array(
+				'conditions' => array(
+					self::PAGE_ONBOARDING === $page,
+					$this->hook_contains($hook, self::PAGE_ONBOARDING),
+				),
+				'methods'    => array('enqueue_onboarding_assets'),
+			),
+			array(
+				'conditions' => array(
+					(self::PAGE_DEV_TOOLS === $page || $this->hook_contains($hook, self::PAGE_DEV_TOOLS) || $this->is_diagnostics_tab($page, 'dev-tools')) && AIPS_Config::get_instance()->get_option('aips_developer_mode'),
+				),
+				'methods'    => array('enqueue_dev_tools_assets'),
+			),
+			array(
+				'conditions' => array(
+					self::PAGE_STATUS === $page,
+					$this->hook_contains($hook, self::PAGE_STATUS),
+					$this->is_diagnostics_tab($page, 'status'),
+				),
+				'methods'    => array('enqueue_status_1_assets', 'enqueue_status_2_assets'),
+			),
+			array(
+				'conditions' => array(
+					self::PAGE_TAXONOMY === $page,
+					$this->hook_contains($hook, self::PAGE_TAXONOMY),
+					$this->is_automations_tab($page, 'taxonomy'),
+				),
+				'methods'    => array('enqueue_taxonomy_assets'),
+			),
+			array(
+				'conditions' => array(
+					self::PAGE_SOURCES === $page,
+					$this->hook_contains($hook, self::PAGE_SOURCES),
+					$this->is_automations_tab($page, 'sources'),
+				),
+				'methods'    => array('enqueue_sources_assets'),
+			),
+			array(
+				'conditions' => array(
+					self::PAGE_SETTINGS === $page,
+					$this->hook_contains($hook, self::PAGE_SETTINGS),
+				),
+				'methods'    => array('enqueue_settings_assets'),
+			),
+			array(
+				'conditions' => array(
+					(self::PAGE_TELEMETRY === $page || $this->hook_contains($hook, self::PAGE_TELEMETRY) || $this->is_diagnostics_tab($page, 'telemetry')) && AIPS_Config::get_instance()->get_option('aips_enable_telemetry'),
+				),
+				'methods'    => array('enqueue_telemetry_assets'),
+			),
+			array(
+				'conditions' => array(
+					self::PAGE_INTERNAL_LINKS === $page,
+					$this->hook_contains($hook, self::PAGE_INTERNAL_LINKS),
+					$this->is_automations_tab($page, 'internal-links'),
+				),
+				'methods'    => array('enqueue_internal_links_assets'),
+			),
+			array(
+				'conditions' => array(
+					self::PAGE_CACHE_MONITOR === $page,
+					$this->hook_contains($hook, self::PAGE_CACHE_MONITOR),
+					$this->is_diagnostics_tab($page, 'cache-monitor'),
+				),
+				'methods'    => array('enqueue_cache_monitor_assets'),
+			),
+		);
 	}
 
 	/**

--- a/ai-post-scheduler/tests/Test_AIPS_Admin_Assets.php
+++ b/ai-post-scheduler/tests/Test_AIPS_Admin_Assets.php
@@ -1,0 +1,20 @@
+<?php
+class Test_AIPS_Admin_Assets extends WP_UnitTestCase {
+    public function test_get_asset_routes() {
+        $assets = new AIPS_Admin_Assets();
+        $reflection = new ReflectionClass(AIPS_Admin_Assets::class);
+        $method = $reflection->getMethod('get_asset_routes');
+        $method->setAccessible(true);
+        $routes = $method->invokeArgs($assets, array('toplevel_page_ai-post-scheduler', 'ai-post-scheduler'));
+        $this->assertIsArray($routes);
+        $this->assertNotEmpty($routes);
+        $has_dashboard = false;
+        foreach ($routes as $route) {
+            if (in_array('enqueue_dashboard_assets', $route['methods'], true)) {
+                $has_dashboard = true;
+                $this->assertTrue($route['conditions'][0] || $route['conditions'][1]);
+            }
+        }
+        $this->assertTrue($has_dashboard, 'Dashboard route not found');
+    }
+}


### PR DESCRIPTION
## Tangle
`AIPS_Admin_Assets::enqueue_admin_assets()` in `class-aips-admin-assets.php` functioned as a God Object and central registry for routing hook dependencies to specific module scripts. It contained over 100 lines of chained if-else blocks checking every possible slug/tab combination, heavily violating the Open/Closed Principle. Adding a new module or page to the admin area required modifying this massive block, causing code bloat and increasing cyclomatic complexity.

## Detangle
Extracted the conditional routing logic into a new protected method `get_asset_routes($hook, $page)` that cleanly defines and returns a configuration map containing conditions and their callback methods. The primary method, `enqueue_admin_assets()`, now simply iterates over this mapping arrays and dynamically invokes the matching methods via `call_user_func()`. This structure vastly improves maintainability, enabling new routes to be added efficiently without bloating the invocation method.

## Journal
Appended the structural refactor note to `.build/atlas-journal.md`.

## Tests
Created `Test_AIPS_Admin_Assets.php` leveraging `ReflectionClass` and `setAccessible(true)` to isolate and validate the mapping structure inside `get_asset_routes()` ensuring the correct parameters and callbacks exist (e.g. `enqueue_dashboard_assets` when the slug/hook matches dashboard conditions). Full PHPUnit suite passes without regressions.

---
*PR created automatically by Jules for task [21687113204804179](https://jules.google.com/task/21687113204804179) started by @rpnunez*