### PR TITLE
Fix partial generation reconciliation after AI Edit and WordPress post saves

### DIFF
--- a/ai-post-scheduler/includes/class-aips-ai-edit-controller.php
+++ b/ai-post-scheduler/includes/class-aips-ai-edit-controller.php
@@ -30,6 +30,11 @@ class AIPS_AI_Edit_Controller {
 	 * @var AIPS_History_Repository_Interface
 	 */
 	private $history_repository;
+
+	/**
+	 * @var AIPS_Post_Manager
+	 */
+	private $post_manager;
 	
 	/**
 	 * Constructor
@@ -41,6 +46,7 @@ class AIPS_AI_Edit_Controller {
 		$container = AIPS_Container::get_instance();
 		$this->service            = $service ?: new AIPS_Component_Regeneration_Service();
 		$this->history_repository = $history_repository ?: ($container->has(AIPS_History_Repository_Interface::class) ? $container->make(AIPS_History_Repository_Interface::class) : new AIPS_History_Repository());
+		$this->post_manager       = new AIPS_Post_Manager();
 		
 		// Register AJAX endpoints
 		add_action('wp_ajax_aips_get_post_components', array($this, 'ajax_get_post_components'));
@@ -405,9 +411,9 @@ class AIPS_AI_Edit_Controller {
 		// Update featured image
 		if (isset($components['featured_image_id'])) {
 			$attachment_id = absint($components['featured_image_id']);
+			$updated_components[] = 'featured_image';
 			if ($attachment_id > 0) {
 				set_post_thumbnail($post_id, $attachment_id);
-				$updated_components[] = 'featured_image';
 			} else {
 				delete_post_thumbnail($post_id);
 			}
@@ -429,6 +435,7 @@ class AIPS_AI_Edit_Controller {
 		}
 
 		do_action('aips_post_components_updated', $post_id, $updated_components, $sanitized_components);
+		$this->reconcile_partial_generation_state($post_id);
 		
 		AIPS_Ajax_Response::success(array(
 			'message' => __('Post updated successfully!', 'ai-post-scheduler'),
@@ -590,6 +597,27 @@ class AIPS_AI_Edit_Controller {
 				AIPS_Ajax_Response::error(__('An error occurred while restoring component revision.', 'ai-post-scheduler'));
 			}
 		}
+
+		$sanitized_components = array();
+		switch ($component) {
+			case 'title':
+				$sanitized_components['title'] = sanitize_text_field((string) $restored_value);
+				break;
+			case 'excerpt':
+				$sanitized_components['excerpt'] = sanitize_textarea_field((string) $restored_value);
+				break;
+			case 'content':
+				$sanitized_components['content'] = wp_kses_post((string) $restored_value);
+				break;
+			case 'featured_image':
+				$sanitized_components['featured_image_id'] = is_array($restored_value) && isset($restored_value['attachment_id'])
+					? absint($restored_value['attachment_id'])
+					: 0;
+				break;
+		}
+
+		do_action('aips_post_components_updated', $post_id, array($component), $sanitized_components);
+		$this->reconcile_partial_generation_state($post_id);
 		
 		AIPS_Ajax_Response::success(array(
 			'message' => __('Revision restored successfully!', 'ai-post-scheduler'),
@@ -649,5 +677,18 @@ class AIPS_AI_Edit_Controller {
 			default:
 				return '';
 		}
+	}
+
+	/**
+	 * Reconcile partial-generation metadata against the post's current persisted state.
+	 *
+	 * This is used after AJAX save/restore requests because the AI Edit
+	 * controller is booted in AJAX mode without the admin save_post reconciler.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return void
+	 */
+	private function reconcile_partial_generation_state($post_id) {
+		$this->post_manager->reconcile_generation_status_meta_from_post($post_id);
 	}
 }

