### PR TITLE
🎨 Palette: Add explicit type="button" to UI buttons to prevent unintended form submissions

### DIFF
--- a/ai-post-scheduler/.build/palette.md
+++ b/ai-post-scheduler/.build/palette.md
@@ -4,3 +4,9 @@
 **PR:** 🎨 Palette: Standardize Admin Modals Structure and Button Classes
 **Learning:** Inconsistent HTML structure in modals (missing headers, unstructured buttons) degrades both visual consistency and codebase maintainability.
 **Action:** Always ensure modals follow the `.aips-modal-header`, `.aips-modal-body`, `.aips-modal-footer` structure and use standardized `.aips-btn` classes for primary/secondary actions. Avoid redundant ID mapping when a standard class (`.aips-modal-title`, `.aips-modal-content-body`) provides sufficient hooks for dynamic JS updates.
+## 2026-06-05 - Add explicit type="button" to UI buttons
+**Area:** Admin Templates (`templates/admin/*.php`)
+**Status:** opened PR
+**PR:** 🎨 Palette: Add explicit type="button" to UI buttons to prevent unintended form submissions
+**Learning:** Missing `type` attributes on `<button>` elements default to `type="submit"`, causing unintended form submissions when users interact with UI buttons (e.g., toggles, clear buttons) within forms.
+**Action:** Always add `type="button"` to `<button>` elements that are not intended to submit a form.

