### PR TITLE
UI/notifications adminbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [3.0.1] - 2026-07-05
+
+### Added
+- **Per-User Notification Read State**: Added notification read receipts so admin-bar unread counts and mark-as-read actions are scoped to the current admin user.
+
+### Changed
+- **AI Scheduler Admin Bar**: Rebuilt the flyout with a 2-column quick-links panel, wider popup layout, aligned `Context` and `Mark as Read` actions, and clearer unread summary copy.
+- **Notification Titles**: Normalized admin-bar notification titles to short action labels while keeping post/template details in the message body.
+
 ## [3.0.0] - 2026-06-21
 
 ### Added

--- a/ai-post-scheduler/ai-post-scheduler.php
+++ b/ai-post-scheduler/ai-post-scheduler.php
@@ -3,7 +3,7 @@
  * Plugin Name: AI Post Scheduler
  * Plugin URI: https://nunezserver.com/nunezscheduler
  * Description: Schedule AI-generated posts using advanced features & scheduling options.
- * Version: 3.0.0
+ * Version: 3.0.1
  * Author: Raymond Nunez
  * Author URI: https://nunezserver.com
  * License: GPL v2 or later
@@ -44,7 +44,7 @@ if (!defined('AIPS_TELEMETRY_QUERY_SAMPLE_LIMIT')) {
 
 // Define plugin constants
 if (!defined('AIPS_VERSION')) {
-    define('AIPS_VERSION', '3.0.0');
+    define('AIPS_VERSION', '3.0.1');
 }
 
 if (!defined('AIPS_PLUGIN_DIR')) {
@@ -233,18 +233,6 @@ final class AI_Post_Scheduler {
 
         if (is_wp_error($install_result)) {
             $logger->log('Table installation failed during activation: ' . $install_result->get_error_message(), 'error');
-
-            $notifications = class_exists('AIPS_Notifications') ? new AIPS_Notifications() : null;
-            if ($notifications instanceof AIPS_Notifications) {
-                $notifications->system_error(array(
-                    'title'         => __('Database installation failed', 'ai-post-scheduler'),
-                    'error_code'    => $install_result->get_error_code(),
-                    'error_message' => $install_result->get_error_message(),
-                    'url'           => admin_url('admin.php?page=aips-status'),
-                    'dedupe_key'    => 'db_install_failed_activation',
-                    'dedupe_window' => 1800,
-                ));
-            }
         }
         
         $crons = self::get_cron_events();

--- a/ai-post-scheduler/assets/css/admin-bar.css
+++ b/ai-post-scheduler/assets/css/admin-bar.css
@@ -1,14 +1,11 @@
 /**
- * AI Post Scheduler – Admin Toolbar Styles
+ * AI Post Scheduler - Admin Toolbar Styles
  */
 
-/* -------------------------------------------------------
-   Root node
-------------------------------------------------------- */
 #wpadminbar #wp-admin-bar-aips-toolbar > .ab-item {
 	display: flex;
 	align-items: center;
-	gap: 4px;
+	gap: 6px;
 }
 
 #wpadminbar #wp-admin-bar-aips-toolbar .aips-toolbar-icon {
@@ -18,7 +15,6 @@
 	vertical-align: middle;
 }
 
-/* Notification badge on the root node */
 #wpadminbar .aips-toolbar-badge {
 	display: inline-flex;
 	align-items: center;
@@ -26,90 +22,145 @@
 	min-width: 18px;
 	height: 18px;
 	padding: 0 4px;
-	border-radius: 9px;
+	border-radius: 999px;
 	background: #d63638;
 	color: #fff;
 	font-size: 11px;
 	font-weight: 600;
 	line-height: 1;
 	margin-left: 4px;
-	vertical-align: middle;
 }
 
-/* -------------------------------------------------------
-   Dropdown container
-------------------------------------------------------- */
 #wpadminbar #wp-admin-bar-aips-toolbar .ab-sub-wrapper {
-	min-width: 320px;
+	width: min(760px, calc(100vw - 32px));
+	min-width: 360px;
 }
 
-/* -------------------------------------------------------
-   Quick-links group
-------------------------------------------------------- */
 #wpadminbar #wp-admin-bar-aips-toolbar-links {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	grid-template-rows: repeat(3, minmax(0, auto));
+	grid-auto-flow: column;
+	gap: 6px 10px;
+	padding: 10px 12px 12px;
 	border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-	padding-bottom: 4px;
 	margin-bottom: 4px;
 }
 
-#wpadminbar #wp-admin-bar-aips-toolbar-links .ab-item .dashicons {
-	font-size: 16px;
-	vertical-align: middle;
-	margin-right: 4px;
+#wpadminbar #wp-admin-bar-aips-toolbar-links > li {
+	margin: 0;
 }
 
-/* -------------------------------------------------------
-   Notifications group
-------------------------------------------------------- */
-#wpadminbar .aips-toolbar-group-notifications {
-	max-height: 320px;
-	overflow-y: auto;
+#wpadminbar #wp-admin-bar-aips-toolbar-links .ab-item {
+	display: block;
+	padding: 0;
+	height: auto;
+	line-height: inherit;
+	text-align: center;
 }
 
-/* Notifications header row */
-#wpadminbar .aips-toolbar-notif-header > .ab-item {
-	display: flex !important;
+#wpadminbar #wp-admin-bar-aips-toolbar-links .aips-toolbar-link-inner {
+	display: inline-flex;
 	align-items: center;
-	justify-content: space-between;
-	padding: 6px 12px;
-	cursor: default;
-	pointer-events: none; /* clicks handled by inner buttons */
-	color: rgba(255, 255, 255, 0.7);
-	font-size: 11px;
-	font-weight: 600;
-	text-transform: uppercase;
-	letter-spacing: 0.05em;
+	justify-content: center;
+	gap: 8px;
+	padding: 8px 10px;
+	border: 1px solid rgba(255, 255, 255, 0.08);
+	border-radius: 6px;
+	background: rgba(255, 255, 255, 0.03);
+	width: 100%;
+	box-sizing: border-box;
 }
 
-#wpadminbar .aips-toolbar-notif-heading {
+#wpadminbar #wp-admin-bar-aips-toolbar-links .ab-item:hover .aips-toolbar-link-inner {
+	background: rgba(255, 255, 255, 0.08);
+}
+
+#wpadminbar #wp-admin-bar-aips-toolbar-links .aips-toolbar-link-icon {
+	display: inline-block;
+	font: normal 16px/1 dashicons;
+	speak: never;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
+
+#wpadminbar #wp-admin-bar-aips-toolbar-links .aips-toolbar-link-icon,
+#wpadminbar #wp-admin-bar-aips-toolbar-links .dashicons {
+	font-size: 16px;
+	width: 16px;
+	height: 16px;
+	line-height: 16px;
+	flex-shrink: 0;
+}
+
+#wpadminbar #wp-admin-bar-aips-toolbar-links .aips-toolbar-link-label {
+	font-size: 12px;
+	font-weight: 500;
+}
+
+#wpadminbar #wp-admin-bar-aips-toolbar-notifications {
+	max-height: 360px;
+	overflow-y: auto;
+	padding-bottom: 8px;
+}
+
+#wpadminbar .aips-toolbar-notif-header > .ab-item {
+	display: block !important;
+	padding: 8px 12px 10px;
+	cursor: default;
 	pointer-events: none;
 }
 
-/* "Mark all as read" button inside header */
+#wpadminbar .aips-toolbar-notif-header-inner {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 12px;
+}
+
+#wpadminbar .aips-toolbar-notif-header-copy {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	min-width: 0;
+}
+
+#wpadminbar .aips-toolbar-notif-heading {
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
+	color: rgba(255, 255, 255, 0.72);
+}
+
+#wpadminbar .aips-toolbar-notif-summary {
+	font-size: 12px;
+	color: rgba(255, 255, 255, 0.6);
+}
+
 #wpadminbar .aips-mark-all-read {
 	pointer-events: all;
 	background: none;
-	border: 1px solid rgba(255, 255, 255, 0.4);
-	border-radius: 3px;
-	color: rgba(255, 255, 255, 0.8);
+	border: 1px solid rgba(255, 255, 255, 0.35);
+	border-radius: 4px;
+	color: rgba(255, 255, 255, 0.82);
 	cursor: pointer;
 	font-size: 11px;
-	padding: 2px 6px;
+	font-weight: 600;
+	padding: 4px 8px;
 	line-height: 1.4;
+	flex-shrink: 0;
 }
 
 #wpadminbar .aips-mark-all-read:hover {
-	background: rgba(255, 255, 255, 0.15);
+	background: rgba(255, 255, 255, 0.12);
 	color: #fff;
 }
 
-/* Individual notification rows */
 #wpadminbar .aips-toolbar-notification > .ab-item {
-	display: flex !important;
-	align-items: flex-start;
-	gap: 8px;
+	display: block !important;
+	padding: 0;
 	white-space: normal;
-	padding: 8px 12px;
 	line-height: 1.4;
 	cursor: default;
 }
@@ -118,34 +169,84 @@
 	background: rgba(255, 255, 255, 0.07);
 }
 
+#wpadminbar .aips-notif-grid {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	gap: 12px;
+	align-items: start;
+	padding: 10px 12px;
+}
+
+#wpadminbar .aips-notif-body {
+	min-width: 0;
+}
+
+#wpadminbar .aips-notif-title {
+	display: block;
+	margin-bottom: 4px;
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	color: rgba(255, 255, 255, 0.64);
+}
+
 #wpadminbar .aips-notif-message {
-	flex: 1;
+	display: block;
 	font-size: 12px;
-	color: rgba(255, 255, 255, 0.9);
+	color: rgba(255, 255, 255, 0.92);
 	word-break: break-word;
 }
 
-#wpadminbar .aips-notif-message a {
-	color: #72aee6;
-	text-decoration: underline;
-}
-
-#wpadminbar .aips-notif-message a:hover {
-	color: #a8d0f0;
-}
-
-/* Mark-as-read button */
-#wpadminbar .aips-mark-read {
-	background: none;
-	border: none;
-	color: rgba(255, 255, 255, 0.5);
-	cursor: pointer;
-	padding: 0;
+#wpadminbar .aips-notif-actions {
+	display: flex;
+	align-items: center;
+	gap: 8px;
 	flex-shrink: 0;
-	line-height: 1;
+}
+
+#wpadminbar .aips-notif-context,
+#wpadminbar .aips-mark-read {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 28px;
+	border-radius: 4px;
+	font-size: 11px;
+	font-weight: 600;
+	text-decoration: none;
+}
+
+#wpadminbar .aips-notif-context {
+	padding: 0 10px;
+	border: 1px solid rgba(114, 174, 230, 0.45);
+	color: #72aee6;
+	background: rgba(114, 174, 230, 0.08);
+}
+
+#wpadminbar .aips-notif-context:hover {
+	color: #c5d9ed;
+	background: rgba(114, 174, 230, 0.16);
+}
+
+#wpadminbar .aips-notif-context-disabled {
+	border-color: rgba(255, 255, 255, 0.14);
+	color: rgba(255, 255, 255, 0.4);
+	background: rgba(255, 255, 255, 0.04);
+	cursor: default;
+}
+
+#wpadminbar .aips-mark-read {
+	padding: 0 8px;
+	border: 1px solid rgba(255, 255, 255, 0.14);
+	background: rgba(255, 255, 255, 0.04);
+	color: rgba(255, 255, 255, 0.62);
+	cursor: pointer;
 }
 
 #wpadminbar .aips-mark-read:hover {
+	border-color: rgba(74, 184, 102, 0.55);
+	background: rgba(74, 184, 102, 0.12);
 	color: #4ab866;
 }
 
@@ -153,23 +254,20 @@
 	font-size: 16px;
 	width: 16px;
 	height: 16px;
-	line-height: 1;
+	line-height: 16px;
 }
 
-/* "No new notifications" row */
 #wpadminbar .aips-toolbar-no-notifications > .ab-item {
 	cursor: default;
+	padding: 10px 12px;
 }
 
 #wpadminbar .aips-toolbar-empty {
-	color: rgba(255, 255, 255, 0.5);
+	color: rgba(255, 255, 255, 0.52);
 	font-style: italic;
 	font-size: 12px;
 }
 
-/* -------------------------------------------------------
-   Notification severity levels
-------------------------------------------------------- */
 #wpadminbar .aips-notif-level-warning > .ab-item {
 	border-left: 3px solid #f0b429;
 }
@@ -178,21 +276,37 @@
 	border-left: 3px solid #d63638;
 }
 
-/* Notification title line */
-#wpadminbar .aips-notif-title {
-	display: block;
-	font-size: 11px;
-	font-weight: 600;
-	color: rgba(255, 255, 255, 0.6);
-	text-transform: uppercase;
-	letter-spacing: 0.04em;
-	margin-bottom: 2px;
-}
-
 #wpadminbar .aips-notif-level-warning .aips-notif-title {
 	color: #f0b429;
 }
 
 #wpadminbar .aips-notif-level-error .aips-notif-title {
 	color: #f86368;