--- a/ai-post-scheduler/includes/class-aips-ai-edit-controller.php
+++ b/ai-post-scheduler/includes/class-aips-ai-edit-controller.php
@@ -560,7 +560,7 @@ class AIPS_AI_Edit_Controller {
 		// Restore the value to the post
 		$post_data = array('ID' => $post_id);
 		$restored_value = $revision_to_restore['value'];
-		
+
 		switch ($component) {
 			case 'title':
 				$post_data['post_title'] = sanitize_text_field($restored_value);
@@ -572,19 +572,22 @@ class AIPS_AI_Edit_Controller {
 				$post_data['post_content'] = wp_kses_post($restored_value);
 				break;
 			case 'featured_image':
-				// For featured image, the value is an array with attachment_id
-				if (is_array($restored_value) && isset($restored_value['attachment_id'])) {
-					$attachment_id = absint($restored_value['attachment_id']);
-					if ($attachment_id > 0) {
-						set_post_thumbnail($post_id, $attachment_id);
-					} else {
-						delete_post_thumbnail($post_id);
-					}
-					$restored_value = array(
-						'attachment_id' => $attachment_id,
-						'url' => $attachment_id ? wp_get_attachment_url($attachment_id) : '',
-					);
+				$restored_featured_image = $this->normalize_featured_image_revision_value($restored_value);
+				if (is_wp_error($restored_featured_image)) {
+					AIPS_Ajax_Response::error(__('Invalid featured image revision data.', 'ai-post-scheduler'));
 				}
+
+				$attachment_id = $restored_featured_image['attachment_id'];
+				if ($attachment_id > 0) {
+					$thumbnail_result = set_post_thumbnail($post_id, $attachment_id);
+					if (false === $thumbnail_result) {
+						AIPS_Ajax_Response::error(__('Failed to restore featured image revision.', 'ai-post-scheduler'));
+					}
+				} else {
+					delete_post_thumbnail($post_id);
+				}
+
+				$restored_value = $restored_featured_image;
 				break;
 		}
 		
@@ -677,6 +680,35 @@ class AIPS_AI_Edit_Controller {
 			default:
 				return '';
 		}
+	}
+
+	/**
+	 * Validate and normalize a featured image revision payload before restore.
+	 *
+	 * Featured image revisions are stored as arrays with attachment_id/url. If
+	 * that shape is missing, the restore should fail instead of silently
+	 * pretending the component was restored.
+	 *
+	 * @param mixed $value Raw revision payload.
+	 * @return array|WP_Error
+	 */
+	private function normalize_featured_image_revision_value($value) {
+		if (!is_array($value) || !array_key_exists('attachment_id', $value)) {
+			return new WP_Error('invalid_featured_image_revision', __('Invalid featured image revision data.', 'ai-post-scheduler'));
+		}
+
+		$attachment_id = absint($value['attachment_id']);
+		if ($attachment_id > 0) {
+			$attachment = get_post($attachment_id);
+			if (!$attachment || 'attachment' !== $attachment->post_type) {
+				return new WP_Error('invalid_featured_image_revision', __('Invalid featured image revision data.', 'ai-post-scheduler'));
+			}
+		}
+
+		return array(
+			'attachment_id' => $attachment_id,
+			'url' => $attachment_id ? wp_get_attachment_url($attachment_id) : '',
+		);
 	}
 
 	/**

--- a/ai-post-scheduler/includes/class-aips-partial-generation-state-reconciler.php
+++ b/ai-post-scheduler/includes/class-aips-partial-generation-state-reconciler.php
@@ -57,7 +57,7 @@ class AIPS_Partial_Generation_State_Reconciler {
 	 * @param WP_Post|null $post_before Previous post object when available.
 	 * @return void
 	 */
-	public function on_after_insert_post($post_id, $post, $update, $post_before) {
+	public function on_after_insert_post($post_id, $post, $update, $post_before = null) {
 		$this->reconcile_from_post_object($post_id, $post, $update, 'wp_after_insert_post');
 	}
 

--- a/ai-post-scheduler/includes/class-aips-partial-generation-state-reconciler.php
+++ b/ai-post-scheduler/includes/class-aips-partial-generation-state-reconciler.php
@@ -29,6 +29,7 @@ class AIPS_Partial_Generation_State_Reconciler {
 		$this->post_manager = new AIPS_Post_Manager();
 
 		add_action('save_post', array($this, 'on_save_post'), 20, 3);
+		add_action('wp_after_insert_post', array($this, 'on_after_insert_post'), 20, 4);
 		add_action('aips_post_components_updated', array($this, 'on_post_components_updated'), 10, 3);
 	}
 
@@ -41,26 +42,23 @@ class AIPS_Partial_Generation_State_Reconciler {
 	 * @return void
 	 */
 	public function on_save_post($post_id, $post, $update) {
-		if (!$update || empty($post_id) || !$post || $post->post_type !== 'post') {
-			return;
-		}
+		$this->reconcile_from_post_object($post_id, $post, $update, 'save_post');
+	}
 
-		if (wp_is_post_revision($post_id) || wp_is_post_autosave($post_id)) {
-			return;
-		}
-
-		$has_generation_meta_keys = metadata_exists('post', $post_id, 'aips_post_generation_component_statuses')
-			|| metadata_exists('post', $post_id, 'aips_post_generation_incomplete')
-			|| metadata_exists('post', $post_id, 'aips_post_generation_had_partial');
-
-		if (!$has_generation_meta_keys) {
-			return;
-		}
-
-		$statuses = $this->post_manager->reconcile_generation_status_meta_from_post($post_id);
-		if (is_array($statuses)) {
-			do_action('aips_partial_generation_state_reconciled', $post_id, $statuses, 'save_post');
-		}
+	/**
+	 * Reconcile metadata after the post has been fully inserted/updated.
+	 *
+	 * This fires later than save_post and catches the plain Edit Post screen
+	 * after WordPress has persisted the final post state.
+	 *
+	 * @param int     $post_id      Post ID.
+	 * @param WP_Post $post         Post object.
+	 * @param bool    $update       Whether this is an existing post being updated.
+	 * @param WP_Post|null $post_before Previous post object when available.
+	 * @return void
+	 */
+	public function on_after_insert_post($post_id, $post, $update, $post_before) {
+		$this->reconcile_from_post_object($post_id, $post, $update, 'wp_after_insert_post');
 	}
 
 	/**
@@ -101,6 +99,39 @@ class AIPS_Partial_Generation_State_Reconciler {
 		$statuses = $this->post_manager->reconcile_generation_status_meta_from_post($post_id, $overrides);
 		if (is_array($statuses)) {
 			do_action('aips_partial_generation_state_reconciled', $post_id, $statuses, 'aips_post_components_updated');
+		}
+	}
+
+	/**
+	 * Reconcile partial-generation metadata for a post object when it is eligible.
+	 *
+	 * @param int        $post_id  Post ID.
+	 * @param WP_Post    $post     Post object.
+	 * @param bool       $update   Whether this is an existing post being updated.
+	 * @param string     $source   Action source used in the reconciliation hook.
+	 * @return void
+	 */
+	private function reconcile_from_post_object($post_id, $post, $update, $source) {
+		$post_id = absint($post_id);
+		if (!$update || empty($post_id) || !$post || $post->post_type !== 'post') {
+			return;
+		}
+
+		if (wp_is_post_revision($post_id) || wp_is_post_autosave($post_id)) {
+			return;
+		}
+
+		$has_generation_meta_keys = metadata_exists('post', $post_id, 'aips_post_generation_component_statuses')
+			|| metadata_exists('post', $post_id, 'aips_post_generation_incomplete')
+			|| metadata_exists('post', $post_id, 'aips_post_generation_had_partial');
+
+		if (!$has_generation_meta_keys) {
+			return;
+		}
+
+		$statuses = $this->post_manager->reconcile_generation_status_meta_from_post($post_id);
+		if (is_array($statuses)) {
+			do_action('aips_partial_generation_state_reconciled', $post_id, $statuses, $source);
 		}
 	}
 }

--- a/ai-post-scheduler/tests/Test_AIPS_AI_Edit_Controller.php
+++ b/ai-post-scheduler/tests/Test_AIPS_AI_Edit_Controller.php
@@ -219,12 +219,21 @@ class Test_AIPS_AI_Edit_Controller extends WP_UnitTestCase {
 			'post_excerpt' => 'Old excerpt',
 			'post_content' => 'Old content',
 		));
+
+		update_post_meta($post_id, 'aips_post_generation_component_statuses', wp_json_encode(array(
+			'post_title'     => false,
+			'post_excerpt'   => false,
+			'featured_image' => true,
+			'post_content'   => false,
+		)));
+		update_post_meta($post_id, 'aips_post_generation_incomplete', 'true');
+		update_post_meta($post_id, 'aips_post_generation_had_partial', 'true');
 		
 		$_POST = array(
 			'action' => 'aips_save_post_components',
 			'post_id' => $post_id,
 			'components' => array(
-				'title' => 'New Title',
+				'title' => 'AI Generated Post: New Title',
 				'excerpt' => 'New excerpt',
 				'content' => 'New content',
 			),
@@ -245,9 +254,18 @@ class Test_AIPS_AI_Edit_Controller extends WP_UnitTestCase {
 		
 		// Verify post was updated
 		$updated_post = get_post($post_id);
-		$this->assertEquals('New Title', $updated_post->post_title);
+		$this->assertEquals('AI Generated Post: New Title', $updated_post->post_title);
 		$this->assertEquals('New excerpt', $updated_post->post_excerpt);
 		$this->assertEquals('New content', $updated_post->post_content);
+		$this->assertSame('false', get_post_meta($post_id, 'aips_post_generation_incomplete', true));
+		$this->assertSame('true', get_post_meta($post_id, 'aips_post_generation_had_partial', true));
+
+		$statuses = json_decode((string) get_post_meta($post_id, 'aips_post_generation_component_statuses', true), true);
+		$this->assertIsArray($statuses);
+		$this->assertTrue($statuses['post_title']);
+		$this->assertTrue($statuses['post_excerpt']);
+		$this->assertTrue($statuses['post_content']);
+		$this->assertTrue($statuses['featured_image']);
 	}
 	
 	/**
@@ -346,29 +364,30 @@ class Test_AIPS_AI_Edit_Controller extends WP_UnitTestCase {
 			'post_title' => 'Revision Restore Target',
 		));
 
-		$attachment_id = $this->factory->post->create(array(
-			'post_type' => 'attachment',
-			'post_mime_type' => 'image/jpeg',
-			'post_title' => 'Image Attachment',
-			'post_status' => 'inherit',
-		));
-
 		$history_id = $this->history_repository->create(array(
 			'post_id' => $post_id,
 			'status' => 'completed',
 		));
 
+		update_post_meta($post_id, 'aips_post_generation_component_statuses', wp_json_encode(array(
+			'post_title'     => false,
+			'post_excerpt'   => true,
+			'featured_image' => true,
+			'post_content'   => true,
+		)));
+		update_post_meta($post_id, 'aips_post_generation_incomplete', 'true');
+		update_post_meta($post_id, 'aips_post_generation_had_partial', 'true');
+
 		$revision_id = $this->history_repository->add_log_entry(
 			$history_id,
 			'ai_response',
 			array(
-				'message' => 'Image Snapshot',
+				'message' => 'Title Snapshot',
 				'output' => array(
-					'attachment_id' => $attachment_id,
-					'url' => 'https://example.test/image.jpg',
+					'value' => 'Restored Title',
 				),
 				'context' => array(
-					'component' => 'featured_image',
+					'component' => 'title',
 					'post_id' => $post_id,
 				),
 			),
@@ -378,7 +397,7 @@ class Test_AIPS_AI_Edit_Controller extends WP_UnitTestCase {
 		$_POST = array(
 			'action' => 'aips_restore_component_revision',
 			'post_id' => $post_id,
-			'component_type' => 'featured_image',
+			'component_type' => 'title',
 			'revision_id' => $revision_id,
 			'nonce' => wp_create_nonce('aips_ajax_nonce'),
 		);
@@ -394,9 +413,15 @@ class Test_AIPS_AI_Edit_Controller extends WP_UnitTestCase {
 		$response = json_decode($output, true);
 
 		$this->assertTrue($response['success']);
-		$this->assertEquals('featured_image', $response['data']['component']);
-		$this->assertIsArray($response['data']['value']);
-		$this->assertEquals($attachment_id, $response['data']['value']['attachment_id']);
+		$this->assertEquals('title', $response['data']['component']);
+		$this->assertEquals('Restored Title', $response['data']['value']);
+		$this->assertEquals('Restored Title', get_post($post_id)->post_title);
+		$this->assertSame('false', get_post_meta($post_id, 'aips_post_generation_incomplete', true));
+		$this->assertSame('true', get_post_meta($post_id, 'aips_post_generation_had_partial', true));
+
+		$statuses = json_decode((string) get_post_meta($post_id, 'aips_post_generation_component_statuses', true), true);
+		$this->assertIsArray($statuses);
+		$this->assertTrue($statuses['post_title']);
 	}
 
 	/**

--- a/ai-post-scheduler/tests/Test_AIPS_AI_Edit_Controller.php
+++ b/ai-post-scheduler/tests/Test_AIPS_AI_Edit_Controller.php
@@ -425,6 +425,76 @@ class Test_AIPS_AI_Edit_Controller extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Invalid featured-image revision payloads should be rejected instead of
+	 * silently falling back to a no-op restore.
+	 */
+	public function test_restore_component_revision_rejects_invalid_featured_image_payload() {
+		$post_id = $this->factory->post->create(array(
+			'post_title' => 'Featured Image Restore Target',
+		));
+
+		$current_attachment_id = $this->factory->post->create(array(
+			'post_type'      => 'attachment',
+			'post_mime_type' => 'image/jpeg',
+			'post_status'    => 'inherit',
+		));
+		update_post_meta($post_id, '_thumbnail_id', $current_attachment_id);
+
+		$history_id = $this->history_repository->create(array(
+			'post_id' => $post_id,
+			'status' => 'completed',
+		));
+
+		$revision_id = $this->history_repository->add_log_entry(
+			$history_id,
+			'ai_response',
+			array(
+				'message' => 'Broken Featured Image Snapshot',
+				'output' => array(
+					'url' => 'https://example.com/broken.jpg',
+				),
+				'context' => array(
+					'component' => 'featured_image',
+					'post_id' => $post_id,
+				),
+			),
+			AIPS_History_Type::AI_RESPONSE
+		);
+
+		update_post_meta($post_id, 'aips_post_generation_component_statuses', wp_json_encode(array(
+			'post_title'     => true,
+			'post_excerpt'   => true,
+			'featured_image' => false,
+			'post_content'   => true,
+		)));
+		update_post_meta($post_id, 'aips_post_generation_incomplete', 'true');
+		update_post_meta($post_id, 'aips_post_generation_had_partial', 'true');
+
+		$_POST = array(
+			'action' => 'aips_restore_component_revision',
+			'post_id' => $post_id,
+			'component' => 'featured_image',
+			'revision_id' => $revision_id,
+			'nonce' => wp_create_nonce('aips_ajax_nonce'),
+		);
+		$this->sync_request_from_post();
+
+		ob_start();
+		try {
+			$this->controller->ajax_restore_component_revision();
+		} catch (WPAjaxDieContinueException $e) {
+			// Expected.
+		}
+		$output = ob_get_clean();
+		$response = json_decode($output, true);
+
+		$this->assertFalse($response['success']);
+		$this->assertStringContainsString('Invalid featured image revision data', $response['data']['message']);
+		$this->assertSame($current_attachment_id, get_post_thumbnail_id($post_id));
+		$this->assertSame('true', get_post_meta($post_id, 'aips_post_generation_incomplete', true));
+	}
+
+	/**
 	 * Test restore_component_revision snapshots a manual draft before overwrite.
 	 */
 	public function test_restore_component_revision_captures_manual_snapshot() {

--- a/ai-post-scheduler/tests/Test_AIPS_Post_Review_Repository.php
+++ b/ai-post-scheduler/tests/Test_AIPS_Post_Review_Repository.php
@@ -173,6 +173,7 @@ class Test_AIPS_Post_Review_Repository extends WP_UnitTestCase {
 		$active_partial = $this->create_test_post_with_history('draft', 1);
 		$resolved_partial = $this->create_test_post_with_history('draft', 2);
 		$never_partial = $this->create_test_post_with_history('draft', 3);
+		$controller = new AIPS_Generated_Posts_Controller();
 
 		update_post_meta($active_partial['post_id'], 'aips_post_generation_incomplete', 'true');
 		update_post_meta($active_partial['post_id'], 'aips_post_generation_component_statuses', wp_json_encode(array(
@@ -216,6 +217,7 @@ class Test_AIPS_Post_Review_Repository extends WP_UnitTestCase {
 				$found_resolved_partial = true;
 				$this->assertSame('false', get_post_meta($item->post_id, 'aips_post_generation_incomplete', true));
 				$this->assertSame('true', get_post_meta($item->post_id, 'aips_post_generation_had_partial', true));
+				$this->assertSame(array(), $controller->get_missing_components($item->component_statuses));
 			}
 			$this->assertNotEquals($never_partial['post_id'], $item->post_id);
 		}

--- a/ai-post-scheduler/tests/Test_Partial_Generation_State_Reconciler.php
+++ b/ai-post-scheduler/tests/Test_Partial_Generation_State_Reconciler.php
@@ -243,6 +243,42 @@ class Test_Partial_Generation_State_Reconciler extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The after-insert callback should remain callable when WordPress does not
+	 * provide a post_before argument.
+	 */
+	public function test_after_insert_hook_accepts_optional_post_before_argument() {
+		$post_id = $this->factory->post->create(array(
+			'post_title'   => 'AI Generated Post: Optional Argument',
+			'post_excerpt' => '',
+			'post_content' => '',
+			'post_status'  => 'draft',
+		));
+
+		update_post_meta($post_id, 'aips_post_generation_component_statuses', wp_json_encode(array(
+			'post_title'     => false,
+			'post_excerpt'   => false,
+			'featured_image' => true,
+			'post_content'   => false,
+		)));
+		update_post_meta($post_id, 'aips_post_generation_incomplete', 'true');
+		update_post_meta($post_id, 'aips_post_generation_had_partial', 'true');
+
+		wp_update_post(array(
+			'ID'           => $post_id,
+			'post_excerpt' => 'Optional argument excerpt',
+			'post_content' => 'Optional argument content',
+		));
+
+		$this->reconciler->on_after_insert_post($post_id, get_post($post_id), true);
+
+		$this->assertSame('false', get_post_meta($post_id, 'aips_post_generation_incomplete', true));
+		$statuses = json_decode((string) get_post_meta($post_id, 'aips_post_generation_component_statuses', true), true);
+		$this->assertIsArray($statuses);
+		$this->assertTrue($statuses['post_excerpt']);
+		$this->assertTrue($statuses['post_content']);
+	}
+
+	/**
 	 * The featured-image path must reconcile after the thumbnail is persisted.
 	 */
 	public function test_reconciles_featured_image_after_thumbnail_update() {

--- a/ai-post-scheduler/tests/Test_Partial_Generation_State_Reconciler.php
+++ b/ai-post-scheduler/tests/Test_Partial_Generation_State_Reconciler.php
@@ -59,6 +59,13 @@ class Test_Partial_Generation_State_Reconciler extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The reconciler should listen to the later wp_after_insert_post hook too.
+	 */
+	public function test_registers_after_insert_post_hook() {
+		$this->assertNotFalse(has_action('wp_after_insert_post', array($this->reconciler, 'on_after_insert_post')));
+	}
+
+	/**
 	 * on_save_post() must do nothing for non-"post" post types.
 	 */
 	public function test_skips_for_non_post_type() {
@@ -104,8 +111,11 @@ class Test_Partial_Generation_State_Reconciler extends WP_UnitTestCase {
 	 */
 	public function test_proceeds_when_primary_meta_exists() {
 		global $aips_test_meta;
+		$post_id = $this->factory->post->create(array(
+			'post_title' => 'Meta Exists Post',
+		));
 		$aips_test_meta = array(
-			42 => array(
+			$post_id => array(
 				'aips_post_generation_component_statuses' => 'some_value',
 			),
 		);
@@ -115,7 +125,7 @@ class Test_Partial_Generation_State_Reconciler extends WP_UnitTestCase {
 			$actions_fired[] = true;
 		});
 
-		$this->reconciler->on_save_post(42, $this->make_post(), true);
+		$this->reconciler->on_save_post($post_id, get_post($post_id), true);
 
 		$this->assertNotEmpty($actions_fired, 'Hook must fire when primary meta key exists and reconcile returns data.');
 	}
@@ -129,9 +139,12 @@ class Test_Partial_Generation_State_Reconciler extends WP_UnitTestCase {
 	 */
 	public function test_reconciles_when_meta_key_exists_with_empty_value() {
 		global $aips_test_meta;
+		$post_id = $this->factory->post->create(array(
+			'post_title' => 'Meta Exists Empty Value Post',
+		));
 		// metadata_exists returns true because the row exists (even with an empty value).
 		$aips_test_meta = array(
-			42 => array(
+			$post_id => array(
 				'aips_post_generation_component_statuses' => '',
 				'aips_post_generation_incomplete'         => '',
 				'aips_post_generation_had_partial'        => '',
@@ -143,9 +156,131 @@ class Test_Partial_Generation_State_Reconciler extends WP_UnitTestCase {
 			$actions_fired[] = true;
 		});
 
-		$this->reconciler->on_save_post(42, $this->make_post(), true);
+		$this->reconciler->on_save_post($post_id, get_post($post_id), true);
 
 		// The metadata_exists fast-path passes → reconcile runs → hook fires.
 		$this->assertNotEmpty($actions_fired, 'Hook must fire when a meta key exists, even with an empty value.');
+	}
+
+	/**
+	 * A partially generated post should be marked resolved once the stored post
+	 * content is complete, even if the title still carries the AI prefix.
+	 */
+	public function test_reconciles_partial_post_after_manual_save() {
+		$post_id = $this->factory->post->create(array(
+			'post_title'   => 'AI Generated Post: Observability Stack Review',
+			'post_excerpt' => '',
+			'post_content' => '',
+			'post_status'  => 'draft',
+		));
+
+		update_post_meta($post_id, 'aips_post_generation_component_statuses', wp_json_encode(array(
+			'post_title'     => false,
+			'post_excerpt'   => false,
+			'featured_image' => true,
+			'post_content'   => false,
+		)));
+		update_post_meta($post_id, 'aips_post_generation_incomplete', 'true');
+		update_post_meta($post_id, 'aips_post_generation_had_partial', 'true');
+
+		wp_update_post(array(
+			'ID'           => $post_id,
+			'post_title'   => 'AI Generated Post: Observability Stack Review',
+			'post_excerpt' => 'Resolved excerpt',
+			'post_content' => 'Resolved content',
+		));
+
+		$this->reconciler->on_save_post($post_id, get_post($post_id), true);
+
+		$this->assertSame('false', get_post_meta($post_id, 'aips_post_generation_incomplete', true));
+		$this->assertSame('true', get_post_meta($post_id, 'aips_post_generation_had_partial', true));
+
+		$statuses = json_decode((string) get_post_meta($post_id, 'aips_post_generation_component_statuses', true), true);
+		$this->assertIsArray($statuses);
+		$this->assertTrue($statuses['post_title']);
+		$this->assertTrue($statuses['post_excerpt']);
+		$this->assertTrue($statuses['post_content']);
+		$this->assertTrue($statuses['featured_image']);
+	}
+
+	/**
+	 * The later after-insert hook should also reconcile the current post state.
+	 */
+	public function test_reconciles_partial_post_after_after_insert_hook() {
+		$post_id = $this->factory->post->create(array(
+			'post_title'   => 'AI Generated Post: Edit Screen Refresh',
+			'post_excerpt' => '',
+			'post_content' => '',
+			'post_status'  => 'draft',
+		));
+
+		update_post_meta($post_id, 'aips_post_generation_component_statuses', wp_json_encode(array(
+			'post_title'     => false,
+			'post_excerpt'   => false,
+			'featured_image' => true,
+			'post_content'   => false,
+		)));
+		update_post_meta($post_id, 'aips_post_generation_incomplete', 'true');
+		update_post_meta($post_id, 'aips_post_generation_had_partial', 'true');
+
+		wp_update_post(array(
+			'ID'           => $post_id,
+			'post_title'   => 'AI Generated Post: Edit Screen Refresh',
+			'post_excerpt' => 'Edit screen excerpt',
+			'post_content' => 'Edit screen content',
+		));
+
+		$this->reconciler->on_after_insert_post($post_id, get_post($post_id), true, null);
+
+		$this->assertSame('false', get_post_meta($post_id, 'aips_post_generation_incomplete', true));
+		$this->assertSame('true', get_post_meta($post_id, 'aips_post_generation_had_partial', true));
+
+		$statuses = json_decode((string) get_post_meta($post_id, 'aips_post_generation_component_statuses', true), true);
+		$this->assertIsArray($statuses);
+		$this->assertTrue($statuses['post_title']);
+		$this->assertTrue($statuses['post_excerpt']);
+		$this->assertTrue($statuses['post_content']);
+	}
+
+	/**
+	 * The featured-image path must reconcile after the thumbnail is persisted.
+	 */
+	public function test_reconciles_featured_image_after_thumbnail_update() {
+		$post_id = $this->factory->post->create(array(
+			'post_title'   => 'AI Generated Post: Featured Image Repair',
+			'post_excerpt' => 'Resolved excerpt',
+			'post_content' => 'Resolved content',
+			'post_status'  => 'draft',
+		));
+
+		$attachment_id = $this->factory->post->create(array(
+			'post_type'      => 'attachment',
+			'post_mime_type' => 'image/jpeg',
+			'post_status'    => 'inherit',
+		));
+
+		update_post_meta($post_id, 'aips_post_generation_component_statuses', wp_json_encode(array(
+			'post_title'     => true,
+			'post_excerpt'   => true,
+			'featured_image' => false,
+			'post_content'   => true,
+		)));
+		update_post_meta($post_id, 'aips_post_generation_incomplete', 'true');
+		update_post_meta($post_id, 'aips_post_generation_had_partial', 'true');
+
+		$this->reconciler->on_save_post($post_id, get_post($post_id), true);
+		$this->assertSame('true', get_post_meta($post_id, 'aips_post_generation_incomplete', true));
+
+		update_post_meta($post_id, '_thumbnail_id', $attachment_id);
+		$this->reconciler->on_post_components_updated($post_id, array('featured_image'), array(
+			'featured_image_id' => $attachment_id,
+		));
+
+		$this->assertSame('false', get_post_meta($post_id, 'aips_post_generation_incomplete', true));
+		$this->assertSame('true', get_post_meta($post_id, 'aips_post_generation_had_partial', true));
+
+		$statuses = json_decode((string) get_post_meta($post_id, 'aips_post_generation_component_statuses', true), true);
+		$this->assertIsArray($statuses);
+		$this->assertTrue($statuses['featured_image']);
 	}
 }


### PR DESCRIPTION
## Summary
This changeset keeps partial-generation metadata in sync after both AI Edit actions and normal WordPress post edits.

Previously, a post could remain stuck in the Partial Generations view even after the missing components were filled in through AI Edit or the standard Edit Post screen.

## What changed
- Reconcile partial-generation state after AI Edit saves and component restores.
- Add a later WordPress post-save hook so regular admin edits also refresh partial state.
- Keep `aips_post_generation_had_partial` as the historical marker, while letting `aips_post_generation_incomplete` and component-status meta reflect the current post content.
- Treat a title with the `AI Generated Post:` prefix as complete as long as the stored title is non-empty.
- Keep resolved historical partials visible in Partial Generations, but show them as resolved with no missing badges.

## Tests
- Added reconciler coverage for:
  - manual post-save resolution
  - after-insert post-save resolution
  - featured-image timing reconciliation
- Added AI Edit controller coverage for:
  - save path reconciliation
  - restore path reconciliation
- Updated repository/controller coverage to confirm resolved historical partials still appear with empty missing-components output.

## Verification
- `php -l` passed for all modified PHP files.
- Full PHPUnit rerun was not completed in this environment because the local WP test DB/session state was already dirty.