--- a/ai-post-scheduler/templates/admin/author-topics.php
+++ b/ai-post-scheduler/templates/admin/author-topics.php
@@ -93,7 +93,7 @@ $posts_count        = $logs_repository->count_generated_posts_by_author($author_
 						<span class="dashicons dashicons-edit"></span>
 						<?php esc_html_e('Edit Author', 'ai-post-scheduler'); ?>
 					</a>
-					<button class="aips-btn aips-btn-primary aips-generate-topics-now" data-id="<?php echo esc_attr($author->id); ?>">
+					<button type="button" class="aips-btn aips-btn-primary aips-generate-topics-now" data-id="<?php echo esc_attr($author->id); ?>">
 						<span class="dashicons dashicons-update"></span>
 						<?php esc_html_e('Generate Topics', 'ai-post-scheduler'); ?>
 					</button>
@@ -134,23 +134,23 @@ $posts_count        = $logs_repository->count_generated_posts_by_author($author_
 		<div class="aips-content-panel" id="aips-author-topics-panel">
 			<!-- Tabs -->
 			<div class="aips-topics-tabs aips-page-tabs">
-				<button class="aips-tab-link active" data-tab="pending">
+				<button type="button" class="aips-tab-link active" data-tab="pending">
 					<?php esc_html_e('Pending Review', 'ai-post-scheduler'); ?>
 					<span class="aips-tab-count" id="pending-count"><?php echo esc_html($status_counts['pending']); ?></span>
 				</button>
-				<button class="aips-tab-link" data-tab="approved">
+				<button type="button" class="aips-tab-link" data-tab="approved">
 					<?php esc_html_e('Approved', 'ai-post-scheduler'); ?>
 					<span class="aips-tab-count" id="approved-count"><?php echo esc_html($status_counts['approved']); ?></span>
 				</button>
-				<button class="aips-tab-link" data-tab="rejected">
+				<button type="button" class="aips-tab-link" data-tab="rejected">
 					<?php esc_html_e('Rejected', 'ai-post-scheduler'); ?>
 					<span class="aips-tab-count" id="rejected-count"><?php echo esc_html($status_counts['rejected']); ?></span>
 				</button>
-				<button class="aips-tab-link" data-tab="posts_generated">
+				<button type="button" class="aips-tab-link" data-tab="posts_generated">
 					<?php esc_html_e('Posts Generated', 'ai-post-scheduler'); ?>
 					<span class="aips-tab-count" id="posts-generated-count"><?php echo esc_html($status_counts['posts_generated']); ?></span>
 				</button>
-				<button class="aips-tab-link" data-tab="feedback">
+				<button type="button" class="aips-tab-link" data-tab="feedback">
 					<?php esc_html_e('Feedback', 'ai-post-scheduler'); ?>
 				</button>
 			</div>
@@ -164,7 +164,7 @@ $posts_count        = $logs_repository->count_generated_posts_by_author($author_
 						<option value="reject"><?php esc_html_e('Reject', 'ai-post-scheduler'); ?></option>
 						<option value="delete"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></option>
 					</select>
-					<button class="aips-btn aips-btn-sm aips-btn-secondary aips-bulk-action-execute"><?php esc_html_e('Execute', 'ai-post-scheduler'); ?></button>
+					<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-bulk-action-execute"><?php esc_html_e('Execute', 'ai-post-scheduler'); ?></button>
 				</div>
 				<div class="aips-filter-right">
 					<label class="screen-reader-text" for="aips-topic-search"><?php esc_html_e('Search Topics:', 'ai-post-scheduler'); ?></label>

--- a/ai-post-scheduler/templates/admin/authors.php
+++ b/ai-post-scheduler/templates/admin/authors.php
@@ -46,11 +46,11 @@ $site_ctx = AIPS_Site_Context::get();
                     <p class="aips-page-description"><?php esc_html_e('Manage AI author profiles, generate topics, and create authentic content from different perspectives.', 'ai-post-scheduler'); ?></p>
                 </div>
                 <div class="aips-page-actions">
-                    <button class="aips-btn aips-btn-secondary" id="aips-suggest-authors-btn">
+                    <button type="button" class="aips-btn aips-btn-secondary" id="aips-suggest-authors-btn">
                         <span class="dashicons dashicons-lightbulb"></span>
                         <?php esc_html_e('Suggest Authors', 'ai-post-scheduler'); ?>
                     </button>
-                    <button class="aips-btn aips-btn-primary aips-add-author-btn">
+                    <button type="button" class="aips-btn aips-btn-primary aips-add-author-btn">
                         <span class="dashicons dashicons-plus-alt"></span>
                         <?php esc_html_e('Add Author', 'ai-post-scheduler'); ?>
                     </button>
@@ -240,20 +240,20 @@ $site_ctx = AIPS_Site_Context::get();
                                     <td>
                                         <div class="cell-actions">
                                             <div class="aips-author-generation-actions">
-                                                <button class="aips-btn aips-btn-sm aips-btn-primary aips-generate-topics-now" data-id="<?php echo esc_attr($author->id); ?>" title="<?php esc_attr_e('Generate Topics', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Generate Topics', 'ai-post-scheduler'); ?>">
+                                                <button type="button" class="aips-btn aips-btn-sm aips-btn-primary aips-generate-topics-now" data-id="<?php echo esc_attr($author->id); ?>" title="<?php esc_attr_e('Generate Topics', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Generate Topics', 'ai-post-scheduler'); ?>">
                                                     <span class="dashicons dashicons-update"></span>
                                                     <?php esc_html_e('Generate Topics', 'ai-post-scheduler'); ?>
                                                 </button>
-                                                <button class="aips-btn aips-btn-sm aips-btn-author-posts aips-generate-author-posts-now" data-id="<?php echo esc_attr($author->id); ?>" data-type="<?php echo esc_attr(AIPS_Unified_Schedule_Service::TYPE_AUTHOR_POST); ?>" data-quantity="<?php echo esc_attr(isset($author->manual_post_generation_quantity) ? max(1, (int) $author->manual_post_generation_quantity) : 1); ?>" title="<?php esc_attr_e('Generate Posts', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Generate Posts', 'ai-post-scheduler'); ?>">
+                                                <button type="button" class="aips-btn aips-btn-sm aips-btn-author-posts aips-generate-author-posts-now" data-id="<?php echo esc_attr($author->id); ?>" data-type="<?php echo esc_attr(AIPS_Unified_Schedule_Service::TYPE_AUTHOR_POST); ?>" data-quantity="<?php echo esc_attr(isset($author->manual_post_generation_quantity) ? max(1, (int) $author->manual_post_generation_quantity) : 1); ?>" title="<?php esc_attr_e('Generate Posts', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Generate Posts', 'ai-post-scheduler'); ?>">
                                                     <span class="dashicons dashicons-admin-post"></span>
                                                     <?php esc_html_e('Generate Posts', 'ai-post-scheduler'); ?>
                                                 </button>
                                             </div>
-                                            <button class="aips-btn aips-btn-sm aips-btn-secondary aips-edit-author" data-id="<?php echo esc_attr($author->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
+                                            <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-edit-author" data-id="<?php echo esc_attr($author->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
                                                 <span class="dashicons dashicons-edit"></span>
                                                 <?php esc_html_e('Edit', 'ai-post-scheduler'); ?>
                                             </button>
-                                            <button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-author" data-id="<?php echo esc_attr($author->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
+                                            <button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-author" data-id="<?php echo esc_attr($author->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
                                                 <span class="dashicons dashicons-trash"></span>
                                                 <?php esc_html_e('Delete', 'ai-post-scheduler'); ?>
                                             </button>
@@ -306,7 +306,7 @@ $site_ctx = AIPS_Site_Context::get();
                         <h3 class="aips-empty-state-title"><?php esc_html_e('No Authors Yet', 'ai-post-scheduler'); ?></h3>
                         <p class="aips-empty-state-description"><?php esc_html_e('Create your first author to start generating topically diverse blog posts.', 'ai-post-scheduler'); ?></p>
                         <div class="aips-empty-state-actions">
-                            <button class="aips-btn aips-btn-primary aips-add-author-btn">
+                            <button type="button" class="aips-btn aips-btn-primary aips-add-author-btn">
                                 <span class="dashicons dashicons-plus-alt"></span>
                                 <?php esc_html_e('Add Author', 'ai-post-scheduler'); ?>
                             </button>
@@ -762,24 +762,24 @@ $site_ctx = AIPS_Site_Context::get();
 
 <script type="text/html" id="aips-tmpl-topic-actions-pending">
 <div class="cell-actions">
-    <button class="aips-btn aips-btn-sm aips-btn-secondary aips-edit-topic" data-id="{{id}}">{{editLabel}}</button>
+    <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-edit-topic" data-id="{{id}}">{{editLabel}}</button>
 </div>
 <div class="cell-actions" style="margin-top: 6px;">
-    <button class="aips-btn aips-btn-sm aips-btn-secondary aips-approve-topic" data-id="{{id}}">{{approveLabel}}</button>
-    <button class="aips-btn aips-btn-sm aips-btn-secondary aips-reject-topic" data-id="{{id}}">{{rejectLabel}}</button>
+    <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-approve-topic" data-id="{{id}}">{{approveLabel}}</button>
+    <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-reject-topic" data-id="{{id}}">{{rejectLabel}}</button>
 </div>
 </script>
 
 <script type="text/html" id="aips-tmpl-topic-actions-approved">
 <div class="cell-actions">
-    <button class="aips-btn aips-btn-sm aips-btn-secondary aips-generate-post-now" data-id="{{id}}">{{generateLabel}}</button>
-    <button class="aips-btn aips-btn-sm aips-btn-ghost aips-edit-topic" data-id="{{id}}">{{editLabel}}</button>
+    <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-generate-post-now" data-id="{{id}}">{{generateLabel}}</button>
+    <button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-edit-topic" data-id="{{id}}">{{editLabel}}</button>
 </div>
 </script>
 
 <script type="text/html" id="aips-tmpl-topic-actions-rejected">
 <div class="cell-actions">
-    <button class="aips-btn aips-btn-sm aips-btn-ghost aips-edit-topic" data-id="{{id}}">{{editLabel}}</button>
+    <button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-edit-topic" data-id="{{id}}">{{editLabel}}</button>
 </div>
 </script>
 

--- a/ai-post-scheduler/templates/admin/calendar.php
+++ b/ai-post-scheduler/templates/admin/calendar.php
@@ -33,31 +33,31 @@ if (!defined('ABSPATH')) {
 				<!-- Calendar Header with Navigation -->
 				<div class="aips-calendar-header">
 					<div class="aips-calendar-nav">
-						<button class="aips-btn aips-btn-sm aips-btn-secondary aips-calendar-prev" title="<?php esc_attr_e('Previous Month', 'ai-post-scheduler'); ?>">
+						<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-calendar-prev" title="<?php esc_attr_e('Previous Month', 'ai-post-scheduler'); ?>">
 							<span class="dashicons dashicons-arrow-left-alt2"></span>
 						</button>
 						<h2 class="aips-calendar-title">
 							<span class="aips-calendar-month-year"></span>
 						</h2>
-						<button class="aips-btn aips-btn-sm aips-btn-secondary aips-calendar-next" title="<?php esc_attr_e('Next Month', 'ai-post-scheduler'); ?>">
+						<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-calendar-next" title="<?php esc_attr_e('Next Month', 'ai-post-scheduler'); ?>">
 							<span class="dashicons dashicons-arrow-right-alt2"></span>
 						</button>
 					</div>
 					
 					<div class="aips-calendar-view-switcher">
-						<button class="aips-btn aips-btn-sm aips-calendar-view-btn active" data-view="month">
+						<button type="button" class="aips-btn aips-btn-sm aips-calendar-view-btn active" data-view="month">
 							<?php esc_html_e('Month', 'ai-post-scheduler'); ?>
 						</button>
-						<button class="aips-btn aips-btn-sm aips-calendar-view-btn" data-view="week">
+						<button type="button" class="aips-btn aips-btn-sm aips-calendar-view-btn" data-view="week">
 							<?php esc_html_e('Week', 'ai-post-scheduler'); ?>
 						</button>
-						<button class="aips-btn aips-btn-sm aips-calendar-view-btn" data-view="day">
+						<button type="button" class="aips-btn aips-btn-sm aips-calendar-view-btn" data-view="day">
 							<?php esc_html_e('Day', 'ai-post-scheduler'); ?>
 						</button>
 					</div>
 					
 					<div class="aips-calendar-today">
-						<button class="aips-btn aips-btn-secondary aips-calendar-today-btn">
+						<button type="button" class="aips-btn aips-btn-secondary aips-calendar-today-btn">
 							<?php esc_html_e('Today', 'ai-post-scheduler'); ?>
 						</button>
 					</div>

--- a/ai-post-scheduler/templates/admin/dashboard.php
+++ b/ai-post-scheduler/templates/admin/dashboard.php
@@ -133,19 +133,19 @@ if (!defined('ABSPATH')) {
 			<div class="aips-content-panel detail-tabs-panel glass-morphic">
 				<!-- Tab Headers -->
 				<div class="aips-tab-headers" role="tablist">
-					<button class="aips-tab-btn active" role="tab" aria-selected="true" aria-controls="tab-posts" id="btn-tab-posts">
+					<button type="button" class="aips-tab-btn active" role="tab" aria-selected="true" aria-controls="tab-posts" id="btn-tab-posts">
 						<span class="dashicons dashicons-edit"></span>
 						<?php esc_html_e('Generated Posts', 'ai-post-scheduler'); ?>
 					</button>
-					<button class="aips-tab-btn" role="tab" aria-selected="false" aria-controls="tab-topics" id="btn-tab-topics">
+					<button type="button" class="aips-tab-btn" role="tab" aria-selected="false" aria-controls="tab-topics" id="btn-tab-topics">
 						<span class="dashicons dashicons-welcome-write-blog"></span>
 						<?php esc_html_e('Author Topics', 'ai-post-scheduler'); ?>
 					</button>
-					<button class="aips-tab-btn" role="tab" aria-selected="false" aria-controls="tab-topic-posts" id="btn-tab-topic-posts">
+					<button type="button" class="aips-tab-btn" role="tab" aria-selected="false" aria-controls="tab-topic-posts" id="btn-tab-topic-posts">
 						<span class="dashicons dashicons-admin-links"></span>
 						<?php esc_html_e('Posts by Topic', 'ai-post-scheduler'); ?>
 					</button>
-					<button class="aips-tab-btn" role="tab" aria-selected="false" aria-controls="tab-schedules" id="btn-tab-schedules">
+					<button type="button" class="aips-tab-btn" role="tab" aria-selected="false" aria-controls="tab-schedules" id="btn-tab-schedules">
 						<span class="dashicons dashicons-update"></span>
 						<?php esc_html_e('Schedules Executed', 'ai-post-scheduler'); ?>
 					</button>

--- a/ai-post-scheduler/templates/admin/history.php
+++ b/ai-post-scheduler/templates/admin/history.php
@@ -48,7 +48,7 @@ if (is_object($history)) {
                     <p class="aips-page-description"><?php esc_html_e('View generation history containers and inspect every logged step, AI call, and error for each run.', 'ai-post-scheduler'); ?></p>
                 </div>
                 <div class="aips-page-actions">
-                    <button class="aips-btn aips-btn-secondary" id="aips-export-history-btn">
+                    <button type="button" class="aips-btn aips-btn-secondary" id="aips-export-history-btn">
                         <span class="dashicons dashicons-download"></span>
                         <?php esc_html_e('Export CSV', 'ai-post-scheduler'); ?>
                     </button>
@@ -86,7 +86,7 @@ if (is_object($history)) {
                         <option value="failed" <?php selected($status_filter, 'failed'); ?>><?php esc_html_e('Failed', 'ai-post-scheduler'); ?></option>
                         <option value="processing" <?php selected($status_filter, 'processing'); ?>><?php esc_html_e('Processing', 'ai-post-scheduler'); ?></option>
                     </select>
-                    <button class="aips-btn aips-btn-sm aips-btn-secondary" id="aips-filter-btn">
+                    <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary" id="aips-filter-btn">
                         <span class="dashicons dashicons-filter"></span>
                         <?php esc_html_e('Filter', 'ai-post-scheduler'); ?>
                     </button>
@@ -104,21 +104,21 @@ if (is_object($history)) {
             <!-- Toolbar (bulk actions) -->
             <div class="aips-panel-toolbar">
                 <div class="aips-toolbar-left">
-                    <button class="aips-btn aips-btn-sm aips-btn-danger aips-btn-danger-solid" id="aips-delete-selected-btn" disabled>
+                    <button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-btn-danger-solid" id="aips-delete-selected-btn" disabled>
                         <span class="dashicons dashicons-trash"></span>
                         <?php esc_html_e('Delete Selected', 'ai-post-scheduler'); ?>
                     </button>
-                    <button class="aips-btn aips-btn-sm aips-btn-secondary" id="aips-reload-history-btn">
+                    <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary" id="aips-reload-history-btn">
                         <span class="dashicons dashicons-update"></span>
                         <?php esc_html_e('Reload', 'ai-post-scheduler'); ?>
                     </button>
                 </div>
                 <div class="aips-toolbar-right aips-history-pagination-cell">
-                    <button class="aips-btn aips-btn-sm aips-btn-danger aips-btn-danger-solid aips-clear-history" data-status="failed">
+                    <button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-btn-danger-solid aips-clear-history" data-status="failed">
                         <span class="dashicons dashicons-dismiss"></span>
                         <?php esc_html_e('Clear Failed', 'ai-post-scheduler'); ?>
                     </button>
-                    <button class="aips-btn aips-btn-sm aips-btn-danger aips-btn-danger-solid aips-clear-history" data-status="all">
+                    <button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-btn-danger-solid aips-clear-history" data-status="all">
                         <span class="dashicons dashicons-trash"></span>
                         <?php esc_html_e('Clear All', 'ai-post-scheduler'); ?>
                     </button>

--- a/ai-post-scheduler/templates/admin/research.php
+++ b/ai-post-scheduler/templates/admin/research.php
@@ -497,7 +497,7 @@ if (!in_array($active_tab, $valid_tabs, true)) {
             <td>{{researched_at}}</td>
             <td>
                 <div class="aips-topic-actions">
-                    <button class="aips-btn aips-btn-sm aips-btn-danger delete-topic" data-id="{{id}}">
+                    <button type="button" class="aips-btn aips-btn-sm aips-btn-danger delete-topic" data-id="{{id}}">
                         <span class="dashicons dashicons-trash"></span> {{delete_label}}
                     </button>
                 </div>
@@ -569,7 +569,7 @@ if (!in_array($active_tab, $valid_tabs, true)) {
             <p class="aips-gap-reason">{{reason}}</p>
             <p class="aips-gap-intent"><?php esc_html_e('Intent:', 'ai-post-scheduler'); ?> {{search_intent}}</p>
             <div class="aips-gap-actions">
-                <button class="aips-btn aips-btn-sm aips-btn-secondary generate-gap-ideas" data-topic="{{missing_topic}}">{{generate_ideas_label}}</button>
+                <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary generate-gap-ideas" data-topic="{{missing_topic}}">{{generate_ideas_label}}</button>
             </div>
         </div>
     </script>

--- a/ai-post-scheduler/templates/admin/schedule.php
+++ b/ai-post-scheduler/templates/admin/schedule.php
@@ -169,7 +169,7 @@ if (!function_exists('aips_datetime_from_db_value')) {
 				</div>
 				<div class="aips-page-actions">
 					<?php if (!empty($templates)): ?>
-					<button class="aips-btn aips-btn-primary aips-add-schedule-btn">
+					<button type="button" class="aips-btn aips-btn-primary aips-add-schedule-btn">
 						<span class="dashicons dashicons-plus-alt"></span>
 						<?php esc_html_e('Add Template Schedule', 'ai-post-scheduler'); ?>
 					</button>
@@ -406,7 +406,7 @@ if (!function_exists('aips_datetime_from_db_value')) {
 							<div class="cell-actions">
 								<!-- Edit (template schedules only) -->
 								<?php if ($sched['type'] === AIPS_Unified_Schedule_Service::TYPE_TEMPLATE): ?>
-								<button class="aips-btn aips-btn-sm aips-btn-ghost aips-edit-schedule"
+								<button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-edit-schedule"
 									aria-label="<?php esc_attr_e('Edit schedule', 'ai-post-scheduler'); ?>"
 									title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>"
 									data-schedule-id="<?php echo esc_attr($sched['id']); ?>"
@@ -423,7 +423,7 @@ if (!function_exists('aips_datetime_from_db_value')) {
 								<?php endif; ?>
 
 								<!-- Run Now (all types) -->
-								<button class="aips-btn aips-btn-sm aips-btn-ghost aips-unified-run-now"
+								<button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-unified-run-now"
 									data-id="<?php echo esc_attr($sched['id']); ?>"
 									data-type="<?php echo esc_attr($sched['type']); ?>"
 									aria-label="<?php esc_attr_e('Run now', 'ai-post-scheduler'); ?>"
@@ -433,14 +433,14 @@ if (!function_exists('aips_datetime_from_db_value')) {
 
 								<!-- Delete (template schedules only) -->
 								<?php if ($sched['can_delete']): ?>
-								<button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-schedule"
+								<button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-schedule"
 									data-id="<?php echo esc_attr($sched['id']); ?>"
 									aria-label="<?php esc_attr_e('Delete schedule', 'ai-post-scheduler'); ?>"
 									title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
 									<span class="dashicons dashicons-trash"></span>
 								</button>
 								<?php elseif (!empty($sched['campaign_id'])): ?>
-								<button class="aips-btn aips-btn-sm aips-btn-danger" disabled
+								<button type="button" class="aips-btn aips-btn-sm aips-btn-danger" disabled
 									aria-label="<?php esc_attr_e('Delete schedule', 'ai-post-scheduler'); ?>"
 									title="<?php esc_attr_e('This schedule cannot be deleted here because it belongs to a campaign. Delete it from the Campaigns page.', 'ai-post-scheduler'); ?>">
 									<span class="dashicons dashicons-trash"></span>
@@ -480,7 +480,7 @@ if (!function_exists('aips_datetime_from_db_value')) {
 					</p>
 					<?php if (!empty($templates)): ?>
 					<div class="aips-empty-state-actions">
-						<button class="aips-btn aips-btn-primary aips-add-schedule-btn">
+						<button type="button" class="aips-btn aips-btn-primary aips-add-schedule-btn">
 							<span class="dashicons dashicons-plus-alt"></span>
 							<?php esc_html_e('Add Template Schedule', 'ai-post-scheduler'); ?>
 						</button>

--- a/ai-post-scheduler/templates/admin/sections.php
+++ b/ai-post-scheduler/templates/admin/sections.php
@@ -17,7 +17,7 @@ if (!isset($sections) || !is_array($sections)) {
 					<p class="aips-page-description"><?php esc_html_e('Create and manage reusable prompt sections that can be inserted into your templates using placeholders.', 'ai-post-scheduler'); ?></p>
 				</div>
 				<div class="aips-page-actions">
-					<button class="aips-btn aips-btn-primary aips-add-section-btn">
+					<button type="button" class="aips-btn aips-btn-primary aips-add-section-btn">
 						<span class="dashicons dashicons-plus-alt"></span>
 						<?php esc_html_e('Add Section', 'ai-post-scheduler'); ?>
 					</button>
@@ -76,10 +76,10 @@ if (!isset($sections) || !is_array($sections)) {
 								<?php endif; ?>
 							</td>
 							<td class="column-actions">
-								<button class="aips-btn aips-btn-sm aips-btn-ghost aips-edit-section" data-id="<?php echo esc_attr($section->id); ?>" aria-label="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
+								<button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-edit-section" data-id="<?php echo esc_attr($section->id); ?>" aria-label="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
 									<span class="dashicons dashicons-edit"></span>
 								</button>
-								<button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-section" data-id="<?php echo esc_attr($section->id); ?>" aria-label="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
+								<button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-section" data-id="<?php echo esc_attr($section->id); ?>" aria-label="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
 									<span class="dashicons dashicons-trash"></span>
 								</button>
 							</td>
@@ -108,7 +108,7 @@ if (!isset($sections) || !is_array($sections)) {
 				<h3 class="aips-empty-state-title"><?php esc_html_e('No Prompt Sections', 'ai-post-scheduler'); ?></h3>
 				<p class="aips-empty-state-description"><?php esc_html_e('Create reusable prompt sections that can be inserted into your article structures using placeholders like {{section:key}}.', 'ai-post-scheduler'); ?></p>
 				<div class="aips-empty-state-actions">
-					<button class="aips-btn aips-btn-primary aips-add-section-btn">
+					<button type="button" class="aips-btn aips-btn-primary aips-add-section-btn">
 						<span class="dashicons dashicons-plus-alt"></span>
 						<?php esc_html_e('Create First Section', 'ai-post-scheduler'); ?>
 					</button>

--- a/ai-post-scheduler/templates/admin/sources.php
+++ b/ai-post-scheduler/templates/admin/sources.php
@@ -176,19 +176,19 @@ $is_embedded_sources_view = !empty($embedded);
 							</td>
 							<td class="column-actions">
 								<div class="aips-action-buttons">
-									<button class="aips-btn aips-btn-sm aips-edit-source"
+									<button type="button" class="aips-btn aips-btn-sm aips-edit-source"
 										data-id="<?php echo esc_attr($source->id); ?>"
 										title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
 										<span class="dashicons dashicons-edit"></span>
 										<span class="screen-reader-text"><?php esc_html_e('Edit', 'ai-post-scheduler'); ?></span>
 									</button>
-									<button class="aips-btn aips-btn-sm aips-btn-secondary aips-fetch-source-now"
+									<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-fetch-source-now"
 										data-id="<?php echo esc_attr($source->id); ?>"
 										title="<?php esc_attr_e('Fetch content now', 'ai-post-scheduler'); ?>">
 										<span class="dashicons dashicons-download"></span>
 										<span class="screen-reader-text"><?php esc_html_e('Fetch Now', 'ai-post-scheduler'); ?></span>
 									</button>
-									<button class="aips-btn aips-btn-sm aips-btn-ghost aips-toggle-source"
+									<button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-toggle-source"
 										data-id="<?php echo esc_attr($source->id); ?>"
 										data-active="<?php echo esc_attr($source->is_active); ?>"
 										title="<?php echo $source->is_active ? esc_attr__('Deactivate', 'ai-post-scheduler') : esc_attr__('Activate', 'ai-post-scheduler'); ?>">
@@ -197,7 +197,7 @@ $is_embedded_sources_view = !empty($embedded);
 											<?php echo $source->is_active ? esc_html__('Deactivate', 'ai-post-scheduler') : esc_html__('Activate', 'ai-post-scheduler'); ?>
 										</span>
 									</button>
-									<button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-source"
+									<button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-source"
 										data-id="<?php echo esc_attr($source->id); ?>"
 										title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
 										<span class="dashicons dashicons-trash"></span>
@@ -367,7 +367,7 @@ $is_embedded_sources_view = !empty($embedded);
 								<tr data-term-id="<?php echo esc_attr($group->term_id); ?>">
 									<td><?php echo esc_html($group->name); ?></td>
 									<td>
-										<button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-source-group"
+										<button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-source-group"
 											data-term-id="<?php echo esc_attr($group->term_id); ?>"
 											title="<?php esc_attr_e('Delete group', 'ai-post-scheduler'); ?>">
 											<span class="dashicons dashicons-trash"></span>

--- a/ai-post-scheduler/templates/admin/structures.php
+++ b/ai-post-scheduler/templates/admin/structures.php
@@ -77,7 +77,7 @@ if (!isset($sections) || !is_array($sections)) {
 						</td>
 						<td class="column-actions">
 							<div class="aips-action-buttons">
-								<button class="aips-btn aips-btn-sm aips-edit-structure" data-id="<?php echo esc_attr($structure->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
+								<button type="button" class="aips-btn aips-btn-sm aips-edit-structure" data-id="<?php echo esc_attr($structure->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
 									<span class="dashicons dashicons-edit"></span>
 									<span class="screen-reader-text"><?php esc_html_e('Edit', 'ai-post-scheduler'); ?></span>
 								</button>
@@ -85,7 +85,7 @@ if (!isset($sections) || !is_array($sections)) {
 									<span class="dashicons dashicons-calendar-alt"></span>
 									<span class="screen-reader-text"><?php esc_html_e('Schedule', 'ai-post-scheduler'); ?></span>
 								</a>
-								<button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-structure" data-id="<?php echo esc_attr($structure->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
+								<button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-structure" data-id="<?php echo esc_attr($structure->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
 									<span class="dashicons dashicons-trash"></span>
 									<span class="screen-reader-text"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></span>
 								</button>
@@ -134,7 +134,7 @@ if (!isset($sections) || !is_array($sections)) {
 				<h3 class="aips-empty-state-title"><?php esc_html_e('No Article Structures', 'ai-post-scheduler'); ?></h3>
 				<p class="aips-empty-state-description"><?php esc_html_e('Create article structures to customize how templates assemble content.', 'ai-post-scheduler'); ?></p>
 				<div class="aips-empty-state-actions">
-					<button class="aips-btn aips-btn-primary aips-add-structure-btn"><?php esc_html_e('Create Structure', 'ai-post-scheduler'); ?></button>
+					<button type="button" class="aips-btn aips-btn-primary aips-add-structure-btn"><?php esc_html_e('Create Structure', 'ai-post-scheduler'); ?></button>
 				</div>
 			</div>
 			<?php endif; ?>
@@ -180,11 +180,11 @@ if (!isset($sections) || !is_array($sections)) {
 						</td>
 						<td>
 							<div class="aips-action-buttons">
-								<button class="aips-btn aips-btn-sm aips-edit-section" data-id="<?php echo esc_attr($section->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
+								<button type="button" class="aips-btn aips-btn-sm aips-edit-section" data-id="<?php echo esc_attr($section->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
 									<span class="dashicons dashicons-edit"></span>
 									<span class="screen-reader-text"><?php esc_html_e('Edit', 'ai-post-scheduler'); ?></span>
 								</button>
-								<button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-section" data-id="<?php echo esc_attr($section->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
+								<button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-section" data-id="<?php echo esc_attr($section->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
 									<span class="dashicons dashicons-trash"></span>
 									<span class="screen-reader-text"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></span>
 								</button>
@@ -226,7 +226,7 @@ if (!isset($sections) || !is_array($sections)) {
 				<h3 class="aips-empty-state-title"><?php esc_html_e('No Prompt Sections', 'ai-post-scheduler'); ?></h3>
 				<p class="aips-empty-state-description"><?php esc_html_e('Create prompt sections to reuse across article structures.', 'ai-post-scheduler'); ?></p>
 				<div class="aips-empty-state-actions">
-					<button class="aips-btn aips-btn-primary aips-add-section-btn"><?php esc_html_e('Create Section', 'ai-post-scheduler'); ?></button>
+					<button type="button" class="aips-btn aips-btn-primary aips-add-section-btn"><?php esc_html_e('Create Section', 'ai-post-scheduler'); ?></button>
 				</div>
 			</div>
 			<?php endif; ?>
@@ -343,7 +343,7 @@ if (!isset($sections) || !is_array($sections)) {
 	<td class="column-active">{{activeBadge}}</td>
 	<td class="column-actions">
 		<div class="aips-action-buttons">
-			<button class="aips-btn aips-btn-sm aips-edit-structure" data-id="{{id}}" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
+			<button type="button" class="aips-btn aips-btn-sm aips-edit-structure" data-id="{{id}}" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
 				<span class="dashicons dashicons-edit"></span>
 				<span class="screen-reader-text"><?php esc_html_e('Edit', 'ai-post-scheduler'); ?></span>
 			</button>
@@ -351,7 +351,7 @@ if (!isset($sections) || !is_array($sections)) {
 				<span class="dashicons dashicons-calendar-alt"></span>
 				<span class="screen-reader-text"><?php esc_html_e('Schedule', 'ai-post-scheduler'); ?></span>
 			</a>
-			<button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-structure" data-id="{{id}}" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
+			<button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-structure" data-id="{{id}}" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
 				<span class="dashicons dashicons-trash"></span>
 				<span class="screen-reader-text"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></span>
 			</button>
@@ -368,11 +368,11 @@ if (!isset($sections) || !is_array($sections)) {
 	<td>{{activeBadge}}</td>
 	<td>
 		<div class="aips-action-buttons">
-			<button class="aips-btn aips-btn-sm aips-edit-section" data-id="{{id}}" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
+			<button type="button" class="aips-btn aips-btn-sm aips-edit-section" data-id="{{id}}" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
 				<span class="dashicons dashicons-edit"></span>
 				<span class="screen-reader-text"><?php esc_html_e('Edit', 'ai-post-scheduler'); ?></span>
 			</button>
-			<button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-section" data-id="{{id}}" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
+			<button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-section" data-id="{{id}}" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
 				<span class="dashicons dashicons-trash"></span>
 				<span class="screen-reader-text"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></span>
 			</button>

--- a/ai-post-scheduler/templates/admin/taxonomy.php
+++ b/ai-post-scheduler/templates/admin/taxonomy.php
@@ -32,7 +32,7 @@ $is_embedded_taxonomy_view = !empty($embedded);
 					</p>
 				</div>
 				<div class="aips-page-actions">
-					<button class="aips-btn aips-btn-primary aips-generate-taxonomy" id="aips-open-generate-modal">
+					<button type="button" class="aips-btn aips-btn-primary aips-generate-taxonomy" id="aips-open-generate-modal">
 						<span class="dashicons dashicons-update"></span>
 						<?php esc_html_e('Generate Taxonomy', 'ai-post-scheduler'); ?>
 					</button>
@@ -65,11 +65,11 @@ $is_embedded_taxonomy_view = !empty($embedded);
 		<div class="aips-content-panel" id="aips-taxonomy-panel">
 			<!-- Tabs -->
 			<div class="aips-topics-tabs aips-page-tabs">
-				<button class="aips-tab-link active" data-tab="categories">
+				<button type="button" class="aips-tab-link active" data-tab="categories">
 					<?php esc_html_e('Categories', 'ai-post-scheduler'); ?>
 					<span class="aips-tab-count" id="categories-count"><?php echo esc_html($status_counts['categories']['pending'] + $status_counts['categories']['approved'] + $status_counts['categories']['rejected']); ?></span>
 				</button>
-				<button class="aips-tab-link" data-tab="tags">
+				<button type="button" class="aips-tab-link" data-tab="tags">
 					<?php esc_html_e('Tags', 'ai-post-scheduler'); ?>
 					<span class="aips-tab-count" id="tags-count"><?php echo esc_html($status_counts['tags']['pending'] + $status_counts['tags']['approved'] + $status_counts['tags']['rejected']); ?></span>
 				</button>
@@ -85,7 +85,7 @@ $is_embedded_taxonomy_view = !empty($embedded);
 						<option value="generate_terms"><?php esc_html_e('Generate Terms', 'ai-post-scheduler'); ?></option>
 						<option value="delete"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></option>
 					</select>
-					<button class="aips-btn aips-btn-sm aips-btn-secondary aips-bulk-action-execute"><?php esc_html_e('Execute', 'ai-post-scheduler'); ?></button>
+					<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-bulk-action-execute"><?php esc_html_e('Execute', 'ai-post-scheduler'); ?></button>
 				</div>
 				<div class="aips-filter-right">
 					<label class="screen-reader-text" for="aips-taxonomy-search"><?php esc_html_e('Search Taxonomy:', 'ai-post-scheduler'); ?></label>
@@ -210,15 +210,15 @@ $is_embedded_taxonomy_view = !empty($embedded);
 
 <script type="text/html" id="aips-tmpl-taxonomy-actions-pending">
 <div class="cell-actions">
-	<button class="aips-btn aips-btn-sm aips-btn-secondary aips-approve-taxonomy" data-id="{{id}}">{{approveLabel}}</button>
-	<button class="aips-btn aips-btn-sm aips-btn-secondary aips-reject-taxonomy" data-id="{{id}}">{{rejectLabel}}</button>
+	<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-approve-taxonomy" data-id="{{id}}">{{approveLabel}}</button>
+	<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-reject-taxonomy" data-id="{{id}}">{{rejectLabel}}</button>
 </div>
 </script>
 
 <script type="text/html" id="aips-tmpl-taxonomy-actions-approved">
 <div class="cell-actions">
 	{{createControl}}
-	<button class="aips-btn aips-btn-sm aips-btn-ghost aips-btn-icon aips-delete-taxonomy" data-id="{{id}}" aria-label="{{deleteLabel}}">
+	<button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-btn-icon aips-delete-taxonomy" data-id="{{id}}" aria-label="{{deleteLabel}}">
 		<span class="dashicons dashicons-trash" aria-hidden="true"></span>
 		<span class="screen-reader-text">{{deleteLabel}}</span>
 	</button>
@@ -227,7 +227,7 @@ $is_embedded_taxonomy_view = !empty($embedded);
 
 <script type="text/html" id="aips-tmpl-taxonomy-actions-rejected">
 <div class="cell-actions">
-	<button class="aips-btn aips-btn-sm aips-btn-ghost aips-delete-taxonomy" data-id="{{id}}">{{deleteLabel}}</button>
+	<button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-delete-taxonomy" data-id="{{id}}">{{deleteLabel}}</button>
 </div>
 </script>
 

--- a/ai-post-scheduler/templates/admin/templates.php
+++ b/ai-post-scheduler/templates/admin/templates.php
@@ -15,7 +15,7 @@ $is_embedded_templates_view = !empty($embedded);
                     <p class="aips-page-description"><?php esc_html_e('Create and manage AI post generation templates with custom prompts and settings.', 'ai-post-scheduler'); ?></p>
                 </div>
                 <div class="aips-page-actions">
-                    <button class="aips-btn aips-btn-primary aips-add-template-btn">
+                    <button type="button" class="aips-btn aips-btn-primary aips-add-template-btn">
                         <span class="dashicons dashicons-plus-alt"></span>
                         <?php esc_html_e('Add Template', 'ai-post-scheduler'); ?>
                     </button>
@@ -140,11 +140,11 @@ $is_embedded_templates_view = !empty($embedded);
                             </td>
                             <td>
                                 <div class="cell-actions">
-                                    <button class="aips-btn aips-btn-sm aips-btn-secondary aips-edit-template" data-id="<?php echo esc_attr($template->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
+                                    <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-edit-template" data-id="<?php echo esc_attr($template->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
                                         <span class="dashicons dashicons-edit"></span>
                                         <?php esc_html_e('Edit', 'ai-post-scheduler'); ?>
                                     </button>
-                                    <button class="aips-btn aips-btn-sm aips-btn-secondary aips-run-now" data-id="<?php echo esc_attr($template->id); ?>" title="<?php esc_attr_e('Run Now', 'ai-post-scheduler'); ?>">
+                                    <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-run-now" data-id="<?php echo esc_attr($template->id); ?>" title="<?php esc_attr_e('Run Now', 'ai-post-scheduler'); ?>">
                                         <span class="dashicons dashicons-controls-play"></span>
                                         <?php esc_html_e('Run Now', 'ai-post-scheduler'); ?>
                                     </button>
@@ -152,11 +152,11 @@ $is_embedded_templates_view = !empty($embedded);
                                         <span class="dashicons dashicons-calendar-alt"></span>
                                         <span class="screen-reader-text"><?php esc_html_e('Schedule', 'ai-post-scheduler'); ?></span>
                                     </a>
-                                    <button class="aips-btn aips-btn-sm aips-btn-ghost aips-clone-template" data-id="<?php echo esc_attr($template->id); ?>" title="<?php esc_attr_e('Clone', 'ai-post-scheduler'); ?>">
+                                    <button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-clone-template" data-id="<?php echo esc_attr($template->id); ?>" title="<?php esc_attr_e('Clone', 'ai-post-scheduler'); ?>">
                                         <span class="dashicons dashicons-admin-page"></span>
                                         <span class="screen-reader-text"><?php esc_html_e('Clone', 'ai-post-scheduler'); ?></span>
                                     </button>
-                                    <button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-template" data-id="<?php echo esc_attr($template->id); ?>" title="<?php echo !empty($template->campaign_id) ? esc_attr__('This template cannot be deleted here because it belongs to a campaign. Delete it from the Campaigns page.', 'ai-post-scheduler') : esc_attr__('Delete', 'ai-post-scheduler'); ?>" <?php disabled(!empty($template->campaign_id)); ?>>
+                                    <button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-template" data-id="<?php echo esc_attr($template->id); ?>" title="<?php echo !empty($template->campaign_id) ? esc_attr__('This template cannot be deleted here because it belongs to a campaign. Delete it from the Campaigns page.', 'ai-post-scheduler') : esc_attr__('Delete', 'ai-post-scheduler'); ?>" <?php disabled(!empty($template->campaign_id)); ?>>
                                         <span class="dashicons dashicons-trash"></span>
                                         <span class="screen-reader-text"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></span>
                                     </button>
@@ -209,7 +209,7 @@ $is_embedded_templates_view = !empty($embedded);
                     <h3 class="aips-empty-state-title"><?php esc_html_e('No Templates Yet', 'ai-post-scheduler'); ?></h3>
                     <p class="aips-empty-state-description"><?php esc_html_e('Templates define how your AI-generated posts are structured. Create your first template to start generating content automatically.', 'ai-post-scheduler'); ?></p>
                     <div class="aips-empty-state-actions">
-                        <button class="aips-btn aips-btn-primary aips-add-template-btn">
+                        <button type="button" class="aips-btn aips-btn-primary aips-add-template-btn">
                             <span class="dashicons dashicons-plus-alt"></span>
                             <?php esc_html_e('Create Template', 'ai-post-scheduler'); ?>
                         </button>

--- a/ai-post-scheduler/templates/admin/voices.php
+++ b/ai-post-scheduler/templates/admin/voices.php
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
                     </p>
                 </div>
                 <div class="aips-page-actions">
-                    <button class="aips-btn aips-btn-primary aips-add-voice-btn">
+                    <button type="button" class="aips-btn aips-btn-primary aips-add-voice-btn">
                         <span class="dashicons dashicons-plus-alt2"></span>
                         <?php esc_html_e('Add Voice', 'ai-post-scheduler'); ?>
                     </button>
@@ -75,11 +75,11 @@ if (!defined('ABSPATH')) {
                                 </td>
                                 <td class="column-actions">
                                     <div class="aips-action-buttons">
-                                        <button class="aips-btn aips-btn-sm aips-edit-voice" data-id="<?php echo esc_attr($voice->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
+                                        <button type="button" class="aips-btn aips-btn-sm aips-edit-voice" data-id="<?php echo esc_attr($voice->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
                                             <span class="dashicons dashicons-edit"></span>
                                             <span class="screen-reader-text"><?php esc_html_e('Edit', 'ai-post-scheduler'); ?></span>
                                         </button>
-                                        <button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-voice" data-id="<?php echo esc_attr($voice->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
+                                        <button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-voice" data-id="<?php echo esc_attr($voice->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
                                             <span class="dashicons dashicons-trash"></span>
                                             <span class="screen-reader-text"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></span>
                                         </button>
@@ -118,7 +118,7 @@ if (!defined('ABSPATH')) {
                     <h3 class="aips-empty-state-title"><?php esc_html_e('No Voices Yet', 'ai-post-scheduler'); ?></h3>
                     <p class="aips-empty-state-description"><?php esc_html_e('Create a voice to establish consistent tone and style for your generated posts.', 'ai-post-scheduler'); ?></p>
                     <div class="aips-empty-state-actions">
-                        <button class="aips-btn aips-btn-primary aips-btn-lg aips-add-voice-btn">
+                        <button type="button" class="aips-btn aips-btn-primary aips-btn-lg aips-add-voice-btn">
                             <span class="dashicons dashicons-plus-alt2"></span>
                             <?php esc_html_e('Create Voice', 'ai-post-scheduler'); ?>
                         </button>


### PR DESCRIPTION
**What:** Added explicit `type="button"` to UI buttons across admin templates (excluding intended submit buttons in `operations-insights.php` and `system-status.php`).
**Why:** By default, HTML `<button>` elements have `type="submit"`. If these are placed inside a form (or injected into one dynamically), clicking them will submit the form unexpectedly, leading to poor UX and potential data loss or unwanted actions.
**Accessibility:** Improves predictability of UI controls, particularly for keyboard users navigating complex interfaces.
**Verification:** Modified files passed PHP linting. Visual review of the diff confirms that only non-submit buttons were modified. No structural changes were made.

---
*PR created automatically by Jules for task [11701958518429989017](https://jules.google.com/task/11701958518429989017) started by @rpnunez*