+}
+
+@media screen and (max-width: 960px) {
+	#wpadminbar #wp-admin-bar-aips-toolbar .ab-sub-wrapper {
+		width: min(100vw - 20px, 680px);
+		min-width: 0;
+	}
+
+	#wpadminbar .aips-notif-grid {
+		grid-template-columns: 1fr;
+	}
+
+	#wpadminbar .aips-notif-actions {
+		justify-content: flex-start;
+	}
+}
+
+@media screen and (max-width: 782px) {
+	#wpadminbar #wp-admin-bar-aips-toolbar-links {
+		grid-template-columns: 1fr;
+		grid-template-rows: none;
+		grid-auto-flow: row;
+	}
+
+	#wpadminbar .aips-toolbar-notif-header-inner {
+		flex-direction: column;
+	}
 }

--- a/ai-post-scheduler/assets/js/admin-bar.js
+++ b/ai-post-scheduler/assets/js/admin-bar.js
@@ -55,18 +55,45 @@
 		},
 
 		/**
-		 * Build the "no new notifications" placeholder list item HTML.
+		 * Build the "no notifications" placeholder list item HTML.
 		 *
 		 * @return {string} HTML string.
 		 */
 		adminBarNoNotificationsHtml: function () {
-			var noNotifText = wp && wp.i18n
-				? wp.i18n.__('No new notifications', 'ai-post-scheduler')
-				: 'No new notifications';
+			var noNotifText = window.wp && window.wp.i18n
+				? wp.i18n.__('No notifications', 'ai-post-scheduler')
+				: 'No notifications';
 			return '<li id="wp-admin-bar-aips-toolbar-no-notifications" class="aips-toolbar-no-notifications ab-empty-item">'
 				+ '<span class="ab-item aips-toolbar-empty">'
 				+ $('<div>').text(noNotifText).html()
 				+ '</span></li>';
+		},
+
+		/**
+		 * Update the notifications header summary based on current DOM and unread count.
+		 *
+		 * @param {number} count Remaining unread count for the current user.
+		 */
+		adminBarRefreshHeader: function (count) {
+			var l10n       = window.aipsAdminBarL10n || {};
+			var $header    = $('#wp-admin-bar-aips-toolbar-notifications-header');
+			var $summary   = $header.find('.aips-toolbar-notif-summary');
+			var shownCount = $('#wpadminbar li.aips-toolbar-notification').length;
+			var summary;
+
+			if (!$summary.length || count <= 0) {
+				return;
+			}
+
+			if (count > shownCount && shownCount > 0) {
+				summary = (l10n.showingSummaryTemplate || 'Showing %1$d of %2$d unread')
+					.replace('%1$d', shownCount)
+					.replace('%2$d', count);
+			} else {
+				summary = String(count) + ' ' + (l10n.unreadSummaryLabel || 'unread');
+			}
+
+			$summary.text(summary);
 		},
 
 		/**
@@ -102,6 +129,8 @@
 							$('#wp-admin-bar-aips-toolbar-notifications .ab-submenu').append(
 								AIPS.adminBarNoNotificationsHtml()
 							);
+						} else {
+							AIPS.adminBarRefreshHeader(response.data.unread_count || 0);
 						}
 					});
 					AIPS.adminBarUpdateBadge(response.data.unread_count);
@@ -139,6 +168,7 @@
 				if (response && response.success) {
 					$('#wpadminbar li.aips-toolbar-notification').remove();
 					$('#wp-admin-bar-aips-toolbar-notifications-header').remove();
+					$('#wp-admin-bar-aips-toolbar-no-notifications').remove();
 
 					// Add "no notifications" placeholder inside the submenu <ul>.
 					$('#wp-admin-bar-aips-toolbar-notifications .ab-submenu').append(

--- a/ai-post-scheduler/includes/class-aips-admin-bar.php
+++ b/ai-post-scheduler/includes/class-aips-admin-bar.php
@@ -20,6 +20,11 @@ if (!defined('ABSPATH')) {
 class AIPS_Admin_Bar {
 
 	/**
+	 * Maximum notifications rendered in the flyout at once.
+	 */
+	private const NOTIFICATION_LIMIT = 20;
+
+	/**
 	 * Lazily-resolved notifications repository.
 	 * Null until the first rendering hook actually needs it.
 	 *
@@ -67,8 +72,12 @@ class AIPS_Admin_Bar {
 		wp_localize_script('aips-admin-bar', 'aipsAdminBarL10n', array(
 			'ajaxUrl'         => admin_url('admin-ajax.php'),
 			'nonce'           => wp_create_nonce('aips_admin_bar_nonce'),
+			'contextLabel'    => __('Context', 'ai-post-scheduler'),
 			'markReadError'   => __('Could not mark notification as read.', 'ai-post-scheduler'),
 			'markAllReadError' => __('Could not mark all notifications as read.', 'ai-post-scheduler'),
+			'unreadSummaryLabel' => __('unread', 'ai-post-scheduler'),
+			'latestSummaryTemplate' => __('Latest %1$d of %2$d unread', 'ai-post-scheduler'),
+			'showingSummaryTemplate' => __('Showing %1$d of %2$d unread', 'ai-post-scheduler'),
 		));
 	}
 
@@ -137,18 +146,33 @@ class AIPS_Admin_Bar {
 
 		$quick_links = array(
 			array(
+				'id'    => 'aips-toolbar-dashboard',
+				'title' => $this->build_quick_link_title('dashicons-chart-bar', __('Dashboard', 'ai-post-scheduler')),
+				'href'  => AIPS_Admin_Menu_Helper::get_page_url('dashboard'),
+			),
+			array(
+				'id'    => 'aips-toolbar-automations',
+				'title' => $this->build_quick_link_title('dashicons-controls-repeat', __('Automations', 'ai-post-scheduler')),
+				'href'  => AIPS_Admin_Menu_Helper::get_page_url('automations'),
+			),
+			array(
+				'id'    => 'aips-toolbar-history',
+				'title' => $this->build_quick_link_title('dashicons-backup', __('History', 'ai-post-scheduler')),
+				'href'  => AIPS_Admin_Menu_Helper::get_page_url('history'),
+			),
+			array(
 				'id'    => 'aips-toolbar-templates',
-				'title' => '<span class="dashicons dashicons-media-document"></span> ' . esc_html__('Templates', 'ai-post-scheduler'),
+				'title' => $this->build_quick_link_title('dashicons-media-document', __('Templates', 'ai-post-scheduler')),
 				'href'  => AIPS_Admin_Menu_Helper::get_page_url('templates'),
 			),
 			array(
 				'id'    => 'aips-toolbar-authors',
-				'title' => '<span class="dashicons dashicons-admin-users"></span> ' . esc_html__('Authors', 'ai-post-scheduler'),
+				'title' => $this->build_quick_link_title('dashicons-admin-users', __('Authors', 'ai-post-scheduler')),
 				'href'  => AIPS_Admin_Menu_Helper::get_page_url('authors'),
 			),
 			array(
 				'id'    => 'aips-toolbar-schedules',
-				'title' => '<span class="dashicons dashicons-calendar-alt"></span> ' . esc_html__('Schedules', 'ai-post-scheduler'),
+				'title' => $this->build_quick_link_title('dashicons-calendar-alt', __('Schedules', 'ai-post-scheduler')),
 				'href'  => AIPS_Admin_Menu_Helper::get_page_url('schedule'),
 			),
 		);
@@ -163,7 +187,7 @@ class AIPS_Admin_Bar {
 		}
 
 		// ---------- Notifications group ----------
-		$notifications = ($unread_count > 0) ? $this->get_repository()->get_unread(20) : array();
+		$notifications = ($unread_count > 0) ? $this->get_repository()->get_unread(self::NOTIFICATION_LIMIT) : array();
 
 		$wp_admin_bar->add_group(array(
 			'id'     => 'aips-toolbar-notifications',
@@ -172,11 +196,11 @@ class AIPS_Admin_Bar {
 		));
 
 		if (empty($notifications)) {
-			// "No new notifications" placeholder
+			// "No notifications" placeholder
 			$wp_admin_bar->add_node(array(
 				'id'     => 'aips-toolbar-no-notifications',
 				'parent' => 'aips-toolbar-notifications',
-				'title'  => '<span class="aips-toolbar-empty">' . esc_html__('No new notifications', 'ai-post-scheduler') . '</span>',
+				'title'  => '<span class="aips-toolbar-empty">' . esc_html__('No notifications', 'ai-post-scheduler') . '</span>',
 				'href'   => false,
 				'meta'   => array('class' => 'aips-toolbar-no-notifications ab-empty-item'),
 			));
@@ -185,35 +209,12 @@ class AIPS_Admin_Bar {
 			$wp_admin_bar->add_node(array(
 				'id'     => 'aips-toolbar-notifications-header',
 				'parent' => 'aips-toolbar-notifications',
-				'title'  => '<span class="aips-toolbar-notif-heading">'
-					. esc_html__('Notifications', 'ai-post-scheduler')
-					. '</span>'
-					. '<button class="aips-mark-all-read" data-nonce="' . esc_attr(wp_create_nonce('aips_admin_bar_nonce')) . '">'
-					. esc_html__('Mark all as read', 'ai-post-scheduler')
-					. '</button>',
+				'title'  => $this->build_notifications_header_title($unread_count, count($notifications)),
 				'href'   => false,
 				'meta'   => array('class' => 'aips-toolbar-notif-header ab-empty-item'),
 			));
 
 			foreach ($notifications as $notif) {
-				$title_markup = '';
-				if (!empty($notif->title)) {
-					$title_markup = '<span class="aips-notif-title">' . esc_html($notif->title) . '</span>';
-				}
-
-				$node_title = $title_markup . '<span class="aips-notif-message">';
-
-				if (!empty($notif->url)) {
-					$node_title .= '<a href="' . esc_url($notif->url) . '">' . esc_html($notif->message) . '</a>';
-				} else {
-					$node_title .= esc_html($notif->message);
-				}
-
-				$node_title .= '</span>'
-					. '<button class="aips-mark-read" data-id="' . esc_attr($notif->id) . '" data-nonce="' . esc_attr(wp_create_nonce('aips_admin_bar_nonce')) . '" title="' . esc_attr__('Mark as read', 'ai-post-scheduler') . '">'
-					. '<span class="dashicons dashicons-yes-alt"></span>'
-					. '</button>';
-
 				$level_class = '';
 				if (!empty($notif->level) && in_array($notif->level, array('warning', 'error'), true)) {
 					$level_class = ' aips-notif-level-' . $notif->level;
@@ -222,7 +223,7 @@ class AIPS_Admin_Bar {
 				$wp_admin_bar->add_node(array(
 					'id'     => 'aips-notif-' . absint($notif->id),
 					'parent' => 'aips-toolbar-notifications',
-					'title'  => $node_title,
+					'title'  => $this->build_notification_row_title($notif),
 					'href'   => false,
 					'meta'   => array(
 						'class'         => 'aips-toolbar-notification ab-empty-item' . $level_class,
@@ -298,6 +299,89 @@ class AIPS_Admin_Bar {
 		AIPS_Ajax_Response::success(array(
 			'unread_count' => $unread_count,
 		));
+	}
+
+	/**
+	 * Build the formatted quick-link label.
+	 *
+	 * @param string $icon Dashicon class suffix.
+	 * @param string $label Human-readable label.
+	 * @return string
+	 */
+	private function build_quick_link_title($icon, $label) {
+		return '<span class="aips-toolbar-link-inner">'
+			. '<span class="aips-toolbar-link-icon dashicons ' . esc_attr($icon) . '" aria-hidden="true"></span>'
+			. '<span class="aips-toolbar-link-label">' . esc_html($label) . '</span>'
+			. '</span>';
+	}
+
+	/**
+	 * Build the notifications header row HTML.
+	 *
+	 * @param int $unread_count Total unread notifications for the current user.
+	 * @param int $displayed_count Number of notifications rendered in the flyout.
+	 * @return string
+	 */
+	private function build_notifications_header_title($unread_count, $displayed_count) {
+		$summary = sprintf(
+			_n('%d unread', '%d unread', $unread_count, 'ai-post-scheduler'),
+			$unread_count
+		);
+
+		if ($unread_count > $displayed_count) {
+			$summary = sprintf(
+				__('Latest %1$d of %2$d unread', 'ai-post-scheduler'),
+				$displayed_count,
+				$unread_count
+			);
+		}
+
+		return '<div class="aips-toolbar-notif-header-inner">'
+			. '<div class="aips-toolbar-notif-header-copy">'
+			. '<span class="aips-toolbar-notif-heading">' . esc_html__('Notifications', 'ai-post-scheduler') . '</span>'
+			. '<span class="aips-toolbar-notif-summary">' . esc_html($summary) . '</span>'
+			. '</div>'
+			. '<button class="aips-mark-all-read" data-nonce="' . esc_attr(wp_create_nonce('aips_admin_bar_nonce')) . '">'
+			. esc_html__('Mark all as read', 'ai-post-scheduler')
+			. '</button>'
+			. '</div>';
+	}
+
+	/**
+	 * Build one notification flyout row.
+	 *
+	 * @param object $notif Notification row.
+	 * @return string
+	 */
+	private function build_notification_row_title($notif) {
+		$title_markup = '';
+		if (!empty($notif->title)) {
+			$title_markup = '<span class="aips-notif-title">' . esc_html($notif->title) . '</span>';
+		}
+
+		$context_markup = '<span class="aips-notif-context aips-notif-context-disabled">'
+			. esc_html__('Context', 'ai-post-scheduler')
+			. '</span>';
+
+		if (!empty($notif->url)) {
+			$context_markup = '<a class="aips-notif-context" href="' . esc_url($notif->url) . '">'
+				. esc_html__('Context', 'ai-post-scheduler')
+				. '</a>';
+		}
+
+		return '<div class="aips-notif-grid">'
+			. '<div class="aips-notif-body">'
+			. $title_markup
+			. '<span class="aips-notif-message">' . esc_html($notif->message) . '</span>'
+			. '</div>'
+			. '<div class="aips-notif-actions">'
+			. $context_markup
+			. '<button class="aips-mark-read" data-id="' . esc_attr($notif->id) . '" data-nonce="' . esc_attr(wp_create_nonce('aips_admin_bar_nonce')) . '" title="' . esc_attr__('Mark as read', 'ai-post-scheduler') . '">'
+			. '<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>'
+			. '<span class="screen-reader-text">' . esc_html__('Mark as read', 'ai-post-scheduler') . '</span>'
+			. '</button>'
+			. '</div>'
+			. '</div>';
 	}
 
 }

