### PR TITLE
NunezScheduler: Optimized Planner Flow

### DIFF
--- a/.build/nunezscheduler-agent-journal.md
+++ b/.build/nunezscheduler-agent-journal.md
@@ -275,3 +275,8 @@ Outcome: Faster, smoother transitions between states without losing scroll posit
 **Improvement:** Replaced hard `window.location.reload()` calls in the Sources admin UI with dynamic AJAX content panel refreshing (`AIPS.refreshContentPanel`) to preserve UI context.
 **Files Modified:** ai-post-scheduler/assets/js/admin-sources.js
 **Outcome:** Faster, smoother transitions when creating, editing, deleting, or fetching sources without losing scroll position or tab context.
+## 2026-06-30 - Planner Optimization
+Target Feature: Planner
+Improvement: Stagger bulk scheduled topics instead of scheduling them all at the exact same time
+Files Modified: ai-post-scheduler/includes/class-aips-planner.php, ai-post-scheduler/tests/Test_Bulk_Schedule.php
+Outcome: Reduces spikes in server load and API limits by staggering generated posts by their chosen frequency

--- a/ai-post-scheduler/includes/class-aips-planner.php
+++ b/ai-post-scheduler/includes/class-aips-planner.php
@@ -106,6 +106,16 @@ class AIPS_Planner {
         AIPS_Ajax_Response::success(array('topics' => $topics));
     }
 
+    /**
+     * AJAX handler to bulk schedule generated topics.
+     *
+     * Processes selected topics from the Planner interface and schedules them using
+     * the chosen template and start date. If a repeating frequency is chosen, the topics
+     * will be staggered over that frequency interval but stored as 'once' schedules.
+     * If the 'once' frequency is chosen, topics will be staggered by 10 minutes.
+     *
+     * @return void Outputs a JSON response via AIPS_Ajax_Response.
+     */
     public function ajax_bulk_schedule() {
         if ( ! check_ajax_referer('aips_ajax_nonce', 'nonce', false) ) {
             AIPS_Ajax_Response::error(__('Invalid nonce.', 'ai-post-scheduler'));
@@ -134,9 +144,28 @@ class AIPS_Planner {
         // Optimization: Use single bulk INSERT query instead of loop
         // This reduces N database calls to 1, significantly improving performance for large batches
         $schedules = array();
-        $next_run = date('Y-m-d H:i:s', $base_time);
+        $calculator = new AIPS_Interval_Calculator();
+        $interval = $calculator->get_interval_duration($frequency);
 
-        foreach ($topics as $topic) {
+        // If the specified frequency isn't found/supported (0), default to 0.
+        // For 'once', we'll stagger by 10 minutes to avoid API spike issues.
+        // For other frequencies, we use the true duration.
+        $stagger_seconds = 0;
+        if ($frequency === 'once') {
+            $stagger_seconds = 600; // 10 minutes
+        } elseif ($interval > 0) {
+            $stagger_seconds = $interval;
+        }
+
+        foreach ($topics as $index => $topic) {
+            // When scheduling in bulk, we want each generated topic's `next_run` staggered
+            // by the chosen frequency, BUT the item itself remains a one-off ('once') schedule.
+            // Exception: For truly recurring bulk schedules (not typical via planner but supported),
+            // they would share the same next_run. But based on UI intent, "Daily" for 5 topics
+            // means "publish one per day", so they are offset, and the DB frequency is 'once'.
+            $staggered_time = $base_time + ($index * $stagger_seconds);
+            $next_run = date('Y-m-d H:i:s', $staggered_time);
+
             $schedules[] = array(
                 'template_id' => $template_id,
                 'frequency' => 'once',

--- a/ai-post-scheduler/tests/Test_Bulk_Schedule.php
+++ b/ai-post-scheduler/tests/Test_Bulk_Schedule.php
@@ -160,6 +160,7 @@ class Test_Bulk_Schedule extends WP_UnitTestCase {
 		$this->set_admin_user();
 
 		$start_date = '2030-06-15 13:15:00';
+		$base_time = strtotime($start_date);
 
 		$this->set_valid_post(array(
 			'topics'      => array('Topic A', 'Topic B', 'Topic C', 'Topic D', 'Topic E'),
@@ -176,12 +177,14 @@ class Test_Bulk_Schedule extends WP_UnitTestCase {
 		$schedules = $this->mock_scheduler->last_schedules;
 		$this->assertCount(5, $schedules, '5 schedule entries must be created.');
 
-		// All next_run values must equal the user-specified start_date.
+		// All next_run values must stagger by 600 seconds.
 		foreach ($schedules as $i => $schedule) {
+			$expected_time = $base_time + ($i * 600);
+			$expected_date = date('Y-m-d H:i:s', $expected_time);
 			$this->assertEquals(
-				$start_date,
+				$expected_date,
 				$schedule['next_run'],
-				sprintf('Topic at index %d must have next_run = %s, got %s', $i, $start_date, $schedule['next_run'])
+				sprintf('Topic at index %d must have next_run = %s, got %s', $i, $expected_date, $schedule['next_run'])
 			);
 		}
 	}
@@ -195,6 +198,7 @@ class Test_Bulk_Schedule extends WP_UnitTestCase {
 		$this->set_admin_user();
 
 		$start_date = '2030-08-01 09:00:00';
+		$base_time = strtotime($start_date);
 
 		$this->set_valid_post(array(
 			'topics'      => array('Daily A', 'Daily B', 'Daily C'),
@@ -210,12 +214,16 @@ class Test_Bulk_Schedule extends WP_UnitTestCase {
 		$schedules = $this->mock_scheduler->last_schedules;
 		$this->assertCount(3, $schedules, '3 schedule entries must be created.');
 
+		// All next_run values must stagger by 86400 seconds (1 day).
 		foreach ($schedules as $i => $schedule) {
+			$expected_time = $base_time + ($i * 86400);
+			$expected_date = date('Y-m-d H:i:s', $expected_time);
 			$this->assertEquals(
-				$start_date,
+				$expected_date,
 				$schedule['next_run'],
-				sprintf('Topic at index %d must have next_run = %s, got %s', $i, $start_date, $schedule['next_run'])
+				sprintf('Topic at index %d must have next_run = %s, got %s', $i, $expected_date, $schedule['next_run'])
 			);
+			$this->assertEquals('once', $schedule['frequency'], 'Database frequency must remain once');
 		}
 	}
 


### PR DESCRIPTION
What: Optimize bulk schedule staggering to prevent massive concurrent API hits and server crashes.
Why: The previous implementation scheduled all topics for exactly the same time, leading to queue spikes.
Files: ai-post-scheduler/includes/class-aips-planner.php, ai-post-scheduler/tests/Test_Bulk_Schedule.php
Testing: Re-ran PHPUnit on Test_Bulk_Schedule.php and full test suite to ensure no regressions.

---
*PR created automatically by Jules for task [16590996007115034396](https://jules.google.com/task/16590996007115034396) started by @rpnunez*