--- a/ai-post-scheduler/includes/class-aips-cache.php
+++ b/ai-post-scheduler/includes/class-aips-cache.php
@@ -67,6 +67,17 @@ class AIPS_Cache {
 	private static $system_enabled = null;
 
 	/**
+	 * Per-request memo of resolved tag versions, keyed "{group}\0{tag}".
+	 *
+	 * Instance-scoped: named cache instances are per-request singletons, so
+	 * this collapses the repeated tag-version SELECTs the repository trait
+	 * issues on every cache_read() without risking cross-driver staleness.
+	 *
+	 * @var array<string, int>
+	 */
+	private $tag_version_memo = array();
+
+	/**
 	 * Constructor.
 	 *
 	 * @param AIPS_Cache_Driver|null $driver Optional driver. When null, the
@@ -245,6 +256,9 @@ class AIPS_Cache {
 		}
 		$result = $this->driver->delete( $key, $group );
 		if ($result) {
+			if (0 === strpos( (string) $key, 'tag_version:' )) {
+				unset( $this->tag_version_memo[ $group . "\0" . substr( (string) $key, strlen( 'tag_version:' ) ) ] );
+			}
 			$index = $this->get_cache_index();
 			if ($index) {
 				$index->record_delete( (string) $key, (string) $group );
@@ -305,6 +319,7 @@ class AIPS_Cache {
 		}
 		$result = $this->driver->flush();
 		if ($result) {
+			$this->tag_version_memo = array();
 			$index = $this->get_cache_index();
 			if ($index) {
 				$index->record_flush();
@@ -448,10 +463,18 @@ class AIPS_Cache {
 			return 1;
 		}
 
-		$key     = $this->build_tag_version_key( $tag );
-		$version = $this->get( $key, $group, 1 );
+		$tag_key  = $this->sanitize_tag( $tag );
+		$memo_key = $group . "\0" . $tag_key;
+		if (isset( $this->tag_version_memo[ $memo_key ] )) {
+			return $this->tag_version_memo[ $memo_key ];
+		}
 
-		return max( 1, (int) $version );
+		$key     = 'tag_version:' . $tag_key;
+		$version = max( 1, (int) $this->get( $key, $group, 1 ) );
+
+		$this->tag_version_memo[ $memo_key ] = $version;
+
+		return $version;
 	}
 
 	/**
@@ -476,6 +499,7 @@ class AIPS_Cache {
 		$current = $this->get( $key, $group, null );
 		$version = null === $current ? 2 : max( 2, (int) $current + 1 );
 		$this->set( $key, $version, 0, $group );
+		$this->tag_version_memo[ $group . "\0" . $tag_key ] = max( 1, (int) $version );
 		$this->record_tag_bump_event( array( $tag_key ), $group );
 
 		return max( 1, (int) $version );
@@ -527,6 +551,7 @@ class AIPS_Cache {
 			$current = $this->get( $key, $group, null );
 			$version = null === $current ? 2 : max( 2, (int) $current + 1 );
 			$this->set( $key, $version, 0, $group );
+			$this->tag_version_memo[ $group . "\0" . $tag ] = $version;
 			$versions[ $tag ] = $version;
 		}
 

--- a/ai-post-scheduler/includes/class-aips-db-manager.php
+++ b/ai-post-scheduler/includes/class-aips-db-manager.php
@@ -21,6 +21,7 @@ class AIPS_DB_Manager {
         'aips_author_topic_logs',
         'aips_topic_feedback',
         'aips_notifications',
+        'aips_notification_reads',
         'aips_sources',
         'aips_source_group_terms',
         'aips_sources_data',
@@ -82,6 +83,7 @@ class AIPS_DB_Manager {
         $table_author_topic_logs = $tables['aips_author_topic_logs'];
         $table_topic_feedback = $tables['aips_topic_feedback'];
         $table_notifications        = $tables['aips_notifications'];
+        $table_notification_reads   = $tables['aips_notification_reads'];
         $table_sources              = $tables['aips_sources'];
         $table_source_group_terms   = $tables['aips_source_group_terms'];
         $table_sources_data         = $tables['aips_sources_data'];
@@ -419,6 +421,15 @@ class AIPS_DB_Manager {
             KEY dedupe_key_created_at (dedupe_key, created_at)
         ) $charset_collate;";
 
+        $sql[] = "CREATE TABLE $table_notification_reads (
+            notification_id bigint(20) NOT NULL,
+            user_id bigint(20) NOT NULL,
+            read_at bigint(20) unsigned NOT NULL DEFAULT 0,
+            PRIMARY KEY  (notification_id, user_id),
+            KEY user_id (user_id),
+            KEY read_at (read_at)
+        ) $charset_collate;";
+
         $sql[] = "CREATE TABLE $table_sources (
             id bigint(20) NOT NULL AUTO_INCREMENT,
             url varchar(2083) NOT NULL,
@@ -649,6 +660,11 @@ class AIPS_DB_Manager {
         $schema = $instance->get_schema();
         global $wpdb;
 
+        $preflight_result = self::repair_tables_before_dbdelta($schema);
+        if (is_wp_error($preflight_result)) {
+            return $preflight_result;
+        }
+
         foreach ($schema as $sql) {
             $pre_error = $wpdb->last_error;
             dbDelta($sql);
@@ -671,6 +687,187 @@ class AIPS_DB_Manager {
 
         // Record that the DB schema is now at the current plugin version
         update_option('aips_db_version', AIPS_VERSION);
+
+        return true;
+    }
+
+    /**
+     * Repair legacy table states that would cause dbDelta to fail before it runs.
+     *
+     * Some older installs can lose the single-column `id` primary key on a table
+     * while still containing rows with duplicate or zero ids. In that state,
+     * dbDelta will fail when it attempts to re-add the primary key. Repair those
+     * ids up front so dbDelta can safely normalize the schema.
+     *
+     * @param array $schema Array of CREATE TABLE statements from get_schema().
+     * @return true|WP_Error
+     */
+    private static function repair_tables_before_dbdelta($schema) {
+        foreach ($schema as $sql) {
+            $table_name = self::extract_table_name_from_schema_sql($sql);
+            if ('' === $table_name || !self::schema_uses_single_id_primary_key($sql)) {
+                continue;
+            }
+
+            $repair_result = self::maybe_repair_single_id_primary_key_table($table_name);
+            if (is_wp_error($repair_result)) {
+                return $repair_result;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Extract the fully-qualified table name from a CREATE TABLE statement.
+     *
+     * @param string $sql CREATE TABLE SQL statement.
+     * @return string
+     */
+    private static function extract_table_name_from_schema_sql($sql) {
+        if (!is_string($sql) || '' === $sql) {
+            return '';
+        }
+
+        if (!preg_match('/CREATE TABLE\s+`?([^\s(]+)`?\s*\(/i', $sql, $matches)) {
+            return '';
+        }
+
+        return (string) $matches[1];
+    }
+
+    /**
+     * Determine whether the schema expects a single-column primary key on `id`.
+     *
+     * @param string $sql CREATE TABLE SQL statement.
+     * @return bool
+     */
+    private static function schema_uses_single_id_primary_key($sql) {
+        if (!is_string($sql) || '' === $sql) {
+            return false;
+        }
+
+        return 1 === preg_match('/PRIMARY KEY\s*\(\s*`?id`?\s*\)/i', $sql);
+    }
+
+    /**
+     * Repair duplicate/non-positive ids on legacy tables that are missing a primary key.
+     *
+     * @param string $table Fully-qualified table name.
+     * @return true|WP_Error
+     */
+    private static function maybe_repair_single_id_primary_key_table($table) {
+        global $wpdb;
+
+        if (!is_string($table) || '' === $table) {
+            return true;
+        }
+
+        $table_exists = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table));
+        if ($table_exists !== $table) {
+            return true;
+        }
+
+        $id_column = $wpdb->get_row($wpdb->prepare(
+            "SHOW COLUMNS FROM `{$table}` WHERE Field = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+            'id'
+        ));
+        if (!$id_column) {
+            return true;
+        }
+
+        $primary_key = $wpdb->get_row(
+            "SHOW INDEX FROM `{$table}` WHERE Key_name = 'PRIMARY'" // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+        );
+        if ($primary_key) {
+            return true;
+        }
+
+        $invalid_ids = (int) $wpdb->get_var(
+            "SELECT COUNT(*) FROM (
+                SELECT id
+                FROM `{$table}`
+                GROUP BY id
+                HAVING id <= 0 OR COUNT(*) > 1
+            ) AS invalid_ids" // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+        );
+
+        if ($invalid_ids <= 0) {
+            return true;
+        }
+
+        $repair_column = 'aips_repair_row_id';
+        $repair_exists = $wpdb->get_row($wpdb->prepare(
+            "SHOW COLUMNS FROM `{$table}` WHERE Field = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+            $repair_column
+        ));
+
+        if (!$repair_exists) {
+            $add_result = $wpdb->query(
+                "ALTER TABLE `{$table}` ADD COLUMN `{$repair_column}` bigint(20) unsigned NOT NULL AUTO_INCREMENT PRIMARY KEY" // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+            );
+
+            if (false === $add_result) {
+                return new WP_Error('db_install_failed', 'Failed to add temporary repair primary key for ' . $table . ': ' . $wpdb->last_error);
+            }
+        }
+
+        $rows = $wpdb->get_results(
+            "SELECT `{$repair_column}` AS repair_row_id, id
+            FROM `{$table}`
+            ORDER BY id ASC, `{$repair_column}` ASC", // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+            ARRAY_A
+        );
+
+        if (empty($rows)) {
+            $cleanup_result = $wpdb->query(
+                "ALTER TABLE `{$table}` DROP PRIMARY KEY, DROP COLUMN `{$repair_column}`" // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+            );
+
+            if (false === $cleanup_result) {
+                return new WP_Error('db_install_failed', 'Failed to clean temporary repair key for ' . $table . ': ' . $wpdb->last_error);
+            }
+
+            return true;
+        }
+
+        $next_id = (int) $wpdb->get_var(
+            "SELECT MAX(id) FROM `{$table}` WHERE id > 0" // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+        );
+        $seen_ids = array();
+
+        foreach ($rows as $row) {
+            $current_id = isset($row['id']) ? (int) $row['id'] : 0;
+            $row_id     = isset($row['repair_row_id']) ? (int) $row['repair_row_id'] : 0;
+
+            if ($current_id > 0 && !isset($seen_ids[$current_id])) {
+                $seen_ids[$current_id] = true;
+                continue;
+            }
+
+            $next_id++;
+            $update_result = $wpdb->update(
+                $table,
+                array('id' => $next_id),
+                array($repair_column => $row_id),
+                array('%d'),
+                array('%d')
+            );
+
+            if (false === $update_result) {
+                return new WP_Error('db_install_failed', 'Failed to repair duplicate ids for ' . $table . ': ' . $wpdb->last_error);
+            }
+
+            $seen_ids[$next_id] = true;
+        }
+
+        $cleanup_result = $wpdb->query(
+            "ALTER TABLE `{$table}` DROP PRIMARY KEY, DROP COLUMN `{$repair_column}`" // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+        );
+
+        if (false === $cleanup_result) {
+            return new WP_Error('db_install_failed', 'Failed to remove temporary repair key for ' . $table . ': ' . $wpdb->last_error);
+        }
 
         return true;
     }
@@ -754,6 +951,9 @@ class AIPS_DB_Manager {
             'aips_notifications' => array(
                 array( 'read_at', false ),
                 array( 'created_at', false ),
+            ),
+            'aips_notification_reads' => array(
+                array( 'read_at', false ),
             ),
             'aips_sources' => array(
                 array( 'last_fetched_at', false ),

--- a/ai-post-scheduler/includes/class-aips-db-migrations.php
+++ b/ai-post-scheduler/includes/class-aips-db-migrations.php
@@ -122,18 +122,6 @@ class AIPS_DB_Migrations {
 				'error'
 			);
 
-			if ( class_exists( 'AIPS_Notifications' ) ) {
-				( new AIPS_Notifications() )->system_error( array(
-					'title'         => __( 'Database upgrade failed', 'ai-post-scheduler' ),
-					'error_code'    => $install_result->get_error_code(),
-					'error_message' => $install_result->get_error_message(),
-					'from_version'  => $from_version,
-					'url'           => admin_url( 'admin.php?page=aips-status' ),
-					'dedupe_key'    => 'db_upgrade_failed_' . sanitize_key( (string) $from_version ),
-					'dedupe_window' => 1800,
-				) );
-			}
-
 			// Return without stamping the version so the next request retries.
 			return;
 		}

--- a/ai-post-scheduler/includes/class-aips-notification-registry.php
+++ b/ai-post-scheduler/includes/class-aips-notification-registry.php
@@ -49,12 +49,14 @@ class AIPS_Notification_Registry {
 		return array(
 			'author_topics_generated' => array(
 				'label'        => __('Author Topics Generated', 'ai-post-scheduler'),
+				'admin_bar_title' => __('Author topics generated', 'ai-post-scheduler'),
 				'description'  => __('New author topics are available for review in the admin area.', 'ai-post-scheduler'),
 				'default_mode' => self::MODE_DB_ONLY,
 				'level'        => 'info',
 			),
 			'generation_failed' => array(
 				'label'         => __('Generation Failed', 'ai-post-scheduler'),
+				'admin_bar_title' => __('Generation failed', 'ai-post-scheduler'),
 				'description'   => __('A manual or direct post generation request failed.', 'ai-post-scheduler'),
 				'default_mode'  => self::MODE_BOTH,
 				'level'         => 'error',
@@ -62,6 +64,7 @@ class AIPS_Notification_Registry {
 			),
 			'quota_alert' => array(
 				'label'         => __('Quota Alert', 'ai-post-scheduler'),
+				'admin_bar_title' => __('Quota alert', 'ai-post-scheduler'),
 				'description'   => __('The AI provider is rejecting requests because usage limits or circuit protection were reached.', 'ai-post-scheduler'),
 				'default_mode'  => self::MODE_BOTH,
 				'level'         => 'error',
@@ -69,6 +72,7 @@ class AIPS_Notification_Registry {
 			),
 			'integration_error' => array(
 				'label'         => __('Integration Error', 'ai-post-scheduler'),
+				'admin_bar_title' => __('AI integration error', 'ai-post-scheduler'),
 				'description'   => __('The AI Engine dependency is unavailable or misconfigured.', 'ai-post-scheduler'),
 				'default_mode'  => self::MODE_BOTH,
 				'level'         => 'error',
@@ -76,6 +80,7 @@ class AIPS_Notification_Registry {
 			),
 			'scheduler_error' => array(
 				'label'         => __('Scheduler Error', 'ai-post-scheduler'),
+				'admin_bar_title' => __('Scheduler error', 'ai-post-scheduler'),
 				'description'   => __('A scheduled automation run failed or could not obtain its execution lock.', 'ai-post-scheduler'),
 				'default_mode'  => self::MODE_BOTH,
 				'level'         => 'error',
@@ -83,6 +88,7 @@ class AIPS_Notification_Registry {
 			),
 			'system_error' => array(
 				'label'         => __('System Error', 'ai-post-scheduler'),
+				'admin_bar_title' => __('System error', 'ai-post-scheduler'),
 				'description'   => __('A plugin-level operational error occurred during activation, upgrades, or cron execution.', 'ai-post-scheduler'),
 				'default_mode'  => self::MODE_BOTH,
 				'level'         => 'error',
@@ -90,6 +96,7 @@ class AIPS_Notification_Registry {
 			),
 			'template_generated' => array(
 				'label'         => __('Template Generated', 'ai-post-scheduler'),
+				'admin_bar_title' => __('Scheduled generation completed', 'ai-post-scheduler'),
 				'description'   => __('A scheduled template run generated one or more posts.', 'ai-post-scheduler'),
 				'default_mode'  => self::MODE_DB_ONLY,
 				'level'         => 'info',
@@ -97,6 +104,7 @@ class AIPS_Notification_Registry {
 			),
 			'manual_generation_completed' => array(
 				'label'         => __('Manual Generation Completed', 'ai-post-scheduler'),
+				'admin_bar_title' => __('Manual generation completed', 'ai-post-scheduler'),
 				'description'   => __('A manually triggered generation request completed successfully.', 'ai-post-scheduler'),
 				'default_mode'  => self::MODE_DB_ONLY,
 				'level'         => 'info',
@@ -104,6 +112,7 @@ class AIPS_Notification_Registry {
 			),
 			'post_ready_for_review' => array(
 				'label'         => __('Post Ready For Review', 'ai-post-scheduler'),
+				'admin_bar_title' => __('Post ready for review', 'ai-post-scheduler'),
 				'description'   => __('A generated post is waiting for editorial review.', 'ai-post-scheduler'),
 				'default_mode'  => self::MODE_DB_ONLY,
 				'level'         => 'info',
@@ -111,6 +120,7 @@ class AIPS_Notification_Registry {
 			),
 			'post_rejected' => array(
 				'label'         => __('Post Rejected', 'ai-post-scheduler'),
+				'admin_bar_title' => __('Post rejected', 'ai-post-scheduler'),
 				'description'   => __('A generated draft was removed from the review queue.', 'ai-post-scheduler'),
 				'default_mode'  => self::MODE_DB_ONLY,
 				'level'         => 'warning',
@@ -118,6 +128,7 @@ class AIPS_Notification_Registry {
 			),
 			'partial_generation_completed' => array(
 				'label'         => __('Partial Generation Completed', 'ai-post-scheduler'),
+				'admin_bar_title' => __('Partial generation completed', 'ai-post-scheduler'),
 				'description'   => __('A post was saved with missing generated components and needs follow-up.', 'ai-post-scheduler'),
 				'default_mode'  => self::MODE_DB_ONLY,
 				'level'         => 'warning',
@@ -146,6 +157,7 @@ class AIPS_Notification_Registry {
 			),
 			'history_cleanup' => array(
 				'label'         => __('History Cleanup', 'ai-post-scheduler'),
+				'admin_bar_title' => __('Cleanup completed', 'ai-post-scheduler'),
 				'description'   => __('Operational cleanup completed.', 'ai-post-scheduler'),
 				'default_mode'  => self::MODE_DB_ONLY,
 				'level'         => 'info',
@@ -153,6 +165,7 @@ class AIPS_Notification_Registry {
 			),
 			'seeder_complete' => array(
 				'label'         => __('Seeder Completed', 'ai-post-scheduler'),
+				'admin_bar_title' => __('Seeder completed', 'ai-post-scheduler'),
 				'description'   => __('Seeder operation finished successfully.', 'ai-post-scheduler'),
 				'default_mode'  => self::MODE_DB_ONLY,
 				'level'         => 'info',
@@ -160,6 +173,7 @@ class AIPS_Notification_Registry {
 			),
 			'template_change' => array(
 				'label'         => __('Template Changed', 'ai-post-scheduler'),
+				'admin_bar_title' => __('Template updated', 'ai-post-scheduler'),
 				'description'   => __('A template was created, updated, cloned, or deleted.', 'ai-post-scheduler'),
 				'default_mode'  => self::MODE_DB_ONLY,
 				'level'         => 'info',
@@ -167,6 +181,7 @@ class AIPS_Notification_Registry {
 			),
 			'author_suggestions' => array(
 				'label'         => __('Author Suggestions Ready', 'ai-post-scheduler'),
+				'admin_bar_title' => __('Author suggestions ready', 'ai-post-scheduler'),
 				'description'   => __('AI-generated author profile suggestions are available.', 'ai-post-scheduler'),
 				'default_mode'  => self::MODE_DB_ONLY,
 				'level'         => 'info',
@@ -174,6 +189,7 @@ class AIPS_Notification_Registry {
 			),
 			'circuit_breaker_opened' => array(
 				'label'         => __('Circuit Breaker Opened', 'ai-post-scheduler'),
+				'admin_bar_title' => __('Circuit breaker opened', 'ai-post-scheduler'),
 				'description'   => __('The circuit breaker has tripped — AI requests are temporarily blocked after repeated failures.', 'ai-post-scheduler'),
 				'default_mode'  => self::MODE_BOTH,
 				'level'         => 'error',
@@ -181,6 +197,7 @@ class AIPS_Notification_Registry {
 			),
 			'rate_limit_reached' => array(
 				'label'         => __('Rate Limit Reached', 'ai-post-scheduler'),
+				'admin_bar_title' => __('AI rate limit reached', 'ai-post-scheduler'),
 				'description'   => __('The internal AI request rate limit has been reached. Requests are being paused.', 'ai-post-scheduler'),
 				'default_mode'  => self::MODE_BOTH,
 				'level'         => 'warning',
@@ -188,6 +205,7 @@ class AIPS_Notification_Registry {
 			),
 			'research_topics_ready' => array(
 				'label'         => __('Research Topics Ready', 'ai-post-scheduler'),
+				'admin_bar_title' => __('Research topics ready', 'ai-post-scheduler'),
 				'description'   => __('Scheduled research completed and new trending topics are available.', 'ai-post-scheduler'),
 				'default_mode'  => self::MODE_DB_ONLY,
 				'level'         => 'info',
@@ -235,5 +253,22 @@ class AIPS_Notification_Registry {
 			self::MODE_EMAIL_ONLY => __('Email only', 'ai-post-scheduler'),
 			self::MODE_BOTH       => __('DB + Email', 'ai-post-scheduler'),
 		);
+	}
+
+	/**
+	 * Return the short admin-bar title for a notification type.
+	 *
+	 * @param string $type Notification type slug.
+	 * @param string $fallback Fallback title when registry metadata is absent.
+	 * @return string
+	 */
+	public static function get_admin_bar_title($type, $fallback = '') {
+		$registry = self::get_type_registry();
+
+		if (isset($registry[$type]['admin_bar_title']) && '' !== (string) $registry[$type]['admin_bar_title']) {
+			return (string) $registry[$type]['admin_bar_title'];
+		}
+
+		return (string) $fallback;
 	}
 }

--- a/ai-post-scheduler/includes/class-aips-notification-senders.php
+++ b/ai-post-scheduler/includes/class-aips-notification-senders.php
@@ -93,6 +93,7 @@ class AIPS_Notification_Senders {
 			$this->dispatcher,
 			'author_topics_generated',
 			array(
+				'title'    => $this->get_admin_bar_title( 'author_topics_generated', __('Author topics generated', 'ai-post-scheduler') ),
 				'channels' => array(AIPS_Notifications::CHANNEL_DB),
 				'url'      => $url,
 				'message'  => $message,
@@ -109,7 +110,7 @@ class AIPS_Notification_Senders {
 	public function generation_failed( array $payload ) {
 		$resource_label = !empty($payload['resource_label']) ? $payload['resource_label'] : __('AI generation request', 'ai-post-scheduler');
 		$error_message  = !empty($payload['error_message'])  ? $payload['error_message']  : __('Unknown error', 'ai-post-scheduler');
-		$title          = sprintf(__('Generation failed: %s', 'ai-post-scheduler'), $resource_label);
+		$title          = $this->get_admin_bar_title( 'generation_failed', __('Generation failed', 'ai-post-scheduler') );
 		$message        = sprintf(__('Generation failed for %1$s. Error: %2$s', 'ai-post-scheduler'), $resource_label, $error_message);
 
 		call_user_func(
@@ -137,7 +138,7 @@ class AIPS_Notification_Senders {
 	public function quota_alert( array $payload ) {
 		$request_type  = !empty($payload['request_type'])  ? $payload['request_type']  : __('request', 'ai-post-scheduler');
 		$error_message = !empty($payload['error_message']) ? $payload['error_message'] : __('Quota threshold reached.', 'ai-post-scheduler');
-		$title         = sprintf(__('Quota alert: %s', 'ai-post-scheduler'), $request_type);
+		$title         = $this->get_admin_bar_title( 'quota_alert', __('Quota alert', 'ai-post-scheduler') );
 		$message       = sprintf(__('AI requests are being blocked for %1$s operations. Error: %2$s', 'ai-post-scheduler'), $request_type, $error_message);
 
 		call_user_func(
@@ -164,7 +165,7 @@ class AIPS_Notification_Senders {
 	 */
 	public function integration_error( array $payload ) {
 		$error_message = !empty($payload['error_message']) ? $payload['error_message'] : __('AI integration unavailable.', 'ai-post-scheduler');
-		$title         = __('AI integration error', 'ai-post-scheduler');
+		$title         = $this->get_admin_bar_title( 'integration_error', __('AI integration error', 'ai-post-scheduler') );
 		$message       = sprintf(__('The AI integration is unavailable. Error: %s', 'ai-post-scheduler'), $error_message);
 
 		call_user_func(
@@ -192,7 +193,7 @@ class AIPS_Notification_Senders {
 	public function scheduler_error( array $payload ) {
 		$schedule_name = !empty($payload['schedule_name']) ? $payload['schedule_name'] : __('Scheduled run', 'ai-post-scheduler');
 		$error_message = !empty($payload['error_message']) ? $payload['error_message'] : __('Unknown scheduler error', 'ai-post-scheduler');
-		$title         = sprintf(__('Scheduler error: %s', 'ai-post-scheduler'), $schedule_name);
+		$title         = $this->get_admin_bar_title( 'scheduler_error', __('Scheduler error', 'ai-post-scheduler') );
 		$message       = sprintf(__('The scheduler could not complete "%1$s". Error: %2$s', 'ai-post-scheduler'), $schedule_name, $error_message);
 
 		call_user_func(
@@ -219,7 +220,7 @@ class AIPS_Notification_Senders {
 	 */
 	public function system_error( array $payload ) {
 		$error_message = !empty($payload['error_message']) ? $payload['error_message'] : __('Unknown system error', 'ai-post-scheduler');
-		$title         = !empty($payload['title'])         ? $payload['title']         : __('System error', 'ai-post-scheduler');
+		$title         = !empty($payload['title']) ? $payload['title'] : $this->get_admin_bar_title( 'system_error', __('System error', 'ai-post-scheduler') );
 		$message       = sprintf(__('A system-level plugin error occurred. Error: %s', 'ai-post-scheduler'), $error_message);
 
 		call_user_func(
@@ -249,11 +250,7 @@ class AIPS_Notification_Senders {
 		$post_count    = count($post_ids);
 		$template_name = !empty($payload['template_name']) ? $payload['template_name'] : __('Template', 'ai-post-scheduler');
 
-		$title = sprintf(
-			_n('%1$d post generated from "%2$s"', '%1$d posts generated from "%2$s"', $post_count, 'ai-post-scheduler'),
-			$post_count,
-			$template_name
-		);
+		$title = $this->get_admin_bar_title( 'template_generated', __('Scheduled generation completed', 'ai-post-scheduler') );
 
 		$message = sprintf(
 			_n('Scheduled run generated %1$d post for template "%2$s".', 'Scheduled run generated %1$d posts for template "%2$s".', $post_count, 'ai-post-scheduler'),
@@ -290,7 +287,7 @@ class AIPS_Notification_Senders {
 		$post       = $post_id ? get_post($post_id) : null;
 		$post_title = ($post && !empty($post->post_title)) ? $post->post_title : __('Untitled', 'ai-post-scheduler');
 
-		$title   = sprintf(__('Manual generation completed: %s', 'ai-post-scheduler'), $post_title);
+		$title   = $this->get_admin_bar_title( 'manual_generation_completed', __('Manual generation completed', 'ai-post-scheduler') );
 		$message = sprintf(__('Manual generation created post "%s".', 'ai-post-scheduler'), $post_title);
 		$url     = $post_id ? esc_url_raw(get_edit_post_link($post_id, 'raw')) : AIPS_Admin_Menu_Helper::get_page_url('generated_posts');
 
@@ -321,7 +318,7 @@ class AIPS_Notification_Senders {
 		$post       = $post_id ? get_post($post_id) : null;
 		$post_title = ($post && !empty($post->post_title)) ? $post->post_title : __('Untitled', 'ai-post-scheduler');
 
-		$title   = sprintf(__('Post ready for review: %s', 'ai-post-scheduler'), $post_title);
+		$title   = $this->get_admin_bar_title( 'post_ready_for_review', __('Post ready for review', 'ai-post-scheduler') );
 		$message = sprintf(__('Generated post "%s" is awaiting review.', 'ai-post-scheduler'), $post_title);
 		$url     = $post_id ? esc_url_raw(get_edit_post_link($post_id, 'raw')) : AIPS_Admin_Menu_Helper::get_page_url('generated_posts');
 
@@ -351,7 +348,7 @@ class AIPS_Notification_Senders {
 		$post_id    = !empty($payload['post_id']) ? absint($payload['post_id']) : 0;
 		$post_label = !empty($payload['post_title']) ? $payload['post_title'] : sprintf(__('Post #%d', 'ai-post-scheduler'), $post_id);
 
-		$title   = sprintf(__('Post rejected: %s', 'ai-post-scheduler'), $post_label);
+		$title   = $this->get_admin_bar_title( 'post_rejected', __('Post rejected', 'ai-post-scheduler') );
 		$message = sprintf(__('Generated draft "%s" was removed from the review queue.', 'ai-post-scheduler'), $post_label);
 		$url     = !empty($payload['url']) ? $payload['url'] : AIPS_Admin_Menu_Helper::get_page_url('generated_posts');
 
@@ -382,7 +379,7 @@ class AIPS_Notification_Senders {
 		$post       = $post_id ? get_post($post_id) : null;
 		$post_title = ($post && !empty($post->post_title)) ? $post->post_title : __('Untitled', 'ai-post-scheduler');
 
-		$title   = sprintf(__('Partial generation completed: %s', 'ai-post-scheduler'), $post_title);
+		$title   = $this->get_admin_bar_title( 'partial_generation_completed', __('Partial generation completed', 'ai-post-scheduler') );
 		$message = sprintf(__('Post "%s" was saved with missing components and requires review.', 'ai-post-scheduler'), $post_title);
 		$url     = !empty($payload['url']) ? $payload['url'] : admin_url('admin.php?page=aips-generated-posts#aips-partial-generations');
 
@@ -720,7 +717,7 @@ class AIPS_Notification_Senders {
 			$this->dispatcher,
 			'research_topics_ready',
 			array(
-				'title'         => sprintf(__('Research topics ready (%d)', 'ai-post-scheduler'), $count),
+				'title'         => $this->get_admin_bar_title( 'research_topics_ready', __('Research topics ready', 'ai-post-scheduler') ),
 				'message'       => sprintf(__('Scheduled research found %1$d new topic(s) for niche "%2$s".', 'ai-post-scheduler'), $count, $niche),
 				'url'           => AIPS_Admin_Menu_Helper::get_page_url('aips-research'),
 				'level'         => 'info',
@@ -732,5 +729,16 @@ class AIPS_Notification_Senders {
 				'dedupe_window' => 300,
 			)
 		);
+	}
+
+	/**
+	 * Resolve the short admin-bar title for a notification type.
+	 *
+	 * @param string $type Notification type slug.
+	 * @param string $fallback Fallback title.
+	 * @return string
+	 */
+	private function get_admin_bar_title( $type, $fallback ) {
+		return AIPS_Notification_Registry::get_admin_bar_title( $type, $fallback );
 	}
 }

--- a/ai-post-scheduler/includes/class-aips-notifications-repository.php
+++ b/ai-post-scheduler/includes/class-aips-notifications-repository.php
@@ -41,12 +41,18 @@ class AIPS_Notifications_Repository implements AIPS_Notifications_Repository_Int
 	private $table;
 
 	/**
+	 * @var string Full read-receipts table name.
+	 */
+	private $reads_table;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
 		global $wpdb;
-		$this->wpdb  = $wpdb;
-		$this->table = $wpdb->prefix . 'aips_notifications';
+		$this->wpdb       = $wpdb;
+		$this->table      = $wpdb->prefix . 'aips_notifications';
+		$this->reads_table = $wpdb->prefix . 'aips_notification_reads';
 	}
 
 	/**
@@ -149,15 +155,35 @@ class AIPS_Notifications_Repository implements AIPS_Notifications_Repository_Int
 	 * @param int $limit Maximum number to return. Default 20.
 	 * @return array Array of notification objects.
 	 */
-	public function get_unread($limit = 20) {
+	public function get_unread($limit = 20, $user_id = 0) {
 		$limit = absint($limit);
 		if ($limit < 1) {
 			$limit = 20;
 		}
 
+		$resolved_user_id = $this->resolve_user_id($user_id);
+
+		if ($resolved_user_id < 1) {
+			return $this->wpdb->get_results(
+				$this->wpdb->prepare(
+					"SELECT id, type, title, message, url, level, is_read, read_at, created_at FROM {$this->table} WHERE is_read = 0 ORDER BY created_at DESC, id DESC LIMIT %d",
+					$limit
+				)
+			);
+		}
+
 		return $this->wpdb->get_results(
 			$this->wpdb->prepare(
-				"SELECT id, type, title, message, url, level, is_read, read_at, created_at FROM {$this->table} WHERE is_read = 0 ORDER BY created_at DESC LIMIT %d",
+				"SELECT n.id, n.type, n.title, n.message, n.url, n.level, n.is_read, n.read_at, n.created_at
+				FROM {$this->table} n
+				LEFT JOIN {$this->reads_table} r
+					ON n.id = r.notification_id
+					AND r.user_id = %d
+				WHERE n.is_read = 0
+					AND r.notification_id IS NULL
+				ORDER BY n.created_at DESC, n.id DESC
+				LIMIT %d",
+				$resolved_user_id,
 				$limit
 			)
 		);
@@ -168,9 +194,26 @@ class AIPS_Notifications_Repository implements AIPS_Notifications_Repository_Int
 	 *
 	 * @return int
 	 */
-	public function count_unread() {
+	public function count_unread($user_id = 0) {
+		$resolved_user_id = $this->resolve_user_id($user_id);
+
+		if ($resolved_user_id < 1) {
+			return (int) $this->wpdb->get_var(
+				"SELECT COUNT(*) FROM {$this->table} WHERE is_read = 0"
+			);
+		}
+
 		return (int) $this->wpdb->get_var(
-			"SELECT COUNT(*) FROM {$this->table} WHERE is_read = 0"
+			$this->wpdb->prepare(
+				"SELECT COUNT(*)
+				FROM {$this->table} n
+				LEFT JOIN {$this->reads_table} r
+					ON n.id = r.notification_id
+					AND r.user_id = %d
+				WHERE n.is_read = 0
+					AND r.notification_id IS NULL",
+				$resolved_user_id
+			)
 		);
 	}
 
@@ -180,19 +223,37 @@ class AIPS_Notifications_Repository implements AIPS_Notifications_Repository_Int
 	 * @param int $id Notification ID.
 	 * @return bool True on success.
 	 */
-	public function mark_as_read($id) {
-		$result = $this->wpdb->update(
-			$this->table,
-			array(
-				'is_read' => 1,
-				'read_at' => AIPS_DateTime::now()->timestamp(),
-			),
-			array('id' => absint($id)),
-			array('%d', '%d'),
-			array('%d')
+	public function mark_as_read($id, $user_id = 0) {
+		$id = absint($id);
+		$resolved_user_id = $this->resolve_user_id($user_id);
+
+		if ($id < 1 || $resolved_user_id < 1) {
+			return false;
+		}
+
+		$existing = $this->wpdb->get_var(
+			$this->wpdb->prepare(
+				"SELECT 1 FROM {$this->reads_table} WHERE notification_id = %d AND user_id = %d",
+				$id,
+				$resolved_user_id
+			)
 		);
 
-		return $result !== false;
+		if ($existing) {
+			return true;
+		}
+
+		$result = $this->wpdb->insert(
+			$this->reads_table,
+			array(
+				'notification_id' => $id,
+				'user_id'         => $resolved_user_id,
+				'read_at'         => AIPS_DateTime::now()->timestamp(),
+			),
+			array('%d', '%d', '%d')
+		);
+
+		return false !== $result;
 	}
 
 	/**
@@ -200,16 +261,27 @@ class AIPS_Notifications_Repository implements AIPS_Notifications_Repository_Int
 	 *
 	 * @return bool True on success.
 	 */
-	public function mark_all_as_read() {
-		$result = $this->wpdb->update(
-			$this->table,
-			array(
-				'is_read' => 1,
-				'read_at' => AIPS_DateTime::now()->timestamp(),
-			),
-			array('is_read' => 0),
-			array('%d', '%d'),
-			array('%d')
+	public function mark_all_as_read($user_id = 0) {
+		$resolved_user_id = $this->resolve_user_id($user_id);
+
+		if ($resolved_user_id < 1) {
+			return false;
+		}
+
+		$result = $this->wpdb->query(
+			$this->wpdb->prepare(
+				"INSERT INTO {$this->reads_table} (notification_id, user_id, read_at)
+				SELECT n.id, %d, %d
+				FROM {$this->table} n
+				LEFT JOIN {$this->reads_table} r
+					ON n.id = r.notification_id
+					AND r.user_id = %d
+				WHERE n.is_read = 0
+					AND r.notification_id IS NULL",
+				$resolved_user_id,
+				AIPS_DateTime::now()->timestamp(),
+				$resolved_user_id
+			)
 		);
 
 		return $result !== false;
@@ -277,5 +349,24 @@ class AIPS_Notifications_Repository implements AIPS_Notifications_Repository_Int
 		}
 
 		return $counts;
+	}
+
+	/**
+	 * Resolve the user ID for per-user unread/read operations.
+	 *
+	 * @param int $user_id Requested user ID.
+	 * @return int
+	 */
+	private function resolve_user_id($user_id) {
+		$user_id = absint($user_id);
+		if ($user_id > 0) {
+			return $user_id;
+		}
+
+		if (function_exists('get_current_user_id')) {
+			return absint(get_current_user_id());
+		}
+
+		return 0;
 	}
 }

--- a/ai-post-scheduler/includes/interface-aips-notifications-repository-interface.php
+++ b/ai-post-scheduler/includes/interface-aips-notifications-repository-interface.php
@@ -38,14 +38,14 @@ interface AIPS_Notifications_Repository_Interface {
 	 * @param int $limit Max rows.
 	 * @return array
 	 */
-	public function get_unread($limit = 20);
+	public function get_unread($limit = 20, $user_id = 0);
 
 	/**
 	 * Count unread notifications.
 	 *
 	 * @return int
 	 */
-	public function count_unread();
+	public function count_unread($user_id = 0);
 
 	/**
 	 * Mark one notification as read.
@@ -53,14 +53,14 @@ interface AIPS_Notifications_Repository_Interface {
 	 * @param int $id Notification ID.
 	 * @return bool
 	 */
-	public function mark_as_read($id);
+	public function mark_as_read($id, $user_id = 0);
 
 	/**
 	 * Mark all notifications as read.
 	 *
 	 * @return int|false
 	 */
-	public function mark_all_as_read();
+	public function mark_all_as_read($user_id = 0);
 
 	/**
 	 * Check whether a dedupe key was sent recently.

--- a/ai-post-scheduler/tests/Test_AIPS_Admin_Bar_Cache.php
+++ b/ai-post-scheduler/tests/Test_AIPS_Admin_Bar_Cache.php
@@ -25,6 +25,7 @@ class Test_AIPS_Admin_Bar_Cache extends WP_UnitTestCase {
 
 		// Clean up any existing notifications
 		global $wpdb;
+		$wpdb->query("DELETE FROM {$wpdb->prefix}aips_notification_reads");
 		$wpdb->query("DELETE FROM {$wpdb->prefix}aips_notifications");
 
 		// Clear cache
@@ -38,6 +39,7 @@ class Test_AIPS_Admin_Bar_Cache extends WP_UnitTestCase {
 	public function tearDown(): void {
 		// Clean up
 		global $wpdb;
+		$wpdb->query("DELETE FROM {$wpdb->prefix}aips_notification_reads");
 		$wpdb->query("DELETE FROM {$wpdb->prefix}aips_notifications");
 		AIPS_Cache_Factory::instance()->flush();
 		AIPS_Cache_Factory::reset();
@@ -59,6 +61,28 @@ class Test_AIPS_Admin_Bar_Cache extends WP_UnitTestCase {
 				return true;
 			}
 		};
+	}
+
+	private function find_node_by_id($admin_bar, $id) {
+		foreach ($admin_bar->nodes as $node) {
+			if (isset($node['id']) && $node['id'] === $id) {
+				return $node;
+			}
+		}
+
+		return null;
+	}
+
+	private function find_nodes_by_parent($admin_bar, $parent) {
+		$matches = array();
+
+		foreach ($admin_bar->nodes as $node) {
+			if (isset($node['parent']) && $node['parent'] === $parent) {
+				$matches[] = $node;
+			}
+		}
+
+		return $matches;
 	}
 
 	/**
@@ -255,5 +279,111 @@ class Test_AIPS_Admin_Bar_Cache extends WP_UnitTestCase {
 			$_POST    = $orig_post;
 			$_REQUEST = $orig_request;
 		}
+	}
+
+	/**
+	 * Test that the toolbar quick links point to the expected pages.
+	 */
+	public function test_toolbar_quick_links_use_expected_destinations() {
+		$wp_admin_bar = $this->make_admin_bar_double();
+
+		$this->admin_bar->add_toolbar_node($wp_admin_bar);
+
+		$this->assertSame(AIPS_Admin_Menu_Helper::get_page_url('dashboard'), $this->find_node_by_id($wp_admin_bar, 'aips-toolbar-dashboard')['href']);
+		$this->assertSame(AIPS_Admin_Menu_Helper::get_page_url('automations'), $this->find_node_by_id($wp_admin_bar, 'aips-toolbar-automations')['href']);
+		$this->assertSame(AIPS_Admin_Menu_Helper::get_page_url('templates'), $this->find_node_by_id($wp_admin_bar, 'aips-toolbar-templates')['href']);
+		$this->assertSame(AIPS_Admin_Menu_Helper::get_page_url('authors'), $this->find_node_by_id($wp_admin_bar, 'aips-toolbar-authors')['href']);
+		$this->assertSame(AIPS_Admin_Menu_Helper::get_page_url('schedule'), $this->find_node_by_id($wp_admin_bar, 'aips-toolbar-schedules')['href']);
+		$this->assertSame(AIPS_Admin_Menu_Helper::get_page_url('history'), $this->find_node_by_id($wp_admin_bar, 'aips-toolbar-history')['href']);
+	}
+
+	/**
+	 * Test that quick links are rendered in the requested two-column reading order.
+	 */
+	public function test_toolbar_quick_links_follow_requested_column_order() {
+		$wp_admin_bar = $this->make_admin_bar_double();
+
+		$this->admin_bar->add_toolbar_node($wp_admin_bar);
+
+		$link_nodes = $this->find_nodes_by_parent($wp_admin_bar, 'aips-toolbar-links');
+		$link_ids   = array_map(
+			function ($node) {
+				return $node['id'];
+			},
+			$link_nodes
+		);
+
+		$this->assertSame(
+			array(
+				'aips-toolbar-dashboard',
+				'aips-toolbar-automations',
+				'aips-toolbar-history',
+				'aips-toolbar-templates',
+				'aips-toolbar-authors',
+				'aips-toolbar-schedules',
+			),
+			$link_ids
+		);
+	}
+
+	/**
+	 * Test that the notifications header communicates when only the latest 20 unread items are shown.
+	 */
+	public function test_toolbar_notifications_header_shows_latest_subset_summary() {
+		$wp_admin_bar = $this->make_admin_bar_double();
+
+		for ($i = 0; $i < 25; $i++) {
+			$this->repository->create('test_notification', 'Test notification ' . $i);
+		}
+
+		AIPS_Cache_Factory::instance()->flush();
+		$this->admin_bar->add_toolbar_node($wp_admin_bar);
+
+		$header = $this->find_node_by_id($wp_admin_bar, 'aips-toolbar-notifications-header');
+
+		$this->assertNotNull($header);
+		$this->assertStringContainsString('Latest 20 of 25 unread', $header['title']);
+		$this->assertStringContainsString('Mark all as read', $header['title']);
+	}
+
+	/**
+	 * Test that each notification row exposes dedicated Context and Mark as Read controls.
+	 */
+	public function test_toolbar_notification_row_renders_context_and_mark_read_controls() {
+		$wp_admin_bar = $this->make_admin_bar_double();
+
+		$notification_id = $this->repository->create_notification(array(
+			'type'    => 'post_ready_for_review',
+			'title'   => 'Post ready for review',
+			'message' => 'Generated post \"Example\" is awaiting review.',
+			'url'     => 'https://example.com/review',
+		));
+
+		AIPS_Cache_Factory::instance()->flush();
+		$this->admin_bar->add_toolbar_node($wp_admin_bar);
+
+		$notification = $this->find_node_by_id($wp_admin_bar, 'aips-notif-' . $notification_id);
+
+		$this->assertNotNull($notification);
+		$this->assertStringContainsString('aips-notif-actions', $notification['title']);
+		$this->assertStringContainsString('aips-notif-context', $notification['title']);
+		$this->assertStringContainsString('Context', $notification['title']);
+		$this->assertStringContainsString('aips-mark-read', $notification['title']);
+		$this->assertStringNotContainsString('<a href="https://example.com/review">Generated post', $notification['title']);
+	}
+
+	/**
+	 * Test that the empty notifications state uses the requested copy.
+	 */
+	public function test_toolbar_empty_state_uses_no_notifications_copy() {
+		$wp_admin_bar = $this->make_admin_bar_double();
+
+		$this->admin_bar->add_toolbar_node($wp_admin_bar);
+
+		$empty_state = $this->find_node_by_id($wp_admin_bar, 'aips-toolbar-no-notifications');
+
+		$this->assertNotNull($empty_state);
+		$this->assertStringContainsString('No notifications', $empty_state['title']);
+		$this->assertStringNotContainsString('No new notifications', $empty_state['title']);
 	}
 }

--- a/ai-post-scheduler/tests/Test_AIPS_Cache_Tag_Version_Memo.php
+++ b/ai-post-scheduler/tests/Test_AIPS_Cache_Tag_Version_Memo.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @group cache
+ */
+class Test_AIPS_Cache_Tag_Version_Memo extends WP_UnitTestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+		update_option( 'aips_enable_cache_system', '1' );
+		AIPS_Cache::reset_system_enabled_flag();
+	}
+
+	private function make_counting_cache( array &$calls ): AIPS_Cache {
+		$driver = new class( $calls ) implements AIPS_Cache_Driver {
+			private $calls;
+			private $store = array();
+			public function __construct( &$calls ) { $this->calls =& $calls; }
+			public function get( $key, $group = 'default' ) {
+				$this->calls['get'] = ( $this->calls['get'] ?? 0 ) + 1;
+				return $this->store[ $group ][ $key ] ?? null;
+			}
+			public function set( $key, $value, $ttl = 0, $group = 'default' ) {
+				$this->store[ $group ][ $key ] = $value;
+				return true;
+			}
+			public function delete( $key, $group = 'default' ) { unset( $this->store[ $group ][ $key ] ); return true; }
+			public function flush() { $this->store = array(); return true; }
+			public function has( $key, $group = 'default' ) { return isset( $this->store[ $group ][ $key ] ); }
+		};
+		return new AIPS_Cache( $driver );
+	}
+
+	public function test_repeated_get_tag_version_reads_driver_once() {
+		$calls = array();
+		$cache = $this->make_counting_cache( $calls );
+
+		$this->assertSame( 1, $cache->get_tag_version( 'authors', 'aips_authors' ) );
+		$this->assertSame( 1, $cache->get_tag_version( 'authors', 'aips_authors' ) );
+		$this->assertSame( 1, $cache->get_tag_version( 'authors', 'aips_authors' ) );
+
+		$this->assertSame( 1, $calls['get'] ?? 0, 'Tag version must be memoized after first read (including misses).' );
+	}
+
+	public function test_bump_updates_memo_without_extra_reads() {
+		$calls = array();
+		$cache = $this->make_counting_cache( $calls );
+
+		$cache->get_tag_version( 'authors', 'aips_authors' ); // seeds memo (1 get)
+		$new = $cache->bump_tag_version( 'authors', 'aips_authors' );
+		$calls = array();
+
+		$this->assertSame( $new, $cache->get_tag_version( 'authors', 'aips_authors' ) );
+		$this->assertSame( 0, $calls['get'] ?? 0, 'Post-bump reads must come from the memo.' );
+	}
+
+	public function test_flush_clears_memo() {
+		$calls = array();
+		$cache = $this->make_counting_cache( $calls );
+
+		$cache->get_tag_version( 'authors', 'aips_authors' );
+		$cache->flush();
+		$calls = array();
+		$cache->get_tag_version( 'authors', 'aips_authors' );
+
+		$this->assertSame( 1, $calls['get'] ?? 0, 'flush() must invalidate the tag-version memo.' );
+	}
+}

--- a/ai-post-scheduler/tests/Test_AIPS_DB_Migrations.php
+++ b/ai-post-scheduler/tests/Test_AIPS_DB_Migrations.php
@@ -58,6 +58,92 @@ class Test_AIPS_DB_Migrations extends WP_UnitTestCase {
 	}
 
 	/**
+	 * install_tables() must create the notification read-receipts table used
+	 * for per-user unread state in the admin bar.
+	 */
+	public function test_install_tables_creates_notification_reads_table() {
+		AIPS_DB_Manager::install_tables();
+
+		global $wpdb;
+		$table = $wpdb->prefix . 'aips_notification_reads';
+
+		$table_exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+		$this->assertSame( $table, $table_exists, 'aips_notification_reads table must exist after install_tables().' );
+
+		$index_names = $wpdb->get_col( "SHOW INDEX FROM `{$table}`", 2 );
+		$this->assertContains( 'PRIMARY', $index_names );
+		$this->assertContains( 'user_id', $index_names );
+	}
+
+	/**
+	 * install_tables() must repair legacy tables that have lost their id
+	 * primary key and contain duplicate zero ids before dbDelta runs.
+	 */
+	public function test_install_tables_repairs_history_duplicate_zero_ids_before_dbdelta() {
+		AIPS_DB_Manager::install_tables();
+
+		global $wpdb;
+		$table = $wpdb->prefix . 'aips_history';
+
+		$wpdb->query( "DELETE FROM `{$table}`" );
+
+		$wpdb->insert(
+			$table,
+			array(
+				'id'           => 1,
+				'status'       => 'pending',
+				'created_at'   => 100,
+				'completed_at' => 0,
+			),
+			array( '%d', '%s', '%d', '%d' )
+		);
+		$wpdb->insert(
+			$table,
+			array(
+				'id'           => 2,
+				'status'       => 'completed',
+				'created_at'   => 200,
+				'completed_at' => 300,
+			),
+			array( '%d', '%s', '%d', '%d' )
+		);
+		$wpdb->insert(
+			$table,
+			array(
+				'id'           => 3,
+				'status'       => 'failed',
+				'created_at'   => 400,
+				'completed_at' => 500,
+			),
+			array( '%d', '%s', '%d', '%d' )
+		);
+
+		$wpdb->query( "ALTER TABLE `{$table}` MODIFY COLUMN id bigint(20) NOT NULL DEFAULT 0" );
+		$wpdb->query( "ALTER TABLE `{$table}` DROP PRIMARY KEY" );
+		$wpdb->query( "UPDATE `{$table}` SET id = 0" );
+
+		$result = AIPS_DB_Manager::install_tables();
+
+		$this->assertTrue( $result === true, 'install_tables() should repair duplicate zero ids and succeed.' );
+
+		$index_names = $wpdb->get_col( "SHOW INDEX FROM `{$table}`", 2 );
+		$this->assertContains( 'PRIMARY', $index_names, 'History table must have a primary key again after repair.' );
+
+		$duplicate_zero_rows = (int) $wpdb->get_var(
+			"SELECT COUNT(*) FROM (
+				SELECT id
+				FROM `{$table}`
+				GROUP BY id
+				HAVING id <= 0 OR COUNT(*) > 1
+			) AS invalid_ids"
+		);
+		$this->assertSame( 0, $duplicate_zero_rows, 'History table ids must be unique positive integers after repair.' );
+
+		$row_count = (int) $wpdb->get_var( "SELECT COUNT(*) FROM `{$table}` WHERE created_at IN (100, 200, 400)" );
+		$this->assertSame( 3, $row_count, 'History rows must be preserved during primary-key repair.' );
+	}
+
+	/**
 	 * check_and_run() with a pre-2.3.1 version must add the composite indexes
 	 * to aips_notifications via the versioned migrate_to_2_3_1() migration.
 	 */

--- a/ai-post-scheduler/tests/Test_AIPS_Notification_Admin_Bar_Titles.php
+++ b/ai-post-scheduler/tests/Test_AIPS_Notification_Admin_Bar_Titles.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Focused tests for admin-bar notification titles.
+ *
+ * @package AI_Post_Scheduler
+ */
+
+class Test_AIPS_Notification_Admin_Bar_Titles extends WP_UnitTestCase {
+
+	/**
+	 * @var AIPS_Notifications
+	 */
+	private $notifications;
+
+	/**
+	 * @var AIPS_Test_Admin_Bar_Title_Repository
+	 */
+	private $repository;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		$this->repository = new AIPS_Test_Admin_Bar_Title_Repository();
+		$this->notifications = new AIPS_Notifications( $this->repository );
+	}
+
+	public function tearDown(): void {
+		$this->repository->reset();
+		wp_set_current_user( 0 );
+		parent::tearDown();
+	}
+
+	public function test_post_ready_for_review_uses_short_action_title() {
+		$post_id = wp_insert_post( array(
+			'post_title'  => 'Review Me',
+			'post_status' => 'draft',
+			'post_type'   => 'post',
+		) );
+
+		$this->notifications->post_ready_for_review( array(
+			'post_id'       => $post_id,
+			'dedupe_key'    => 'admin_bar_title_ready_' . $post_id,
+			'dedupe_window' => 0,
+		) );
+
+		$notification = $this->repository->get_unread( 1 )[0];
+		$this->assertSame( 'Post ready for review', $notification->title );
+		$this->assertStringContainsString( 'Review Me', $notification->message );
+		$this->assertStringNotContainsString( 'Review Me', $notification->title );
+
+		wp_delete_post( $post_id, true );
+	}
+
+	public function test_manual_generation_completed_uses_short_action_title() {
+		$post_id = wp_insert_post( array(
+			'post_title'  => 'Generated Example',
+			'post_status' => 'draft',
+			'post_type'   => 'post',
+		) );
+
+		$this->notifications->manual_generation_completed( array(
+			'post_id'       => $post_id,
+			'dedupe_key'    => 'admin_bar_title_manual_' . $post_id,
+			'dedupe_window' => 0,
+		) );
+
+		$notification = $this->repository->get_unread( 1 )[0];
+		$this->assertSame( 'Manual generation completed', $notification->title );
+		$this->assertStringContainsString( 'Generated Example', $notification->message );
+		$this->assertStringNotContainsString( 'Generated Example', $notification->title );
+
+		wp_delete_post( $post_id, true );
+	}
+
+	public function test_partial_generation_completed_uses_short_action_title() {
+		$post_id = wp_insert_post( array(
+			'post_title'  => 'Partial Example',
+			'post_status' => 'draft',
+			'post_type'   => 'post',
+		) );
+
+		$this->notifications->partial_generation_completed( array(
+			'post_id'            => $post_id,
+			'missing_components' => array( 'post_content' ),
+			'dedupe_key'         => 'admin_bar_title_partial_' . $post_id,
+			'dedupe_window'      => 0,
+		) );
+
+		$notification = $this->repository->get_unread( 1 )[0];
+		$this->assertSame( 'Partial generation completed', $notification->title );
+		$this->assertStringContainsString( 'Partial Example', $notification->message );
+		$this->assertStringNotContainsString( 'Partial Example', $notification->title );
+
+		wp_delete_post( $post_id, true );
+	}
+}
+
+class AIPS_Test_Admin_Bar_Title_Repository implements AIPS_Notifications_Repository_Interface {
+
+	/**
+	 * @var array<int, object>
+	 */
+	private $notifications = array();
+
+	/**
+	 * @var int
+	 */
+	private $next_id = 1;
+
+	public function reset() {
+		$this->notifications = array();
+		$this->next_id       = 1;
+	}
+
+	public function create( $type, $message, $url = '' ) {
+		return $this->create_notification(
+			array(
+				'type'    => $type,
+				'message' => $message,
+				'url'     => $url,
+			)
+		);
+	}
+
+	public function create_notification( array $data ) {
+		$defaults = array(
+			'type'       => '',
+			'title'      => '',
+			'message'    => '',
+			'url'        => '',
+			'level'      => 'info',
+			'dedupe_key' => '',
+		);
+
+		$data = wp_parse_args( $data, $defaults );
+		$id   = $this->next_id++;
+
+		$this->notifications[] = (object) array(
+			'id'         => $id,
+			'type'       => $data['type'],
+			'title'      => $data['title'],
+			'message'    => $data['message'],
+			'url'        => $data['url'],
+			'level'      => $data['level'],
+			'dedupe_key' => $data['dedupe_key'],
+			'is_read'    => 0,
+		);
+
+		return $id;
+	}
+
+	public function get_unread( $limit = 20, $user_id = 0 ) {
+		return array_slice( array_reverse( $this->notifications ), 0, absint( $limit ) );
+	}
+
+	public function count_unread( $user_id = 0 ) {
+		return count( $this->notifications );
+	}
+
+	public function mark_as_read( $id, $user_id = 0 ) {
+		return true;
+	}
+
+	public function mark_all_as_read( $user_id = 0 ) {
+		return true;
+	}
+
+	public function was_recently_sent( $dedupe_key, $window_seconds = 3600 ) {
+		return false;
+	}
+
+	public function get_type_counts_for_window( $seconds, array $types = array() ) {
+		return array();
+	}
+}

--- a/ai-post-scheduler/tests/Test_AIPS_Notification_Template.php
+++ b/ai-post-scheduler/tests/Test_AIPS_Notification_Template.php
@@ -605,6 +605,61 @@ class Test_AIPS_Notifications_Service extends WP_UnitTestCase {
 
 		$this->assertEquals(1, $this->repository->count_unread());
 
+		$notifications = $this->repository->get_unread(1);
+		$this->assertSame('Partial generation completed', $notifications[0]->title);
+
+		wp_delete_post($post_id, true);
+	}
+
+	public function test_post_ready_for_review_uses_action_title_without_post_name() {
+		update_option('aips_notification_preferences', array(
+			'post_ready_for_review' => 'db',
+		));
+
+		$post_id = wp_insert_post(array(
+			'post_title'  => 'Review Me',
+			'post_status' => 'draft',
+			'post_type'   => 'post',
+		));
+
+		$this->notifications->post_ready_for_review(array(
+			'post_id'       => $post_id,
+			'dedupe_key'    => 'test_post_ready_for_review_action_title_' . $post_id,
+			'dedupe_window' => 0,
+		));
+
+		$notifications = $this->repository->get_unread(1);
+		$this->assertCount(1, $notifications);
+		$this->assertSame('Post ready for review', $notifications[0]->title);
+		$this->assertStringContainsString('Review Me', $notifications[0]->message);
+		$this->assertStringNotContainsString('Review Me', $notifications[0]->title);
+
+		wp_delete_post($post_id, true);
+	}
+
+	public function test_manual_generation_completed_uses_action_title_without_post_name() {
+		update_option('aips_notification_preferences', array(
+			'manual_generation_completed' => 'db',
+		));
+
+		$post_id = wp_insert_post(array(
+			'post_title'  => 'Generated Example',
+			'post_status' => 'draft',
+			'post_type'   => 'post',
+		));
+
+		$this->notifications->manual_generation_completed(array(
+			'post_id'       => $post_id,
+			'dedupe_key'    => 'test_manual_generation_completed_action_title_' . $post_id,
+			'dedupe_window' => 0,
+		));
+
+		$notifications = $this->repository->get_unread(1);
+		$this->assertCount(1, $notifications);
+		$this->assertSame('Manual generation completed', $notifications[0]->title);
+		$this->assertStringContainsString('Generated Example', $notifications[0]->message);
+		$this->assertStringNotContainsString('Generated Example', $notifications[0]->title);
+
 		wp_delete_post($post_id, true);
 	}
 
@@ -775,7 +830,7 @@ class AIPS_Test_Notifications_Repository extends AIPS_Notifications_Repository {
 		return $id;
 	}
 
-	public function count_unread() {
+	public function count_unread($user_id = 0) {
 		$unread = array_filter($this->notifications, function($notification) {
 			return empty($notification->is_read);
 		});
@@ -783,7 +838,7 @@ class AIPS_Test_Notifications_Repository extends AIPS_Notifications_Repository {
 		return count($unread);
 	}
 
-	public function get_unread($limit = 20) {
+	public function get_unread($limit = 20, $user_id = 0) {
 		$limit = absint($limit);
 		if ($limit < 1) {
 			$limit = 20;
@@ -794,6 +849,25 @@ class AIPS_Test_Notifications_Repository extends AIPS_Notifications_Repository {
 		}));
 
 		return array_slice(array_reverse($unread), 0, $limit);
+	}
+
+	public function mark_as_read($id, $user_id = 0) {
+		foreach ($this->notifications as $index => $notification) {
+			if ((int) $notification->id === (int) $id) {
+				$this->notifications[$index]->is_read = 1;
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	public function mark_all_as_read($user_id = 0) {
+		foreach ($this->notifications as $index => $notification) {
+			$this->notifications[$index]->is_read = 1;
+		}
+
+		return true;
 	}
 
 	public function was_recently_sent($dedupe_key, $window_seconds = 3600) {

--- a/ai-post-scheduler/tests/Test_AIPS_Notifications.php
+++ b/ai-post-scheduler/tests/Test_AIPS_Notifications.php
@@ -18,6 +18,16 @@ class Test_AIPS_Notifications extends WP_UnitTestCase {
 	private $admin_bar;
 
 	/**
+	 * @var int
+	 */
+	private $admin_user_id;
+
+	/**
+	 * @var int
+	 */
+	private $secondary_admin_user_id;
+
+	/**
 	 * IDs created during tests, cleaned up in tearDown.
 	 *
 	 * @var int[]
@@ -31,17 +41,29 @@ class Test_AIPS_Notifications extends WP_UnitTestCase {
 
 		$this->repository = new AIPS_Notifications_Repository();
 		$this->admin_bar  = new AIPS_Admin_Bar();
+		$this->admin_user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$this->secondary_admin_user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $this->admin_user_id );
 
-		// Start each test with a clean notifications table.
-		global $wpdb;
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}aips_notifications" );
+		$this->truncate_notification_tables();
 	}
 
 	public function tearDown(): void {
-		global $wpdb;
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}aips_notifications" );
+		$this->truncate_notification_tables();
 		$this->created_ids = array();
+		wp_set_current_user( 0 );
 		parent::tearDown();
+	}
+
+	/**
+	 * Reset notification tables between tests.
+	 *
+	 * @return void
+	 */
+	private function truncate_notification_tables() {
+		global $wpdb;
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}aips_notification_reads" );
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}aips_notifications" );
 	}
 
 	// -----------------------------------------------------------------------
@@ -129,10 +151,10 @@ class Test_AIPS_Notifications extends WP_UnitTestCase {
 	/**
 	 * Test that get_unread() returns only unread notifications.
 	 */
-	public function test_get_unread_returns_only_unread() {
+	public function test_get_unread_returns_only_unread_for_current_user() {
 		$id1 = $this->repository->create( 'test', 'Unread 1' );
 		$id2 = $this->repository->create( 'test', 'Unread 2' );
-		$id3 = $this->repository->create( 'test', 'Read one' );
+		$id3 = $this->repository->create( 'test', 'Read for primary admin only' );
 
 		$this->repository->mark_as_read( $id3 );
 
@@ -143,19 +165,31 @@ class Test_AIPS_Notifications extends WP_UnitTestCase {
 		$this->assertContains( $id1, $result_ids );
 		$this->assertContains( $id2, $result_ids );
 		$this->assertNotContains( $id3, $result_ids );
+
+		wp_set_current_user( $this->secondary_admin_user_id );
+		$secondary_ids = array_map(
+			function ( $row ) {
+				return (int) $row->id;
+			},
+			$this->repository->get_unread()
+		);
+
+		$this->assertContains( $id3, $secondary_ids, 'A notification read by one admin should remain unread for another admin.' );
 	}
 
 	/**
 	 * Test that get_unread() respects the limit parameter.
 	 */
-	public function test_get_unread_respects_limit() {
-		for ( $i = 0; $i < 5; $i++ ) {
+	public function test_get_unread_respects_limit_and_returns_latest_unread_for_current_user() {
+		for ( $i = 0; $i < 25; $i++ ) {
 			$this->repository->create( 'test', 'Message ' . $i );
 		}
 
-		$results = $this->repository->get_unread( 3 );
+		$results = $this->repository->get_unread( 20 );
 
-		$this->assertCount( 3, $results );
+		$this->assertCount( 20, $results );
+		$this->assertSame( 'Message 24', $results[0]->message );
+		$this->assertSame( 'Message 5', $results[19]->message );
 	}
 
 	/**
@@ -200,7 +234,7 @@ class Test_AIPS_Notifications extends WP_UnitTestCase {
 	/**
 	 * Test that count_unread() returns the correct count.
 	 */
-	public function test_count_unread_returns_correct_count() {
+	public function test_count_unread_returns_correct_count_for_current_user() {
 		$id1 = $this->repository->create( 'test', 'Msg 1' );
 		$id2 = $this->repository->create( 'test', 'Msg 2' );
 		$this->repository->create( 'test', 'Msg 3' );
@@ -210,6 +244,9 @@ class Test_AIPS_Notifications extends WP_UnitTestCase {
 		$this->repository->mark_as_read( $id2 );
 
 		$this->assertEquals( 1, $this->repository->count_unread() );
+
+		wp_set_current_user( $this->secondary_admin_user_id );
+		$this->assertEquals( 3, $this->repository->count_unread(), 'Unread counts should be scoped per admin user.' );
 	}
 
 	// -----------------------------------------------------------------------
@@ -219,7 +256,7 @@ class Test_AIPS_Notifications extends WP_UnitTestCase {
 	/**
 	 * Test that mark_as_read() sets is_read to 1 for the given ID.
 	 */
-	public function test_mark_as_read_updates_row() {
+	public function test_mark_as_read_creates_read_receipt_for_current_user() {
 		$id = $this->repository->create( 'test', 'Mark me read' );
 
 		$result = $this->repository->mark_as_read( $id );
@@ -228,12 +265,35 @@ class Test_AIPS_Notifications extends WP_UnitTestCase {
 		$this->assertEquals( 0, $this->repository->count_unread() );
 
 		global $wpdb;
-		$read_at = $wpdb->get_var( $wpdb->prepare(
-			"SELECT read_at FROM {$wpdb->prefix}aips_notifications WHERE id = %d",
-			$id
+		$receipt = $wpdb->get_row( $wpdb->prepare(
+			"SELECT notification_id, user_id, read_at FROM {$wpdb->prefix}aips_notification_reads WHERE notification_id = %d AND user_id = %d",
+			$id,
+			$this->admin_user_id
 		) );
 
-		$this->assertNotEmpty( $read_at );
+		$this->assertNotNull( $receipt );
+		$this->assertSame( $this->admin_user_id, (int) $receipt->user_id );
+		$this->assertGreaterThan( 0, (int) $receipt->read_at );
+	}
+
+	/**
+	 * Test that mark_as_read() is idempotent per user.
+	 */
+	public function test_mark_as_read_is_idempotent_for_same_user() {
+		global $wpdb;
+
+		$id = $this->repository->create( 'test', 'Mark me once' );
+
+		$this->assertTrue( $this->repository->mark_as_read( $id ) );
+		$this->assertTrue( $this->repository->mark_as_read( $id ) );
+
+		$receipt_count = (int) $wpdb->get_var( $wpdb->prepare(
+			"SELECT COUNT(*) FROM {$wpdb->prefix}aips_notification_reads WHERE notification_id = %d AND user_id = %d",
+			$id,
+			$this->admin_user_id
+		) );
+
+		$this->assertSame( 1, $receipt_count );
 	}
 
 	/**
@@ -256,7 +316,7 @@ class Test_AIPS_Notifications extends WP_UnitTestCase {
 	/**
 	 * Test that mark_all_as_read() clears all unread notifications.
 	 */
-	public function test_mark_all_as_read_clears_unread() {
+	public function test_mark_all_as_read_clears_unread_for_current_user_only() {
 		$this->repository->create( 'test', 'Msg A' );
 		$this->repository->create( 'test', 'Msg B' );
 		$this->repository->create( 'test', 'Msg C' );
@@ -264,6 +324,9 @@ class Test_AIPS_Notifications extends WP_UnitTestCase {
 		$this->repository->mark_all_as_read();
 
 		$this->assertEquals( 0, $this->repository->count_unread() );
+
+		wp_set_current_user( $this->secondary_admin_user_id );
+		$this->assertEquals( 3, $this->repository->count_unread(), 'Mark all as read should not affect another admin user.' );
 	}
 
 	// -----------------------------------------------------------------------
@@ -276,23 +339,37 @@ class Test_AIPS_Notifications extends WP_UnitTestCase {
 	public function test_cleanup_old_removes_old_read_notifications() {
 		global $wpdb;
 
-		// Insert an old read notification directly (bypassing current_time).
+		// Insert an old legacy read notification directly.
 		$wpdb->insert(
 			$wpdb->prefix . 'aips_notifications',
 			array(
 				'type'       => 'test',
+				'title'      => '',
 				'message'    => 'Old read',
 				'url'        => '',
 				'is_read'    => 1,
-				'created_at' => '2000-01-01 00:00:00',
+				'read_at'    => strtotime( '2000-01-01 00:00:00 UTC' ),
+				'created_at' => strtotime( '2000-01-01 00:00:00 UTC' ),
 			),
-			array( '%s', '%s', '%s', '%d', '%s' )
+			array( '%s', '%s', '%s', '%s', '%d', '%d', '%d' )
 		);
 		$old_id = (int) $wpdb->insert_id;
 
-		// Insert a recent read notification.
-		$recent_id = $this->repository->create( 'test', 'Recent read' );
-		$this->repository->mark_as_read( $recent_id );
+		// Insert a recent legacy read notification that should be retained.
+		$wpdb->insert(
+			$wpdb->prefix . 'aips_notifications',
+			array(
+				'type'       => 'test',
+				'title'      => '',
+				'message'    => 'Recent legacy read',
+				'url'        => '',
+				'is_read'    => 1,
+				'read_at'    => time(),
+				'created_at' => time(),
+			),
+			array( '%s', '%s', '%s', '%s', '%d', '%d', '%d' )
+		);
+		$recent_id = (int) $wpdb->insert_id;
 
 		$deleted = $this->repository->cleanup_old( 30 );
 
@@ -377,7 +454,7 @@ class Test_AIPS_Notifications extends WP_UnitTestCase {
 	 * Test that ajax_mark_read() returns success and correct unread count.
 	 */
 	public function test_ajax_mark_read_success() {
-		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( $this->admin_user_id );
 
 		$id1 = $this->repository->create( 'test', 'Notification 1' );
 		$id2 = $this->repository->create( 'test', 'Notification 2' );
@@ -405,6 +482,9 @@ class Test_AIPS_Notifications extends WP_UnitTestCase {
 		$this->assertTrue( $response['success'], 'Should return success' );
 		$this->assertEquals( 1, $response['data']['unread_count'], 'One notification should remain unread' );
 		$this->assertEquals( 1, $this->repository->count_unread(), 'DB count should match' );
+
+		wp_set_current_user( $this->secondary_admin_user_id );
+		$this->assertEquals( 2, $this->repository->count_unread(), 'Another admin should still see both notifications as unread.' );
 	}
 
 	// -----------------------------------------------------------------------
@@ -439,7 +519,7 @@ class Test_AIPS_Notifications extends WP_UnitTestCase {
 	 * Test that ajax_mark_all_read() marks all notifications and returns unread_count 0.
 	 */
 	public function test_ajax_mark_all_read_success() {
-		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( $this->admin_user_id );
 
 		$this->repository->create( 'test', 'Notif A' );
 		$this->repository->create( 'test', 'Notif B' );
@@ -467,6 +547,9 @@ class Test_AIPS_Notifications extends WP_UnitTestCase {
 		$this->assertTrue( $response['success'], 'Should return success' );
 		$this->assertEquals( 0, $response['data']['unread_count'], 'All notifications should be read' );
 		$this->assertEquals( 0, $this->repository->count_unread(), 'DB should have 0 unread' );
+
+		wp_set_current_user( $this->secondary_admin_user_id );
+		$this->assertEquals( 3, $this->repository->count_unread(), 'Mark all as read should only apply to the acting admin.' );
 	}
 
 	// -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Refresh the AI Scheduler admin-bar notification flyout so it behaves like a real per-user notification center.

## What Changed
- added per-user notification read receipts via a new `aips_notification_reads` table
- updated notification repository unread/read operations to resolve against the current logged-in user
- kept notification creation as a shared source record while separating read state per user
- rebuilt the admin-bar flyout layout with CSS grid for aligned rows and actions
- expanded quick links to a 2-column x 3-row layout:
  - Dashboard
  - Automations
  - Templates
  - Authors
  - Schedules
  - History
- routed Automations-related links through `AIPS_Admin_Menu_Helper::get_page_url()`
- widened the flyout for desktop and added narrow-screen fallback behavior
- added `Mark All As Read` support
- fixed single-notification `Mark as Read` row actions so they remain visible and aligned
- updated client-side admin-bar behavior to refresh badge counts, row state, empty state, and header summaries after read actions
- normalized admin-bar notification titles so titles describe the action and messages keep entity-specific detail
- fixed Dashicon/CSS targeting for quick-link and action icons

## Contract Changes
- `get_unread($limit = 20, $user_id = 0)`
- `count_unread($user_id = 0)`
- `mark_as_read($id, $user_id = 0)`
- `mark_all_as_read($user_id = 0)`

## Verification
- passed `Test_AIPS_Notifications.php`
- passed `Test_AIPS_Admin_Bar_Cache.php`
- passed `Test_AIPS_Notification_Admin_Bar_Titles.php`
- passed focused migration coverage for `test_install_tables_creates_notification_reads_table`
- passed `php -l` on touched PHP files

## Notes
- the full `Test_AIPS_DB_Migrations.php` suite still hits the existing logger permission issue in this environment when upgrade-path tests run against `C:/tmp/wordpress/wp-content/uploads/aips-logs/...`
- the new notification-read table assertion itself passes