### PR TITLE
🎨 Palette: Improve accessibility of decorative Dashicons

### DIFF
--- a/.build/palette.md
+++ b/.build/palette.md
@@ -4,3 +4,9 @@
 ## 2026-05-30 - Added loading indicator when editing authors
 **Learning:** AJAX-driven edit modals within this repo can sometimes appear with empty fields while data is still loading, creating a confusing user experience. The standard pattern to solve this is to use the existing WordPress admin `.spinner` element within a loader container.
 **Action:** For future modal-based edit features, ensure a loader container is added alongside the form, and use JavaScript to hide the form and show the loader during the AJAX fetch phase. Only reveal the form when the data has successfully populated.
+## 2026-07-07 - Add aria-hidden to decorative Dashicons
+**Area:** Admin Templates (Global)
+**Status:** opened PR
+**PR:** 🎨 Palette: Improve accessibility of decorative Dashicons
+**Learning:** Decorative dashicons (<span class="dashicons...">) often lack aria-hidden="true", causing screen readers to misinterpret them.
+**Action:** Applied aria-hidden="true" to dashicons across templates.

--- a/ai-post-scheduler/templates/admin/author-topics.php
+++ b/ai-post-scheduler/templates/admin/author-topics.php
@@ -90,15 +90,15 @@ $posts_count        = $logs_repository->count_generated_posts_by_author($author_
 				</div>
 				<div class="aips-page-actions">
 					<a href="<?php echo esc_url($authors_page_url); ?>" class="aips-btn aips-btn-secondary">
-						<span class="dashicons dashicons-edit"></span>
+						<span class="dashicons dashicons-edit" aria-hidden="true"></span>
 						<?php esc_html_e('Edit Author', 'ai-post-scheduler'); ?>
 					</a>
 					<button class="aips-btn aips-btn-primary aips-generate-topics-now" data-id="<?php echo esc_attr($author->id); ?>">
-						<span class="dashicons dashicons-update"></span>
+						<span class="dashicons dashicons-update" aria-hidden="true"></span>
 						<?php esc_html_e('Generate Topics', 'ai-post-scheduler'); ?>
 					</button>
 					<a href="<?php echo esc_url( add_query_arg( array( 'page' => 'aips-generated-posts', 'author_id' => absint( $author->id ) ), admin_url( 'admin.php' ) ) ); ?>" class="aips-btn aips-btn-secondary">
-						<span class="dashicons dashicons-admin-post"></span>
+						<span class="dashicons dashicons-admin-post" aria-hidden="true"></span>
 						<?php esc_html_e('View Generated Posts', 'ai-post-scheduler'); ?>
 					</a>
 				</div>

--- a/ai-post-scheduler/templates/admin/authors.php
+++ b/ai-post-scheduler/templates/admin/authors.php
@@ -47,11 +47,11 @@ $site_ctx = AIPS_Site_Context::get();
                 </div>
                 <div class="aips-page-actions">
                     <button class="aips-btn aips-btn-secondary" id="aips-suggest-authors-btn">
-                        <span class="dashicons dashicons-lightbulb"></span>
+                        <span class="dashicons dashicons-lightbulb" aria-hidden="true"></span>
                         <?php esc_html_e('Suggest Authors', 'ai-post-scheduler'); ?>
                     </button>
                     <button class="aips-btn aips-btn-primary aips-add-author-btn">
-                        <span class="dashicons dashicons-plus-alt"></span>
+                        <span class="dashicons dashicons-plus-alt" aria-hidden="true"></span>
                         <?php esc_html_e('Add Author', 'ai-post-scheduler'); ?>
                     </button>
                 </div>
@@ -170,7 +170,7 @@ $site_ctx = AIPS_Site_Context::get();
                                             aria-label="<?php echo esc_attr($indicator_label); ?>"
                                             aria-describedby="aips-quality-tooltip-<?php echo esc_attr($author->id); ?>"
                                         >
-                                            <span class="dashicons <?php echo esc_attr($indicator_icon); ?>"></span>
+                                            <span class="dashicons <?php echo esc_attr($indicator_icon); ?>" aria-hidden="true"></span>
                                             <span id="aips-quality-tooltip-<?php echo esc_attr($author->id); ?>" class="aips-quality-tooltip" role="tooltip">
                                                 <span class="aips-quality-tooltip-title"><?php echo esc_html($indicator_label); ?></span>
                                                 <span class="aips-quality-tooltip-score"><?php echo esc_html($quality_score_text); ?></span>
@@ -195,19 +195,19 @@ $site_ctx = AIPS_Site_Context::get();
                                     <td>
                                         <?php if ($author->is_active): ?>
                                         <span class="aips-badge aips-badge-success">
-                                            <span class="dashicons dashicons-yes-alt"></span>
+                                            <span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
                                             <?php esc_html_e('Active', 'ai-post-scheduler'); ?>
                                         </span>
                                         <?php else: ?>
                                         <span class="aips-badge aips-badge-neutral">
-                                            <span class="dashicons dashicons-minus"></span>
+                                            <span class="dashicons dashicons-minus" aria-hidden="true"></span>
                                             <?php esc_html_e('Inactive', 'ai-post-scheduler'); ?>
                                         </span>
                                         <?php endif; ?>
                                         <?php if ($policy_flags_count >= 3): ?>
                                         <div style="margin-top: 6px;">
                                             <span class="aips-badge aips-badge-warning">
-                                                <span class="dashicons dashicons-warning"></span>
+                                                <span class="dashicons dashicons-warning" aria-hidden="true"></span>
                                                 <?php
                                                 printf(
                                                     esc_html__('Policy flags: %d', 'ai-post-scheduler'),
@@ -221,7 +221,7 @@ $site_ctx = AIPS_Site_Context::get();
                                     <td>
                                         <div style="display: flex; flex-direction: column; gap: 6px; align-items: flex-start;">
                                             <a href="<?php echo esc_url( AIPS_Admin_Menu_Helper::get_page_url( 'author_topics', array( 'author_id' => absint( $author->id ) ) ) ); ?>" class="aips-btn aips-btn-sm aips-btn-secondary">
-                                                <span class="dashicons dashicons-visibility"></span>
+                                                <span class="dashicons dashicons-visibility" aria-hidden="true"></span>
                                                 <?php echo esc_html(sprintf(_n('%d Topic', '%d Topics', $total_topics, 'ai-post-scheduler'), $total_topics)); ?>
                                             </a>
                                             <div class="cell-meta" style="font-size: 11px;">
@@ -233,7 +233,7 @@ $site_ctx = AIPS_Site_Context::get();
                                     </td>
                                     <td>
                                         <a href="<?php echo esc_url( add_query_arg( array( 'page' => 'aips-generated-posts', 'author_id' => absint( $author->id ) ), admin_url( 'admin.php' ) ) ); ?>" class="aips-btn aips-btn-sm aips-btn-secondary">
-                                            <span class="dashicons dashicons-admin-post"></span>
+                                            <span class="dashicons dashicons-admin-post" aria-hidden="true"></span>
                                             <?php echo esc_html(sprintf(_n('%d Post', '%d Posts', $posts_count, 'ai-post-scheduler'), $posts_count)); ?>
                                         </a>
                                     </td>
@@ -241,20 +241,20 @@ $site_ctx = AIPS_Site_Context::get();
                                         <div class="cell-actions">
                                             <div class="aips-author-generation-actions">
                                                 <button class="aips-btn aips-btn-sm aips-btn-primary aips-generate-topics-now" data-id="<?php echo esc_attr($author->id); ?>" title="<?php esc_attr_e('Generate Topics', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Generate Topics', 'ai-post-scheduler'); ?>">
-                                                    <span class="dashicons dashicons-update"></span>
+                                                    <span class="dashicons dashicons-update" aria-hidden="true"></span>
                                                     <?php esc_html_e('Generate Topics', 'ai-post-scheduler'); ?>
                                                 </button>
                                                 <button class="aips-btn aips-btn-sm aips-btn-author-posts aips-generate-author-posts-now" data-id="<?php echo esc_attr($author->id); ?>" data-type="<?php echo esc_attr(AIPS_Unified_Schedule_Service::TYPE_AUTHOR_POST); ?>" data-quantity="<?php echo esc_attr(isset($author->manual_post_generation_quantity) ? max(1, (int) $author->manual_post_generation_quantity) : 1); ?>" title="<?php esc_attr_e('Generate Posts', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Generate Posts', 'ai-post-scheduler'); ?>">
-                                                    <span class="dashicons dashicons-admin-post"></span>
+                                                    <span class="dashicons dashicons-admin-post" aria-hidden="true"></span>
                                                     <?php esc_html_e('Generate Posts', 'ai-post-scheduler'); ?>
                                                 </button>
                                             </div>
                                             <button class="aips-btn aips-btn-sm aips-btn-secondary aips-edit-author" data-id="<?php echo esc_attr($author->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
-                                                <span class="dashicons dashicons-edit"></span>
+                                                <span class="dashicons dashicons-edit" aria-hidden="true"></span>
                                                 <?php esc_html_e('Edit', 'ai-post-scheduler'); ?>
                                             </button>
                                             <button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-author" data-id="<?php echo esc_attr($author->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
-                                                <span class="dashicons dashicons-trash"></span>
+                                                <span class="dashicons dashicons-trash" aria-hidden="true"></span>
                                                 <?php esc_html_e('Delete', 'ai-post-scheduler'); ?>
                                             </button>
                                         </div>
@@ -291,7 +291,7 @@ $site_ctx = AIPS_Site_Context::get();
                         <p class="aips-empty-state-description"><?php esc_html_e('No authors match your search criteria. Try a different search term.', 'ai-post-scheduler'); ?></p>
                         <div class="aips-empty-state-actions">
                             <button type="button" class="aips-btn aips-btn-primary aips-clear-author-search-btn">
-                                <span class="dashicons dashicons-dismiss"></span>
+                                <span class="dashicons dashicons-dismiss" aria-hidden="true"></span>
                                 <?php esc_html_e('Clear Search', 'ai-post-scheduler'); ?>
                             </button>
                         </div>
@@ -307,7 +307,7 @@ $site_ctx = AIPS_Site_Context::get();
                         <p class="aips-empty-state-description"><?php esc_html_e('Create your first author to start generating topically diverse blog posts.', 'ai-post-scheduler'); ?></p>
                         <div class="aips-empty-state-actions">
                             <button class="aips-btn aips-btn-primary aips-add-author-btn">
-                                <span class="dashicons dashicons-plus-alt"></span>
+                                <span class="dashicons dashicons-plus-alt" aria-hidden="true"></span>
                                 <?php esc_html_e('Add Author', 'ai-post-scheduler'); ?>
                             </button>
                         </div>
@@ -329,7 +329,7 @@ $site_ctx = AIPS_Site_Context::get();
                             <option value=""><?php esc_html_e('All Fields/Niches', 'ai-post-scheduler'); ?></option>
                         </select>
                         <button type="button" id="aips-queue-filter-submit" class="aips-btn aips-btn-sm aips-btn-secondary">
-                            <span class="dashicons dashicons-filter"></span>
+                            <span class="dashicons dashicons-filter" aria-hidden="true"></span>
                             <?php esc_html_e('Filter', 'ai-post-scheduler'); ?>
                         </button>
                     </div>
@@ -354,7 +354,7 @@ $site_ctx = AIPS_Site_Context::get();
                     </div>
                     <div class="aips-toolbar-right">
                         <button type="button" id="aips-queue-reload-btn" class="aips-btn aips-btn-sm aips-btn-secondary">
-                            <span class="dashicons dashicons-update"></span>
+                            <span class="dashicons dashicons-update" aria-hidden="true"></span>
                             <?php esc_html_e('Reload', 'ai-post-scheduler'); ?>
                         </button>
                     </div>
@@ -677,7 +677,7 @@ $site_ctx = AIPS_Site_Context::get();
                 <div class="aips-modal-footer form-actions">
                     <button type="button" class="aips-btn aips-btn-secondary aips-modal-close"><?php esc_html_e('Cancel', 'ai-post-scheduler'); ?></button>
                     <button type="submit" id="aips-suggest-authors-submit" class="aips-btn aips-btn-primary">
-                        <span class="dashicons dashicons-lightbulb"></span>
+                        <span class="dashicons dashicons-lightbulb" aria-hidden="true"></span>
                         <?php esc_html_e('Generate Suggestions', 'ai-post-scheduler'); ?>
                     </button>
                 </div>

--- a/ai-post-scheduler/templates/admin/automations.php
+++ b/ai-post-scheduler/templates/admin/automations.php
@@ -35,14 +35,14 @@ if (!defined('ABSPATH')) {
 							<?php if ('link' === $action_type && !empty($tab_action['url'])) : ?>
 								<a href="<?php echo esc_url($tab_action['url']); ?>" class="<?php echo esc_attr($action_class); ?>"<?php echo $action_id ? ' id="' . esc_attr($action_id) . '"' : ''; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?><?php echo $data_attr_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 									<?php if ($action_icon) : ?>
-										<span class="dashicons <?php echo esc_attr($action_icon); ?>"></span>
+										<span class="dashicons <?php echo esc_attr($action_icon); ?>" aria-hidden="true"></span>
 									<?php endif; ?>
 									<?php echo esc_html($action_label); ?>
 								</a>
 							<?php else : ?>
 								<button type="button" class="<?php echo esc_attr($action_class); ?>"<?php echo $action_id ? ' id="' . esc_attr($action_id) . '"' : ''; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?><?php echo $data_attr_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 									<?php if ($action_icon) : ?>
-										<span class="dashicons <?php echo esc_attr($action_icon); ?>"></span>
+										<span class="dashicons <?php echo esc_attr($action_icon); ?>" aria-hidden="true"></span>
 									<?php endif; ?>
 									<?php echo esc_html($action_label); ?>
 								</button>

--- a/ai-post-scheduler/templates/admin/cache-monitor.php
+++ b/ai-post-scheduler/templates/admin/cache-monitor.php
@@ -70,7 +70,7 @@ $action_nonce = wp_create_nonce('aips_cache_monitor_action');
 					</h2>
 					<div class="aips-btn-group">
 						<button type="button" class="aips-btn aips-btn-secondary aips-cache-monitor-refresh" data-nonce="<?php echo esc_attr($nonce); ?>">
-							<span class="dashicons dashicons-update"></span>
+							<span class="dashicons dashicons-update" aria-hidden="true"></span>
 							<?php esc_html_e('Refresh', 'ai-post-scheduler'); ?>
 						</button>
 						<?php if (!$monitor_enabled): ?>
@@ -205,7 +205,7 @@ $action_nonce = wp_create_nonce('aips_cache_monitor_action');
 							?>
 								<div class="aips-capability-item">
 									<span class="aips-badge <?php echo $supported ? 'aips-badge-success' : 'aips-badge-secondary'; ?>">
-										<span class="dashicons <?php echo $supported ? 'dashicons-yes-alt' : 'dashicons-minus'; ?>"></span>
+										<span class="dashicons <?php echo $supported ? 'dashicons-yes-alt' : 'dashicons-minus'; ?>" aria-hidden="true"></span>
 										<?php echo esc_html($cap_label); ?>
 									</span>
 								</div>
@@ -296,12 +296,12 @@ $action_nonce = wp_create_nonce('aips_cache_monitor_action');
 						<div class="aips-btn-group">
 							<button type="button" class="aips-btn aips-btn-secondary aips-cache-flush-expired"
 								data-nonce="<?php echo esc_attr($action_nonce); ?>">
-								<span class="dashicons dashicons-trash"></span>
+								<span class="dashicons dashicons-trash" aria-hidden="true"></span>
 								<?php esc_html_e('Flush Expired', 'ai-post-scheduler'); ?>
 							</button>
 							<button type="button" class="aips-btn aips-btn-danger aips-cache-flush-all-btn"
 								data-nonce="<?php echo esc_attr($action_nonce); ?>">
-								<span class="dashicons dashicons-warning"></span>
+								<span class="dashicons dashicons-warning" aria-hidden="true"></span>
 								<?php esc_html_e('Flush All Plugin Cache', 'ai-post-scheduler'); ?>
 							</button>
 						</div>
@@ -408,7 +408,7 @@ $action_nonce = wp_create_nonce('aips_cache_monitor_action');
 						<div class="aips-modal-header">
 							<h2><?php esc_html_e('Inspect Cache Entry', 'ai-post-scheduler'); ?></h2>
 							<button type="button" class="aips-modal-close" aria-label="<?php esc_attr_e('Close', 'ai-post-scheduler'); ?>">
-								<span class="dashicons dashicons-no-alt"></span>
+								<span class="dashicons dashicons-no-alt" aria-hidden="true"></span>
 							</button>
 						</div>
 						<div class="aips-modal-body" id="aips-cache-inspect-body">

--- a/ai-post-scheduler/templates/admin/calendar.php
+++ b/ai-post-scheduler/templates/admin/calendar.php
@@ -19,7 +19,7 @@ if (!defined('ABSPATH')) {
 				</div>
 				<div class="aips-page-actions">
 					<a href="<?php echo esc_url(AIPS_Admin_Menu_Helper::get_page_url('schedule')); ?>" class="aips-btn aips-btn-secondary">
-						<span class="dashicons dashicons-list-view"></span>
+						<span class="dashicons dashicons-list-view" aria-hidden="true"></span>
 						<?php esc_html_e('List View', 'ai-post-scheduler'); ?>
 					</a>
 				</div>
@@ -34,13 +34,13 @@ if (!defined('ABSPATH')) {
 				<div class="aips-calendar-header">
 					<div class="aips-calendar-nav">
 						<button class="aips-btn aips-btn-sm aips-btn-secondary aips-calendar-prev" title="<?php esc_attr_e('Previous Month', 'ai-post-scheduler'); ?>">
-							<span class="dashicons dashicons-arrow-left-alt2"></span>
+							<span class="dashicons dashicons-arrow-left-alt2" aria-hidden="true"></span>
 						</button>
 						<h2 class="aips-calendar-title">
 							<span class="aips-calendar-month-year"></span>
 						</h2>
 						<button class="aips-btn aips-btn-sm aips-btn-secondary aips-calendar-next" title="<?php esc_attr_e('Next Month', 'ai-post-scheduler'); ?>">
-							<span class="dashicons dashicons-arrow-right-alt2"></span>
+							<span class="dashicons dashicons-arrow-right-alt2" aria-hidden="true"></span>
 						</button>
 					</div>
 					
@@ -130,7 +130,7 @@ if (!defined('ABSPATH')) {
 			<div class="aips-calendar-modal-header">
 				<h2 class="aips-modal-title"><?php esc_html_e('Schedule Details', 'ai-post-scheduler'); ?></h2>
 				<button type="button" class="aips-calendar-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">
-					<span class="dashicons dashicons-no-alt"></span>
+					<span class="dashicons dashicons-no-alt" aria-hidden="true"></span>
 				</button>
 			</div>
 			<div class="aips-calendar-modal-body">

--- a/ai-post-scheduler/templates/admin/campaign-wizard.php
+++ b/ai-post-scheduler/templates/admin/campaign-wizard.php
@@ -19,7 +19,7 @@ $authors = get_users(array(
 					<p class="aips-page-description"><?php esc_html_e('Build a campaign template, publishing defaults, review policy, and schedule in one flow.', 'ai-post-scheduler'); ?></p>
 				</div>
 				<a class="aips-btn aips-btn-secondary" href="<?php echo esc_url(AIPS_Admin_Menu_Helper::get_page_url('schedule')); ?>">
-					<span class="dashicons dashicons-calendar-alt"></span>
+					<span class="dashicons dashicons-calendar-alt" aria-hidden="true"></span>
 					<?php esc_html_e('Schedules', 'ai-post-scheduler'); ?>
 				</a>
 			</div>

--- a/ai-post-scheduler/templates/admin/campaigns.php
+++ b/ai-post-scheduler/templates/admin/campaigns.php
@@ -82,7 +82,7 @@ $render_campaign_rows = static function($campaigns, $archived = false) {
 				</div>
 				<div class="aips-page-actions">
 					<a href="<?php echo esc_url($campaign_wizard_url); ?>" class="aips-btn aips-btn-primary">
-						<span class="dashicons dashicons-plus-alt"></span>
+						<span class="dashicons dashicons-plus-alt" aria-hidden="true"></span>
 						<?php esc_html_e('Add New Campaign', 'ai-post-scheduler'); ?>
 					</a>
 				</div>

--- a/ai-post-scheduler/templates/admin/dashboard.php
+++ b/ai-post-scheduler/templates/admin/dashboard.php
@@ -26,9 +26,9 @@ if (!defined('ABSPATH')) {
 					<!-- Date Range Filter Trigger Button -->
 					<div class="aips-date-filter-container">
 						<button type="button" class="aips-btn aips-btn-secondary id-aips-date-filter-btn" id="aips-date-filter-trigger">
-							<span class="dashicons dashicons-calendar-alt"></span>
+							<span class="dashicons dashicons-calendar-alt" aria-hidden="true"></span>
 							<span class="aips-date-range-label"><?php echo esc_html($date_from) . ' – ' . esc_html($date_to); ?></span>
-							<span class="dashicons dashicons-arrow-down-alt2"></span>
+							<span class="dashicons dashicons-arrow-down-alt2" aria-hidden="true"></span>
 						</button>
 						
 						<!-- Popover Panel -->
@@ -58,7 +58,7 @@ if (!defined('ABSPATH')) {
 
 		<!-- 1. SUMMARY SECTION -->
 		<div class="aips-dashboard-section-title">
-			<span class="dashicons dashicons-chart-bar"></span>
+			<span class="dashicons dashicons-chart-bar" aria-hidden="true"></span>
 			<h2><?php esc_html_e('Overview Summary', 'ai-post-scheduler'); ?></h2>
 			<span class="aips-section-meta"><?php echo sprintf(__('Activity from %s to %s', 'ai-post-scheduler'), esc_html($date_from), esc_html($date_to)); ?></span>
 		</div>
@@ -67,7 +67,7 @@ if (!defined('ABSPATH')) {
 			<!-- Stats Box: Completed Posts -->
 			<div class="aips-stat-card glass-morphic aips-stat-success">
 				<div class="aips-stat-icon-wrap">
-					<span class="dashicons dashicons-admin-post"></span>
+					<span class="dashicons dashicons-admin-post" aria-hidden="true"></span>
 				</div>
 				<div class="aips-stat-content">
 					<span class="aips-stat-label"><?php esc_html_e('Posts Completed', 'ai-post-scheduler'); ?></span>
@@ -81,7 +81,7 @@ if (!defined('ABSPATH')) {
 			<!-- Stats Box: Partial & Failed -->
 			<div class="aips-stat-card glass-morphic aips-stat-danger">
 				<div class="aips-stat-icon-wrap">
-					<span class="dashicons dashicons-warning"></span>
+					<span class="dashicons dashicons-warning" aria-hidden="true"></span>
 				</div>
 				<div class="aips-stat-content">
 					<span class="aips-stat-label"><?php esc_html_e('Unsuccessful Attempts', 'ai-post-scheduler'); ?></span>
@@ -95,7 +95,7 @@ if (!defined('ABSPATH')) {
 			<!-- Stats Box: AI Activity -->
 			<div class="aips-stat-card glass-morphic aips-stat-info">
 				<div class="aips-stat-icon-wrap">
-					<span class="dashicons dashicons-cloud"></span>
+					<span class="dashicons dashicons-cloud" aria-hidden="true"></span>
 				</div>
 				<div class="aips-stat-content">
 					<span class="aips-stat-label"><?php esc_html_e('AI Requests & Calls', 'ai-post-scheduler'); ?></span>
@@ -109,7 +109,7 @@ if (!defined('ABSPATH')) {
 			<!-- Stats Box: Topics Generated -->
 			<div class="aips-stat-card glass-morphic aips-stat-warning">
 				<div class="aips-stat-icon-wrap">
-					<span class="dashicons dashicons-lightbulb"></span>
+					<span class="dashicons dashicons-lightbulb" aria-hidden="true"></span>
 				</div>
 				<div class="aips-stat-content">
 					<span class="aips-stat-label"><?php esc_html_e('Author Topics Created', 'ai-post-scheduler'); ?></span>
@@ -123,7 +123,7 @@ if (!defined('ABSPATH')) {
 
 		<!-- 2. DETAIL SECTION -->
 		<div class="aips-dashboard-section-title aips-margin-top-large">
-			<span class="dashicons dashicons-list-view"></span>
+			<span class="dashicons dashicons-list-view" aria-hidden="true"></span>
 			<h2><?php esc_html_e('Analytics Detail', 'ai-post-scheduler'); ?></h2>
 			<span class="aips-section-meta"><?php esc_html_e('Explore records and analytical details for the selected period.', 'ai-post-scheduler'); ?></span>
 		</div>
@@ -134,19 +134,19 @@ if (!defined('ABSPATH')) {
 				<!-- Tab Headers -->
 				<div class="aips-tab-headers" role="tablist">
 					<button class="aips-tab-btn active" role="tab" aria-selected="true" aria-controls="tab-posts" id="btn-tab-posts">
-						<span class="dashicons dashicons-edit"></span>
+						<span class="dashicons dashicons-edit" aria-hidden="true"></span>
 						<?php esc_html_e('Generated Posts', 'ai-post-scheduler'); ?>
 					</button>
 					<button class="aips-tab-btn" role="tab" aria-selected="false" aria-controls="tab-topics" id="btn-tab-topics">
-						<span class="dashicons dashicons-welcome-write-blog"></span>
+						<span class="dashicons dashicons-welcome-write-blog" aria-hidden="true"></span>
 						<?php esc_html_e('Author Topics', 'ai-post-scheduler'); ?>
 					</button>
 					<button class="aips-tab-btn" role="tab" aria-selected="false" aria-controls="tab-topic-posts" id="btn-tab-topic-posts">
-						<span class="dashicons dashicons-admin-links"></span>
+						<span class="dashicons dashicons-admin-links" aria-hidden="true"></span>
 						<?php esc_html_e('Posts by Topic', 'ai-post-scheduler'); ?>
 					</button>
 					<button class="aips-tab-btn" role="tab" aria-selected="false" aria-controls="tab-schedules" id="btn-tab-schedules">
-						<span class="dashicons dashicons-update"></span>
+						<span class="dashicons dashicons-update" aria-hidden="true"></span>
 						<?php esc_html_e('Schedules Executed', 'ai-post-scheduler'); ?>
 					</button>
 				</div>
@@ -206,7 +206,7 @@ if (!defined('ABSPATH')) {
 						</div>
 						<?php else: ?>
 						<div class="aips-empty-state">
-							<span class="dashicons dashicons-admin-post aips-empty-state-icon"></span>
+							<span class="dashicons dashicons-admin-post aips-empty-state-icon" aria-hidden="true"></span>
 							<h3 class="aips-empty-state-title"><?php esc_html_e('No Generated Posts', 'ai-post-scheduler'); ?></h3>
 							<p class="aips-empty-state-description"><?php esc_html_e('No content has been generated in the selected date range.', 'ai-post-scheduler'); ?></p>
 						</div>
@@ -262,7 +262,7 @@ if (!defined('ABSPATH')) {
 						</div>
 						<?php else: ?>
 						<div class="aips-empty-state">
-							<span class="dashicons dashicons-lightbulb aips-empty-state-icon"></span>
+							<span class="dashicons dashicons-lightbulb aips-empty-state-icon" aria-hidden="true"></span>
 							<h3 class="aips-empty-state-title"><?php esc_html_e('No Topics Created', 'ai-post-scheduler'); ?></h3>
 							<p class="aips-empty-state-description"><?php esc_html_e('No author topics were generated in the selected date range.', 'ai-post-scheduler'); ?></p>
 						</div>
@@ -308,7 +308,7 @@ if (!defined('ABSPATH')) {
 						</div>
 						<?php else: ?>
 						<div class="aips-empty-state">
-							<span class="dashicons dashicons-admin-links aips-empty-state-icon"></span>
+							<span class="dashicons dashicons-admin-links aips-empty-state-icon" aria-hidden="true"></span>
 							<h3 class="aips-empty-state-title"><?php esc_html_e('No Topic-based Posts', 'ai-post-scheduler'); ?></h3>
 							<p class="aips-empty-state-description"><?php esc_html_e('No posts were generated from approved author topics in the selected date range.', 'ai-post-scheduler'); ?></p>
 						</div>
@@ -373,7 +373,7 @@ if (!defined('ABSPATH')) {
 						</div>
 						<?php else: ?>
 						<div class="aips-empty-state">
-							<span class="dashicons dashicons-yes aips-empty-state-icon"></span>
+							<span class="dashicons dashicons-yes aips-empty-state-icon" aria-hidden="true"></span>
 							<h3 class="aips-empty-state-title"><?php esc_html_e('No Schedules Executed', 'ai-post-scheduler'); ?></h3>
 							<p class="aips-empty-state-description"><?php esc_html_e('No automated schedules have run in the selected date range.', 'ai-post-scheduler'); ?></p>
 						</div>
@@ -440,7 +440,7 @@ if (!defined('ABSPATH')) {
 		<div class="aips-content-panel outlook-panel glass-morphic">
 			<div class="aips-panel-header">
 				<div class="aips-panel-header-title-wrap">
-					<span class="dashicons dashicons-clock aips-outlook-icon"></span>
+					<span class="dashicons dashicons-clock aips-outlook-icon" aria-hidden="true"></span>
 					<h2 class="aips-panel-title"><?php esc_html_e('Next Month Outlook (Next 30 Days)', 'ai-post-scheduler'); ?></h2>
 				</div>
 				<span class="aips-badge aips-badge-info">
@@ -493,7 +493,7 @@ if (!defined('ABSPATH')) {
 				</div>
 				<?php else: ?>
 				<div class="aips-empty-state">
-					<span class="dashicons dashicons-calendar-alt aips-empty-state-icon"></span>
+					<span class="dashicons dashicons-calendar-alt aips-empty-state-icon" aria-hidden="true"></span>
 					<p class="aips-empty-state-description"><?php esc_html_e('No automated runs scheduled for the next 30 days. Check your schedule configurations.', 'ai-post-scheduler'); ?></p>
 				</div>
 				<?php endif; ?>

--- a/ai-post-scheduler/templates/admin/dev-tools.php
+++ b/ai-post-scheduler/templates/admin/dev-tools.php
@@ -23,7 +23,7 @@ if (!defined('ABSPATH')) {
                 <form id="aips-dev-scaffold-form">
                     <div class="aips-form-section">
                         <h3 class="aips-form-section-title">
-                            <span class="dashicons dashicons-admin-tools"></span>
+                            <span class="dashicons dashicons-admin-tools" aria-hidden="true"></span>
                             <?php esc_html_e('Generate Template Scaffold', 'ai-post-scheduler'); ?>
                         </h3>
                         <p class="aips-field-description" style="margin-bottom: 20px;">
@@ -64,7 +64,7 @@ if (!defined('ABSPATH')) {
 
                         <div class="aips-form-actions">
                             <button type="submit" id="aips-dev-scaffold-submit" class="aips-btn aips-btn-primary aips-btn-lg">
-                                <span class="dashicons dashicons-admin-tools"></span>
+                                <span class="dashicons dashicons-admin-tools" aria-hidden="true"></span>
                                 <?php esc_html_e('Generate Scaffold', 'ai-post-scheduler'); ?>
                             </button>
                             <span class="spinner" style="float: none; margin-top: 4px;"></span>

--- a/ai-post-scheduler/templates/admin/history.php
+++ b/ai-post-scheduler/templates/admin/history.php
@@ -49,7 +49,7 @@ if (is_object($history)) {
                 </div>
                 <div class="aips-page-actions">
                     <button class="aips-btn aips-btn-secondary" id="aips-export-history-btn">
-                        <span class="dashicons dashicons-download"></span>
+                        <span class="dashicons dashicons-download" aria-hidden="true"></span>
                         <?php esc_html_e('Export CSV', 'ai-post-scheduler'); ?>
                     </button>
                 </div>
@@ -87,7 +87,7 @@ if (is_object($history)) {
                         <option value="processing" <?php selected($status_filter, 'processing'); ?>><?php esc_html_e('Processing', 'ai-post-scheduler'); ?></option>
                     </select>
                     <button class="aips-btn aips-btn-sm aips-btn-secondary" id="aips-filter-btn">
-                        <span class="dashicons dashicons-filter"></span>
+                        <span class="dashicons dashicons-filter" aria-hidden="true"></span>
                         <?php esc_html_e('Filter', 'ai-post-scheduler'); ?>
                     </button>
                 </div>
@@ -105,21 +105,21 @@ if (is_object($history)) {
             <div class="aips-panel-toolbar">
                 <div class="aips-toolbar-left">
                     <button class="aips-btn aips-btn-sm aips-btn-danger aips-btn-danger-solid" id="aips-delete-selected-btn" disabled>
-                        <span class="dashicons dashicons-trash"></span>
+                        <span class="dashicons dashicons-trash" aria-hidden="true"></span>
                         <?php esc_html_e('Delete Selected', 'ai-post-scheduler'); ?>
                     </button>
                     <button class="aips-btn aips-btn-sm aips-btn-secondary" id="aips-reload-history-btn">
-                        <span class="dashicons dashicons-update"></span>
+                        <span class="dashicons dashicons-update" aria-hidden="true"></span>
                         <?php esc_html_e('Reload', 'ai-post-scheduler'); ?>
                     </button>
                 </div>
                 <div class="aips-toolbar-right aips-history-pagination-cell">
                     <button class="aips-btn aips-btn-sm aips-btn-danger aips-btn-danger-solid aips-clear-history" data-status="failed">
-                        <span class="dashicons dashicons-dismiss"></span>
+                        <span class="dashicons dashicons-dismiss" aria-hidden="true"></span>
                         <?php esc_html_e('Clear Failed', 'ai-post-scheduler'); ?>
                     </button>
                     <button class="aips-btn aips-btn-sm aips-btn-danger aips-btn-danger-solid aips-clear-history" data-status="all">
-                        <span class="dashicons dashicons-trash"></span>
+                        <span class="dashicons dashicons-trash" aria-hidden="true"></span>
                         <?php esc_html_e('Clear All', 'ai-post-scheduler'); ?>
                     </button>
                     <div id="aips-history-pagination-wrap">
@@ -162,7 +162,7 @@ if (is_object($history)) {
                                             <?php if ($has_active_filter): ?>
                                                 <br><br>
                                                 <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-clear-history-search-btn">
-                                                    <span class="dashicons dashicons-dismiss"></span>
+                                                    <span class="dashicons dashicons-dismiss" aria-hidden="true"></span>
                                                     <?php esc_html_e('Clear Filters', 'ai-post-scheduler'); ?>
                                                 </button>
                                             <?php endif; ?>
@@ -180,7 +180,7 @@ if (is_object($history)) {
                             <p class="aips-empty-state-description"><?php esc_html_e('No history containers match your search criteria. Try a different search term or filter.', 'ai-post-scheduler'); ?></p>
                             <div class="aips-empty-state-actions">
                                 <button type="button" class="aips-btn aips-btn-primary aips-clear-history-search-btn">
-                                    <span class="dashicons dashicons-dismiss"></span>
+                                    <span class="dashicons dashicons-dismiss" aria-hidden="true"></span>
                                     <?php esc_html_e('Clear Search', 'ai-post-scheduler'); ?>
                                 </button>
                             </div>

--- a/ai-post-scheduler/templates/admin/internal-links.php
+++ b/ai-post-scheduler/templates/admin/internal-links.php
@@ -41,11 +41,11 @@ $is_embedded_internal_links_view = !empty($embedded);
 				</div>
 				<div class="aips-page-actions">
 					<button type="button" id="aips-start-indexing-btn" class="aips-btn aips-btn-secondary">
-						<span class="dashicons dashicons-database-import"></span>
+						<span class="dashicons dashicons-database-import" aria-hidden="true"></span>
 						<?php esc_html_e('Index Posts', 'ai-post-scheduler'); ?>
 					</button>
 					<button type="button" id="aips-clear-index-btn" class="aips-btn aips-btn-ghost aips-btn-danger">
-						<span class="dashicons dashicons-trash"></span>
+						<span class="dashicons dashicons-trash" aria-hidden="true"></span>
 						<?php esc_html_e('Clear Index', 'ai-post-scheduler'); ?>
 					</button>
 				</div>
@@ -189,11 +189,11 @@ $is_embedded_internal_links_view = !empty($embedded);
 					<div id="aips-gen-feedback" class="aips-notice" style="display:none;margin:16px 0;"></div>
 
 					<button type="button" id="aips-generate-for-post-btn" class="aips-btn aips-btn-primary">
-						<span class="dashicons dashicons-search"></span>
+						<span class="dashicons dashicons-search" aria-hidden="true"></span>
 						<?php esc_html_e('Generate Suggestions', 'ai-post-scheduler'); ?>
 					</button>
 					<button type="button" id="aips-reindex-post-btn" class="aips-btn aips-btn-secondary" style="margin-left:8px;">
-						<span class="dashicons dashicons-update"></span>
+						<span class="dashicons dashicons-update" aria-hidden="true"></span>
 						<?php esc_html_e('Re-index Post', 'ai-post-scheduler'); ?>
 					</button>
 				</div>
@@ -211,7 +211,7 @@ $is_embedded_internal_links_view = !empty($embedded);
 		<div class="aips-modal-header">
 			<h2 class="aips-modal-title"><?php esc_html_e('Insert Link', 'ai-post-scheduler'); ?></h2>
 			<button type="button" class="aips-modal-close" aria-label="<?php esc_attr_e('Close', 'ai-post-scheduler'); ?>">
-				<span class="dashicons dashicons-no-alt"></span>
+				<span class="dashicons dashicons-no-alt" aria-hidden="true"></span>
 			</button>
 		</div>
 		<div class="aips-modal-body" style="padding:0;">
@@ -426,7 +426,7 @@ $is_embedded_internal_links_view = !empty($embedded);
 		<div class="aips-modal-header">
 			<h2 class="aips-modal-title"><?php esc_html_e('Edit Anchor Text', 'ai-post-scheduler'); ?></h2>
 			<button type="button" class="aips-modal-close" aria-label="<?php esc_attr_e('Close', 'ai-post-scheduler'); ?>">
-				<span class="dashicons dashicons-no-alt"></span>
+				<span class="dashicons dashicons-no-alt" aria-hidden="true"></span>
 			</button>
 		</div>
 		<div class="aips-modal-body">

--- a/ai-post-scheduler/templates/admin/onboarding.php
+++ b/ai-post-scheduler/templates/admin/onboarding.php
@@ -27,15 +27,15 @@ $default_title_prompt = __('Create a concise, SEO-friendly title for this articl
 				</div>
 				<div class="aips-btn-group" style="gap: 8px;">
 					<button type="button" class="aips-btn aips-btn-secondary" id="aips-onboarding-skip">
-						<span class="dashicons dashicons-dismiss"></span>
+						<span class="dashicons dashicons-dismiss" aria-hidden="true"></span>
 						<?php esc_html_e('Skip Onboarding', 'ai-post-scheduler'); ?>
 					</button>
 					<a class="aips-btn aips-btn-secondary" href="<?php echo esc_url(AIPS_Admin_Menu_Helper::get_page_url('settings') . '#content-strategy'); ?>">
-						<span class="dashicons dashicons-admin-settings"></span>
+						<span class="dashicons dashicons-admin-settings" aria-hidden="true"></span>
 						<?php esc_html_e('Open Settings', 'ai-post-scheduler'); ?>
 					</a>
 					<button type="button" class="aips-btn aips-btn-danger" id="aips-onboarding-reset">
-						<span class="dashicons dashicons-update"></span>
+						<span class="dashicons dashicons-update" aria-hidden="true"></span>
 						<?php esc_html_e('Restart Wizard', 'ai-post-scheduler'); ?>
 					</button>
 				</div>
@@ -135,7 +135,7 @@ $default_title_prompt = __('Create a concise, SEO-friendly title for this articl
 					</table>
 					<p>
 						<button type="submit" class="aips-btn aips-btn-primary" id="aips-onboarding-save-strategy">
-							<span class="dashicons dashicons-yes-alt"></span>
+							<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
 							<?php esc_html_e('Save Content Strategy', 'ai-post-scheduler'); ?>
 						</button>
 					</p>
@@ -200,7 +200,7 @@ $default_title_prompt = __('Create a concise, SEO-friendly title for this articl
 						</table>
 						<p>
 							<button type="submit" class="aips-btn aips-btn-primary" id="aips-onboarding-create-author" <?php disabled(!$strategy_complete); ?>>
-								<span class="dashicons dashicons-admin-users"></span>
+								<span class="dashicons dashicons-admin-users" aria-hidden="true"></span>
 								<?php esc_html_e('Create Author', 'ai-post-scheduler'); ?>
 							</button>
 						</p>
@@ -253,7 +253,7 @@ $default_title_prompt = __('Create a concise, SEO-friendly title for this articl
 						</table>
 						<p>
 							<button type="submit" class="aips-btn aips-btn-primary" id="aips-onboarding-create-template" <?php disabled(!$author_complete); ?>>
-								<span class="dashicons dashicons-media-text"></span>
+								<span class="dashicons dashicons-media-text" aria-hidden="true"></span>
 								<?php esc_html_e('Create Template', 'ai-post-scheduler'); ?>
 							</button>
 						</p>
@@ -283,7 +283,7 @@ $default_title_prompt = __('Create a concise, SEO-friendly title for this articl
 					<p class="description"><?php esc_html_e('This will generate topic ideas for your onboarding author.', 'ai-post-scheduler'); ?></p>
 					<p>
 						<button type="button" class="aips-btn aips-btn-primary" id="aips-onboarding-generate-topics" <?php disabled(!$template_complete || !$ai_engine_active); ?>>
-							<span class="dashicons dashicons-lightbulb"></span>
+							<span class="dashicons dashicons-lightbulb" aria-hidden="true"></span>
 							<?php esc_html_e('Generate Topics', 'ai-post-scheduler'); ?>
 						</button>
 						<span class="spinner" id="aips-onboarding-topics-spinner" style="float:none;"></span>
@@ -317,7 +317,7 @@ $default_title_prompt = __('Create a concise, SEO-friendly title for this articl
 					</p>
 					<p>
 						<button type="button" class="aips-btn aips-btn-primary" id="aips-onboarding-generate-post" <?php disabled(!$topics_complete || !$ai_engine_active); ?>>
-							<span class="dashicons dashicons-edit"></span>
+							<span class="dashicons dashicons-edit" aria-hidden="true"></span>
 							<?php esc_html_e('Generate Post', 'ai-post-scheduler'); ?>
 						</button>
 						<span class="spinner" id="aips-onboarding-post-spinner" style="float:none;"></span>
@@ -335,11 +335,11 @@ $default_title_prompt = __('Create a concise, SEO-friendly title for this articl
 				<p class="description"><?php esc_html_e('Mark onboarding as completed. You can still run this wizard later from System Status.', 'ai-post-scheduler'); ?></p>
 				<p>
 					<button type="button" class="aips-btn aips-btn-primary" id="aips-onboarding-complete" <?php disabled(!$post_complete); ?>>
-						<span class="dashicons dashicons-yes"></span>
+						<span class="dashicons dashicons-yes" aria-hidden="true"></span>
 						<?php esc_html_e('Finish Onboarding', 'ai-post-scheduler'); ?>
 					</button>
 					<a class="aips-btn aips-btn-secondary" href="<?php echo esc_url(AIPS_Admin_Menu_Helper::get_page_url('dashboard')); ?>" style="margin-left: 8px;">
-						<span class="dashicons dashicons-admin-home"></span>
+						<span class="dashicons dashicons-admin-home" aria-hidden="true"></span>
 						<?php esc_html_e('Go to Dashboard', 'ai-post-scheduler'); ?>
 					</a>
 				</p>

--- a/ai-post-scheduler/templates/admin/planner.php
+++ b/ai-post-scheduler/templates/admin/planner.php
@@ -6,7 +6,7 @@ $default_planner_frequency = 'daily';
     <div class="aips-content-panel">
         <div class="aips-panel-header">
             <div class="aips-panel-header-content">
-                <span class="dashicons dashicons-lightbulb dashicons-icon-lg"></span>
+                <span class="dashicons dashicons-lightbulb dashicons-icon-lg" aria-hidden="true"></span>
                 <div>
                     <h3 class="aips-panel-title"><?php echo esc_html__('Topic Brainstorming', 'ai-post-scheduler'); ?></h3>
                     <p class="aips-panel-description"><?php echo esc_html__('Generate article ideas based on a niche, or paste your own list of topics.', 'ai-post-scheduler'); ?></p>
@@ -52,7 +52,7 @@ $default_planner_frequency = 'daily';
         <div class="aips-content-panel">
             <div class="aips-panel-header">
                 <div class="aips-panel-header-content">
-                    <span class="dashicons dashicons-yes-alt dashicons-icon-lg"></span>
+                    <span class="dashicons dashicons-yes-alt dashicons-icon-lg" aria-hidden="true"></span>
                     <div>
                         <h3 class="aips-panel-title"><?php echo esc_html__('Review Topics', 'ai-post-scheduler'); ?></h3>
                     </div>
@@ -86,7 +86,7 @@ $default_planner_frequency = 'daily';
         <div class="aips-content-panel aips-planner-sidebar">
             <div class="aips-panel-header">
                 <div class="aips-panel-header-content">
-                    <span class="dashicons dashicons-calendar-alt dashicons-icon-lg"></span>
+                    <span class="dashicons dashicons-calendar-alt dashicons-icon-lg" aria-hidden="true"></span>
                     <div>
                         <h3 class="aips-panel-title"><?php echo esc_html__('Schedule', 'ai-post-scheduler'); ?></h3>
                     </div>
@@ -136,7 +136,7 @@ $default_planner_frequency = 'daily';
 <div class="topic-item">
     <input type="checkbox" class="topic-checkbox" checked>
     <input type="text" class="topic-text-input" value="{{topic}}" aria-label="<?php esc_attr_e('Edit topic title', 'ai-post-scheduler'); ?>">
-    <button type="button" class="aips-remove-topic-btn" aria-label="<?php esc_attr_e('Remove Topic', 'ai-post-scheduler'); ?>" title="<?php esc_attr_e('Remove Topic', 'ai-post-scheduler'); ?>"><span class="dashicons dashicons-dismiss"></span></button>
+    <button type="button" class="aips-remove-topic-btn" aria-label="<?php esc_attr_e('Remove Topic', 'ai-post-scheduler'); ?>" title="<?php esc_attr_e('Remove Topic', 'ai-post-scheduler'); ?>"><span class="dashicons dashicons-dismiss" aria-hidden="true"></span></button>
 </div>
 </script>
 

--- a/ai-post-scheduler/templates/admin/post-slices.php
+++ b/ai-post-scheduler/templates/admin/post-slices.php
@@ -38,7 +38,7 @@ $inactive_count = isset($post_slice_counts['inactive']) ? (int) $post_slice_coun
 				</div>
 				<div class="aips-page-actions">
 					<button type="button" class="aips-btn aips-btn-primary" id="aips-add-post-slice-btn">
-						<span class="dashicons dashicons-plus-alt2"></span>
+						<span class="dashicons dashicons-plus-alt2" aria-hidden="true"></span>
 						<?php esc_html_e('Add Post Slice', 'ai-post-scheduler'); ?>
 					</button>
 				</div>
@@ -111,12 +111,12 @@ $inactive_count = isset($post_slice_counts['inactive']) ? (int) $post_slice_coun
 									<td class="column-status">
 										<?php if ($is_active): ?>
 											<span class="aips-badge aips-badge-success">
-												<span class="dashicons dashicons-yes-alt"></span>
+												<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
 												<?php esc_html_e('Active', 'ai-post-scheduler'); ?>
 											</span>
 										<?php else: ?>
 											<span class="aips-badge aips-badge-neutral">
-												<span class="dashicons dashicons-minus"></span>
+												<span class="dashicons dashicons-minus" aria-hidden="true"></span>
 												<?php esc_html_e('Inactive', 'ai-post-scheduler'); ?>
 											</span>
 										<?php endif; ?>
@@ -126,14 +126,14 @@ $inactive_count = isset($post_slice_counts['inactive']) ? (int) $post_slice_coun
 											<button type="button" class="aips-btn aips-btn-sm aips-edit-post-slice"
 												data-id="<?php echo esc_attr($slice_id); ?>"
 												title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
-												<span class="dashicons dashicons-edit"></span>
+												<span class="dashicons dashicons-edit" aria-hidden="true"></span>
 												<span class="screen-reader-text"><?php esc_html_e('Edit', 'ai-post-scheduler'); ?></span>
 											</button>
 											<button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-toggle-post-slice"
 												data-id="<?php echo esc_attr($slice_id); ?>"
 												data-active="<?php echo esc_attr($is_active); ?>"
 												title="<?php echo $is_active ? esc_attr__('Deactivate', 'ai-post-scheduler') : esc_attr__('Activate', 'ai-post-scheduler'); ?>">
-												<span class="dashicons <?php echo $is_active ? 'dashicons-hidden' : 'dashicons-visibility'; ?>"></span>
+												<span class="dashicons <?php echo $is_active ? 'dashicons-hidden' : 'dashicons-visibility'; ?>" aria-hidden="true"></span>
 												<span class="screen-reader-text">
 													<?php echo $is_active ? esc_html__('Deactivate', 'ai-post-scheduler') : esc_html__('Activate', 'ai-post-scheduler'); ?>
 												</span>
@@ -141,7 +141,7 @@ $inactive_count = isset($post_slice_counts['inactive']) ? (int) $post_slice_coun
 											<button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-post-slice"
 												data-id="<?php echo esc_attr($slice_id); ?>"
 												title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
-												<span class="dashicons dashicons-trash"></span>
+												<span class="dashicons dashicons-trash" aria-hidden="true"></span>
 												<span class="screen-reader-text"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></span>
 											</button>
 										</div>

--- a/ai-post-scheduler/templates/admin/research.php
+++ b/ai-post-scheduler/templates/admin/research.php
@@ -233,7 +233,7 @@ if (!in_array($active_tab, $valid_tabs, true)) {
                     </label>
                     
                     <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary" id="load-topics">
-                        <span class="dashicons dashicons-filter"></span>
+                        <span class="dashicons dashicons-filter" aria-hidden="true"></span>
                         <?php esc_html_e('Filter', 'ai-post-scheduler'); ?>
                     </button>
                 </div>
@@ -248,19 +248,19 @@ if (!in_array($active_tab, $valid_tabs, true)) {
             <div class="aips-panel-toolbar">
                 <div class="aips-toolbar-left">
                     <button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-btn-danger-solid" id="aips-delete-selected-topics" disabled>
-                        <span class="dashicons dashicons-trash"></span>
+                        <span class="dashicons dashicons-trash" aria-hidden="true"></span>
                         <?php esc_html_e('Delete', 'ai-post-scheduler'); ?>
                     </button>
                     <button type="button" class="aips-btn aips-btn-sm aips-btn-primary" id="aips-schedule-selected-topics" disabled>
-                        <span class="dashicons dashicons-calendar-alt"></span>
+                        <span class="dashicons dashicons-calendar-alt" aria-hidden="true"></span>
                         <?php esc_html_e('Schedule', 'ai-post-scheduler'); ?>
                     </button>
                     <button type="button" class="aips-btn aips-btn-sm aips-btn-primary" id="aips-generate-selected-topics" disabled>
-                        <span class="dashicons dashicons-media-text"></span>
+                        <span class="dashicons dashicons-media-text" aria-hidden="true"></span>
                         <?php esc_html_e('Generate', 'ai-post-scheduler'); ?>
                     </button>
                     <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary" id="aips-reload-topics-btn">
-                        <span class="dashicons dashicons-update"></span>
+                        <span class="dashicons dashicons-update" aria-hidden="true"></span>
                         <?php esc_html_e('Reload', 'ai-post-scheduler'); ?>
                     </button>
                 </div>
@@ -325,7 +325,7 @@ if (!in_array($active_tab, $valid_tabs, true)) {
                     </table>
                     <div style="margin-top: 8px; display: flex; align-items: center; gap: 12px;">
                         <button type="submit" class="aips-btn aips-btn-primary">
-                            <span class="dashicons dashicons-calendar-alt"></span>
+                            <span class="dashicons dashicons-calendar-alt" aria-hidden="true"></span>
                             <?php esc_html_e('Schedule Topics', 'ai-post-scheduler'); ?>
                         </button>
                         <span class="spinner" style="float: none; margin: 0;"></span>
@@ -346,7 +346,7 @@ if (!in_array($active_tab, $valid_tabs, true)) {
                 <div class="aips-gap-analysis-controls">
                     <input type="text" id="gap-niche" class="regular-text" placeholder="<?php esc_attr_e('Enter Target Niche (e.g., Sustainable Gardening)', 'ai-post-scheduler'); ?>">
                     <button type="button" class="aips-btn aips-btn-primary" id="analyze-gaps-btn">
-                        <span class="dashicons dashicons-chart-area"></span>
+                        <span class="dashicons dashicons-chart-area" aria-hidden="true"></span>
                         <?php esc_html_e('Analyze Site for Gaps', 'ai-post-scheduler'); ?>
                     </button>
                     <span class="spinner" style="float: none; margin-left: 10px;"></span>
@@ -403,7 +403,7 @@ if (!in_array($active_tab, $valid_tabs, true)) {
                 <button type="button" class="aips-btn aips-btn-secondary aips-modal-close"><?php esc_html_e('Cancel', 'ai-post-scheduler'); ?></button>
                 <?php if (!empty($templates)): ?>
                     <button type="button" class="aips-btn aips-btn-primary" id="aips-generate-now-confirm">
-                        <span class="dashicons dashicons-media-text"></span>
+                        <span class="dashicons dashicons-media-text" aria-hidden="true"></span>
                         <?php esc_html_e('Generate Now', 'ai-post-scheduler'); ?>
                     </button>
                 <?php endif; ?>
@@ -498,7 +498,7 @@ if (!in_array($active_tab, $valid_tabs, true)) {
             <td>
                 <div class="aips-topic-actions">
                     <button class="aips-btn aips-btn-sm aips-btn-danger delete-topic" data-id="{{id}}">
-                        <span class="dashicons dashicons-trash"></span> {{delete_label}}
+                        <span class="dashicons dashicons-trash" aria-hidden="true"></span> {{delete_label}}
                     </button>
                 </div>
             </td>

--- a/ai-post-scheduler/templates/admin/schedule.php
+++ b/ai-post-scheduler/templates/admin/schedule.php
@@ -170,12 +170,12 @@ if (!function_exists('aips_datetime_from_db_value')) {
 				<div class="aips-page-actions">
 					<?php if (!empty($templates)): ?>
 					<button class="aips-btn aips-btn-primary aips-add-schedule-btn">
-						<span class="dashicons dashicons-plus-alt"></span>
+						<span class="dashicons dashicons-plus-alt" aria-hidden="true"></span>
 						<?php esc_html_e('Add Template Schedule', 'ai-post-scheduler'); ?>
 					</button>
 					<?php else: ?>
 					<a href="<?php echo esc_url(AIPS_Admin_Menu_Helper::get_page_url('templates')); ?>" class="aips-btn aips-btn-secondary">
-						<span class="dashicons dashicons-media-document"></span>
+						<span class="dashicons dashicons-media-document" aria-hidden="true"></span>
 						<?php esc_html_e('Create Template First', 'ai-post-scheduler'); ?>
 					</a>
 					<?php endif; ?>
@@ -388,7 +388,7 @@ if (!function_exists('aips_datetime_from_db_value')) {
 						<td class="column-status">
 							<div class="aips-schedule-status-wrapper" style="display:flex;align-items:center;gap:8px;">
 								<span class="aips-badge <?php echo esc_attr($badge_cls); ?>">
-									<span class="dashicons <?php echo esc_attr($icon_cls); ?>"></span>
+									<span class="dashicons <?php echo esc_attr($icon_cls); ?>" aria-hidden="true"></span>
 									<?php echo esc_html($status_lbl); ?>
 								</span>
 								<label class="aips-toggle">
@@ -418,7 +418,7 @@ if (!function_exists('aips_datetime_from_db_value')) {
 									data-rotation-pattern="<?php echo esc_attr($sched['rotation_pattern'] ?? ''); ?>"
 									data-next-run="<?php echo esc_attr($sched['next_run'] ?? ''); ?>"
 									data-is-active="<?php echo esc_attr($is_active); ?>">
-									<span class="dashicons dashicons-edit"></span>
+									<span class="dashicons dashicons-edit" aria-hidden="true"></span>
 								</button>
 								<?php endif; ?>
 
@@ -428,7 +428,7 @@ if (!function_exists('aips_datetime_from_db_value')) {
 									data-type="<?php echo esc_attr($sched['type']); ?>"
 									aria-label="<?php esc_attr_e('Run now', 'ai-post-scheduler'); ?>"
 									title="<?php esc_attr_e('Run Now', 'ai-post-scheduler'); ?>">
-									<span class="dashicons dashicons-controls-play"></span>
+									<span class="dashicons dashicons-controls-play" aria-hidden="true"></span>
 								</button>
 
 								<!-- Delete (template schedules only) -->
@@ -437,13 +437,13 @@ if (!function_exists('aips_datetime_from_db_value')) {
 									data-id="<?php echo esc_attr($sched['id']); ?>"
 									aria-label="<?php esc_attr_e('Delete schedule', 'ai-post-scheduler'); ?>"
 									title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
-									<span class="dashicons dashicons-trash"></span>
+									<span class="dashicons dashicons-trash" aria-hidden="true"></span>
 								</button>
 								<?php elseif (!empty($sched['campaign_id'])): ?>
 								<button class="aips-btn aips-btn-sm aips-btn-danger" disabled
 									aria-label="<?php esc_attr_e('Delete schedule', 'ai-post-scheduler'); ?>"
 									title="<?php esc_attr_e('This schedule cannot be deleted here because it belongs to a campaign. Delete it from the Campaigns page.', 'ai-post-scheduler'); ?>">
-									<span class="dashicons dashicons-trash"></span>
+									<span class="dashicons dashicons-trash" aria-hidden="true"></span>
 								</button>
 								<?php endif; ?>
 							</div>
@@ -460,7 +460,7 @@ if (!function_exists('aips_datetime_from_db_value')) {
 					<p class="aips-empty-state-description"><?php esc_html_e('No schedules match your search criteria. Try a different search term.', 'ai-post-scheduler'); ?></p>
 					<div class="aips-empty-state-actions">
 						<button type="button" class="aips-btn aips-btn-primary aips-clear-unified-search-btn">
-							<span class="dashicons dashicons-dismiss"></span>
+							<span class="dashicons dashicons-dismiss" aria-hidden="true"></span>
 							<?php esc_html_e('Clear Search', 'ai-post-scheduler'); ?>
 						</button>
 					</div>
@@ -481,7 +481,7 @@ if (!function_exists('aips_datetime_from_db_value')) {
 					<?php if (!empty($templates)): ?>
 					<div class="aips-empty-state-actions">
 						<button class="aips-btn aips-btn-primary aips-add-schedule-btn">
-							<span class="dashicons dashicons-plus-alt"></span>
+							<span class="dashicons dashicons-plus-alt" aria-hidden="true"></span>
 							<?php esc_html_e('Add Template Schedule', 'ai-post-scheduler'); ?>
 						</button>
 					</div>

--- a/ai-post-scheduler/templates/admin/sections.php
+++ b/ai-post-scheduler/templates/admin/sections.php
@@ -18,7 +18,7 @@ if (!isset($sections) || !is_array($sections)) {
 				</div>
 				<div class="aips-page-actions">
 					<button class="aips-btn aips-btn-primary aips-add-section-btn">
-						<span class="dashicons dashicons-plus-alt"></span>
+						<span class="dashicons dashicons-plus-alt" aria-hidden="true"></span>
 						<?php esc_html_e('Add Section', 'ai-post-scheduler'); ?>
 					</button>
 				</div>
@@ -57,7 +57,7 @@ if (!isset($sections) || !is_array($sections)) {
 								<div class="aips-variable-code-cell">
 									<code><?php echo esc_html($section->section_key); ?></code>
 									<button type="button" class="aips-copy-btn" data-clipboard-text="{{section:<?php echo esc_attr($section->section_key); ?>}}" aria-label="<?php esc_attr_e('Copy placeholder', 'ai-post-scheduler'); ?>" title="<?php esc_attr_e('Copy placeholder', 'ai-post-scheduler'); ?>">
-										<span class="dashicons dashicons-admin-page"></span>
+										<span class="dashicons dashicons-admin-page" aria-hidden="true"></span>
 									</button>
 								</div>
 							</td>
@@ -65,22 +65,22 @@ if (!isset($sections) || !is_array($sections)) {
 							<td class="column-active">
 								<?php if ($section->is_active) : ?>
 									<span class="aips-badge aips-badge-success">
-										<span class="dashicons dashicons-yes-alt"></span>
+										<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
 										<?php esc_html_e('Active', 'ai-post-scheduler'); ?>
 									</span>
 								<?php else : ?>
 									<span class="aips-badge aips-badge-neutral">
-										<span class="dashicons dashicons-minus"></span>
+										<span class="dashicons dashicons-minus" aria-hidden="true"></span>
 										<?php esc_html_e('Inactive', 'ai-post-scheduler'); ?>
 									</span>
 								<?php endif; ?>
 							</td>
 							<td class="column-actions">
 								<button class="aips-btn aips-btn-sm aips-btn-ghost aips-edit-section" data-id="<?php echo esc_attr($section->id); ?>" aria-label="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
-									<span class="dashicons dashicons-edit"></span>
+									<span class="dashicons dashicons-edit" aria-hidden="true"></span>
 								</button>
 								<button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-section" data-id="<?php echo esc_attr($section->id); ?>" aria-label="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
-									<span class="dashicons dashicons-trash"></span>
+									<span class="dashicons dashicons-trash" aria-hidden="true"></span>
 								</button>
 							</td>
 						</tr>
@@ -96,7 +96,7 @@ if (!isset($sections) || !is_array($sections)) {
 				<p class="aips-empty-state-description"><?php esc_html_e('No prompt sections match your search criteria.', 'ai-post-scheduler'); ?></p>
 				<div class="aips-empty-state-actions">
 					<button type="button" class="aips-btn aips-btn-primary aips-clear-section-search-btn">
-						<span class="dashicons dashicons-dismiss"></span>
+						<span class="dashicons dashicons-dismiss" aria-hidden="true"></span>
 						<?php esc_html_e('Clear Search', 'ai-post-scheduler'); ?>
 					</button>
 				</div>
@@ -109,7 +109,7 @@ if (!isset($sections) || !is_array($sections)) {
 				<p class="aips-empty-state-description"><?php esc_html_e('Create reusable prompt sections that can be inserted into your article structures using placeholders like {{section:key}}.', 'ai-post-scheduler'); ?></p>
 				<div class="aips-empty-state-actions">
 					<button class="aips-btn aips-btn-primary aips-add-section-btn">
-						<span class="dashicons dashicons-plus-alt"></span>
+						<span class="dashicons dashicons-plus-alt" aria-hidden="true"></span>
 						<?php esc_html_e('Create First Section', 'ai-post-scheduler'); ?>
 					</button>
 				</div>

--- a/ai-post-scheduler/templates/admin/seeder.php
+++ b/ai-post-scheduler/templates/admin/seeder.php
@@ -23,7 +23,7 @@ if (!defined('ABSPATH')) {
 				<form id="aips-seeder-form">
 					<div class="aips-form-section">
 						<h3 class="aips-form-section-title">
-							<span class="dashicons dashicons-admin-generic"></span>
+							<span class="dashicons dashicons-admin-generic" aria-hidden="true"></span>
 							<?php esc_html_e('Seed Configuration', 'ai-post-scheduler'); ?>
 						</h3>
 
@@ -61,7 +61,7 @@ if (!defined('ABSPATH')) {
 
 <div class="aips-form-actions">
 <button type="submit" id="aips-seeder-submit" class="aips-btn aips-btn-primary aips-btn-lg">
-<span class="dashicons dashicons-database-add"></span>
+<span class="dashicons dashicons-database-add" aria-hidden="true"></span>
 <?php esc_html_e('Run Seeder', 'ai-post-scheduler'); ?>
 </button>
 <span class="spinner" style="float: none; margin-top: 4px;"></span>

--- a/ai-post-scheduler/templates/admin/sources.php
+++ b/ai-post-scheduler/templates/admin/sources.php
@@ -51,11 +51,11 @@ $is_embedded_sources_view = !empty($embedded);
 				</div>
 				<div class="aips-page-actions">
 					<button type="button" class="aips-btn aips-btn-secondary" id="aips-manage-source-groups-btn">
-						<span class="dashicons dashicons-category"></span>
+						<span class="dashicons dashicons-category" aria-hidden="true"></span>
 						<?php esc_html_e('Manage Groups', 'ai-post-scheduler'); ?>
 					</button>
 					<button type="button" class="aips-btn aips-btn-primary" id="aips-add-source-btn">
-						<span class="dashicons dashicons-plus-alt2"></span>
+						<span class="dashicons dashicons-plus-alt2" aria-hidden="true"></span>
 						<?php esc_html_e('Add Source', 'ai-post-scheduler'); ?>
 					</button>
 				</div>
@@ -131,7 +131,7 @@ $is_embedded_sources_view = !empty($embedded);
 							<td class="column-fetch-status">
 								<?php if ($content_count_val > 0): ?>
 									<span class="aips-badge aips-badge-success" title="<?php echo esc_attr($last_fetched_at); ?>">
-										<span class="dashicons dashicons-archive"></span>
+										<span class="dashicons dashicons-archive" aria-hidden="true"></span>
 										<?php
 										printf(
 											/* translators: %d = number of archived content snapshots */
@@ -142,12 +142,12 @@ $is_embedded_sources_view = !empty($embedded);
 									</span>
 								<?php elseif ($fetch_status_val === 'failed'): ?>
 									<span class="aips-badge aips-badge-warning">
-										<span class="dashicons dashicons-warning"></span>
+										<span class="dashicons dashicons-warning" aria-hidden="true"></span>
 										<?php esc_html_e('Failed', 'ai-post-scheduler'); ?>
 									</span>
 								<?php elseif ($fetch_status_val === 'pending'): ?>
 									<span class="aips-badge aips-badge-neutral">
-										<span class="dashicons dashicons-clock"></span>
+										<span class="dashicons dashicons-clock" aria-hidden="true"></span>
 										<?php esc_html_e('Pending', 'ai-post-scheduler'); ?>
 									</span>
 								<?php else: ?>
@@ -164,12 +164,12 @@ $is_embedded_sources_view = !empty($embedded);
 							<td class="column-status">
 								<?php if ($source->is_active): ?>
 									<span class="aips-badge aips-badge-success">
-										<span class="dashicons dashicons-yes-alt"></span>
+										<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
 										<?php esc_html_e('Active', 'ai-post-scheduler'); ?>
 									</span>
 								<?php else: ?>
 									<span class="aips-badge aips-badge-neutral">
-										<span class="dashicons dashicons-minus"></span>
+										<span class="dashicons dashicons-minus" aria-hidden="true"></span>
 										<?php esc_html_e('Inactive', 'ai-post-scheduler'); ?>
 									</span>
 								<?php endif; ?>
@@ -179,20 +179,20 @@ $is_embedded_sources_view = !empty($embedded);
 									<button class="aips-btn aips-btn-sm aips-edit-source"
 										data-id="<?php echo esc_attr($source->id); ?>"
 										title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
-										<span class="dashicons dashicons-edit"></span>
+										<span class="dashicons dashicons-edit" aria-hidden="true"></span>
 										<span class="screen-reader-text"><?php esc_html_e('Edit', 'ai-post-scheduler'); ?></span>
 									</button>
 									<button class="aips-btn aips-btn-sm aips-btn-secondary aips-fetch-source-now"
 										data-id="<?php echo esc_attr($source->id); ?>"
 										title="<?php esc_attr_e('Fetch content now', 'ai-post-scheduler'); ?>">
-										<span class="dashicons dashicons-download"></span>
+										<span class="dashicons dashicons-download" aria-hidden="true"></span>
 										<span class="screen-reader-text"><?php esc_html_e('Fetch Now', 'ai-post-scheduler'); ?></span>
 									</button>
 									<button class="aips-btn aips-btn-sm aips-btn-ghost aips-toggle-source"
 										data-id="<?php echo esc_attr($source->id); ?>"
 										data-active="<?php echo esc_attr($source->is_active); ?>"
 										title="<?php echo $source->is_active ? esc_attr__('Deactivate', 'ai-post-scheduler') : esc_attr__('Activate', 'ai-post-scheduler'); ?>">
-										<span class="dashicons <?php echo $source->is_active ? 'dashicons-hidden' : 'dashicons-visibility'; ?>"></span>
+										<span class="dashicons <?php echo $source->is_active ? 'dashicons-hidden' : 'dashicons-visibility'; ?>" aria-hidden="true"></span>
 										<span class="screen-reader-text">
 											<?php echo $source->is_active ? esc_html__('Deactivate', 'ai-post-scheduler') : esc_html__('Activate', 'ai-post-scheduler'); ?>
 										</span>
@@ -200,7 +200,7 @@ $is_embedded_sources_view = !empty($embedded);
 									<button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-source"
 										data-id="<?php echo esc_attr($source->id); ?>"
 										title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
-										<span class="dashicons dashicons-trash"></span>
+										<span class="dashicons dashicons-trash" aria-hidden="true"></span>
 										<span class="screen-reader-text"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></span>
 									</button>
 								</div>
@@ -370,7 +370,7 @@ $is_embedded_sources_view = !empty($embedded);
 										<button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-source-group"
 											data-term-id="<?php echo esc_attr($group->term_id); ?>"
 											title="<?php esc_attr_e('Delete group', 'ai-post-scheduler'); ?>">
-											<span class="dashicons dashicons-trash"></span>
+											<span class="dashicons dashicons-trash" aria-hidden="true"></span>
 										</button>
 									</td>
 								</tr>
@@ -387,7 +387,7 @@ $is_embedded_sources_view = !empty($embedded);
 				<input type="text" id="aips-new-group-name" class="regular-text"
 					placeholder="<?php esc_attr_e('New group name…', 'ai-post-scheduler'); ?>" style="flex:1;">
 				<button type="button" class="aips-btn aips-btn-primary" id="aips-add-group-btn">
-					<span class="dashicons dashicons-plus-alt2"></span>
+					<span class="dashicons dashicons-plus-alt2" aria-hidden="true"></span>
 					<?php esc_html_e('Add Group', 'ai-post-scheduler'); ?>
 				</button>
 			</div>

--- a/ai-post-scheduler/templates/admin/structures.php
+++ b/ai-post-scheduler/templates/admin/structures.php
@@ -24,11 +24,11 @@ if (!isset($sections) || !is_array($sections)) {
 				</div>
 				<div class="aips-page-actions">
 					<button type="button" class="aips-btn aips-btn-secondary aips-add-section-btn">
-						<span class="dashicons dashicons-plus-alt2"></span>
+						<span class="dashicons dashicons-plus-alt2" aria-hidden="true"></span>
 						<?php esc_html_e('Add Structure Section', 'ai-post-scheduler'); ?>
 					</button>
 					<button type="button" class="aips-btn aips-btn-primary aips-add-structure-btn">
-						<span class="dashicons dashicons-plus-alt2"></span>
+						<span class="dashicons dashicons-plus-alt2" aria-hidden="true"></span>
 						<?php esc_html_e('Add New Structure', 'ai-post-scheduler'); ?>
 					</button>
 				</div>
@@ -70,23 +70,23 @@ if (!isset($sections) || !is_array($sections)) {
 						<td class="column-description"><?php echo esc_html($structure->description); ?></td>
 						<td class="column-active">
 							<?php if ($structure->is_active): ?>
-								<span class="aips-badge aips-badge-success"><span class="dashicons dashicons-yes-alt"></span> <?php esc_html_e('Active', 'ai-post-scheduler'); ?></span>
+								<span class="aips-badge aips-badge-success"><span class="dashicons dashicons-yes-alt" aria-hidden="true"></span> <?php esc_html_e('Active', 'ai-post-scheduler'); ?></span>
 							<?php else: ?>
-								<span class="aips-badge aips-badge-neutral"><span class="dashicons dashicons-minus"></span> <?php esc_html_e('Inactive', 'ai-post-scheduler'); ?></span>
+								<span class="aips-badge aips-badge-neutral"><span class="dashicons dashicons-minus" aria-hidden="true"></span> <?php esc_html_e('Inactive', 'ai-post-scheduler'); ?></span>
 							<?php endif; ?>
 						</td>
 						<td class="column-actions">
 							<div class="aips-action-buttons">
 								<button class="aips-btn aips-btn-sm aips-edit-structure" data-id="<?php echo esc_attr($structure->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
-									<span class="dashicons dashicons-edit"></span>
+									<span class="dashicons dashicons-edit" aria-hidden="true"></span>
 									<span class="screen-reader-text"><?php esc_html_e('Edit', 'ai-post-scheduler'); ?></span>
 								</button>
 								<a class="aips-btn aips-btn-sm aips-btn-ghost" href="<?php echo esc_url(AIPS_Admin_Menu_Helper::get_page_url('aips-schedule', array('schedule_structure' => $structure->id))); ?>" title="<?php esc_attr_e('Schedule', 'ai-post-scheduler'); ?>">
-									<span class="dashicons dashicons-calendar-alt"></span>
+									<span class="dashicons dashicons-calendar-alt" aria-hidden="true"></span>
 									<span class="screen-reader-text"><?php esc_html_e('Schedule', 'ai-post-scheduler'); ?></span>
 								</a>
 								<button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-structure" data-id="<?php echo esc_attr($structure->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
-									<span class="dashicons dashicons-trash"></span>
+									<span class="dashicons dashicons-trash" aria-hidden="true"></span>
 									<span class="screen-reader-text"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></span>
 								</button>
 							</div>
@@ -123,7 +123,7 @@ if (!isset($sections) || !is_array($sections)) {
 				<p class="aips-empty-state-description"><?php esc_html_e('No article structures match your search criteria.', 'ai-post-scheduler'); ?></p>
 				<div class="aips-empty-state-actions">
 					<button type="button" class="aips-btn aips-btn-primary aips-clear-structure-search-btn">
-						<span class="dashicons dashicons-dismiss"></span>
+						<span class="dashicons dashicons-dismiss" aria-hidden="true"></span>
 						<?php esc_html_e('Clear Search', 'ai-post-scheduler'); ?>
 					</button>
 				</div>
@@ -173,19 +173,19 @@ if (!isset($sections) || !is_array($sections)) {
 						<td class="column-description"><?php echo esc_html($section->description); ?></td>
 						<td>
 							<?php if ($section->is_active): ?>
-								<span class="aips-badge aips-badge-success"><span class="dashicons dashicons-yes-alt"></span> <?php esc_html_e('Active', 'ai-post-scheduler'); ?></span>
+								<span class="aips-badge aips-badge-success"><span class="dashicons dashicons-yes-alt" aria-hidden="true"></span> <?php esc_html_e('Active', 'ai-post-scheduler'); ?></span>
 							<?php else: ?>
-								<span class="aips-badge aips-badge-neutral"><span class="dashicons dashicons-minus"></span> <?php esc_html_e('Inactive', 'ai-post-scheduler'); ?></span>
+								<span class="aips-badge aips-badge-neutral"><span class="dashicons dashicons-minus" aria-hidden="true"></span> <?php esc_html_e('Inactive', 'ai-post-scheduler'); ?></span>
 							<?php endif; ?>
 						</td>
 						<td>
 							<div class="aips-action-buttons">
 								<button class="aips-btn aips-btn-sm aips-edit-section" data-id="<?php echo esc_attr($section->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
-									<span class="dashicons dashicons-edit"></span>
+									<span class="dashicons dashicons-edit" aria-hidden="true"></span>
 									<span class="screen-reader-text"><?php esc_html_e('Edit', 'ai-post-scheduler'); ?></span>
 								</button>
 								<button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-section" data-id="<?php echo esc_attr($section->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
-									<span class="dashicons dashicons-trash"></span>
+									<span class="dashicons dashicons-trash" aria-hidden="true"></span>
 									<span class="screen-reader-text"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></span>
 								</button>
 							</div>
@@ -215,7 +215,7 @@ if (!isset($sections) || !is_array($sections)) {
 				<p class="aips-empty-state-description"><?php esc_html_e('No structure sections match your search criteria.', 'ai-post-scheduler'); ?></p>
 				<div class="aips-empty-state-actions">
 					<button type="button" class="aips-btn aips-btn-primary aips-clear-section-search-btn">
-						<span class="dashicons dashicons-dismiss"></span>
+						<span class="dashicons dashicons-dismiss" aria-hidden="true"></span>
 						<?php esc_html_e('Clear Search', 'ai-post-scheduler'); ?>
 					</button>
 				</div>
@@ -344,15 +344,15 @@ if (!isset($sections) || !is_array($sections)) {
 	<td class="column-actions">
 		<div class="aips-action-buttons">
 			<button class="aips-btn aips-btn-sm aips-edit-structure" data-id="{{id}}" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
-				<span class="dashicons dashicons-edit"></span>
+				<span class="dashicons dashicons-edit" aria-hidden="true"></span>
 				<span class="screen-reader-text"><?php esc_html_e('Edit', 'ai-post-scheduler'); ?></span>
 			</button>
 			<a class="aips-btn aips-btn-sm aips-btn-ghost" href="{{scheduleUrl}}" title="<?php esc_attr_e('Schedule', 'ai-post-scheduler'); ?>">
-				<span class="dashicons dashicons-calendar-alt"></span>
+				<span class="dashicons dashicons-calendar-alt" aria-hidden="true"></span>
 				<span class="screen-reader-text"><?php esc_html_e('Schedule', 'ai-post-scheduler'); ?></span>
 			</a>
 			<button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-structure" data-id="{{id}}" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
-				<span class="dashicons dashicons-trash"></span>
+				<span class="dashicons dashicons-trash" aria-hidden="true"></span>
 				<span class="screen-reader-text"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></span>
 			</button>
 		</div>
@@ -369,11 +369,11 @@ if (!isset($sections) || !is_array($sections)) {
 	<td>
 		<div class="aips-action-buttons">
 			<button class="aips-btn aips-btn-sm aips-edit-section" data-id="{{id}}" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
-				<span class="dashicons dashicons-edit"></span>
+				<span class="dashicons dashicons-edit" aria-hidden="true"></span>
 				<span class="screen-reader-text"><?php esc_html_e('Edit', 'ai-post-scheduler'); ?></span>
 			</button>
 			<button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-section" data-id="{{id}}" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
-				<span class="dashicons dashicons-trash"></span>
+				<span class="dashicons dashicons-trash" aria-hidden="true"></span>
 				<span class="screen-reader-text"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></span>
 			</button>
 		</div>

--- a/ai-post-scheduler/templates/admin/system-status.php
+++ b/ai-post-scheduler/templates/admin/system-status.php
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
                 </div>
                 <div class="aips-btn-group">
                     <a class="aips-btn aips-btn-primary" href="<?php echo esc_url(AIPS_Admin_Menu_Helper::get_page_url('onboarding')); ?>">
-                        <span class="dashicons dashicons-welcome-learn-more"></span>
+                        <span class="dashicons dashicons-welcome-learn-more" aria-hidden="true"></span>
                         <?php esc_html_e('Run Onboarding Wizard', 'ai-post-scheduler'); ?>
                     </a>
                 </div>
@@ -85,7 +85,7 @@ if (!defined('ABSPATH')) {
                                             <?php if (!empty($check['cb_open'])) : ?>
                                                 <br>
                                                 <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-reset-circuit-breaker" style="margin-top: 6px;">
-                                                    <span class="dashicons dashicons-controls-repeat"></span>
+                                                    <span class="dashicons dashicons-controls-repeat" aria-hidden="true"></span>
                                                     <?php esc_html_e('Reset Circuit', 'ai-post-scheduler'); ?>
                                                 </button>
                                                 <span class="aips-reset-circuit-result" style="display:none; margin-left: 8px;"></span>
@@ -94,22 +94,22 @@ if (!defined('ABSPATH')) {
                                         <td>
                                             <?php if ($check['status'] === 'ok') : ?>
                                                 <span class="aips-badge aips-badge-success">
-                                                    <span class="dashicons dashicons-yes-alt"></span>
+                                                    <span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
                                                     <?php esc_html_e('OK', 'ai-post-scheduler'); ?>
                                                 </span>
                                             <?php elseif ($check['status'] === 'warning') : ?>
                                                 <span class="aips-badge aips-badge-warning">
-                                                    <span class="dashicons dashicons-warning"></span>
+                                                    <span class="dashicons dashicons-warning" aria-hidden="true"></span>
                                                     <?php esc_html_e('Warning', 'ai-post-scheduler'); ?>
                                                 </span>
                                             <?php elseif ($check['status'] === 'error') : ?>
                                                 <span class="aips-badge aips-badge-error">
-                                                    <span class="dashicons dashicons-dismiss"></span>
+                                                    <span class="dashicons dashicons-dismiss" aria-hidden="true"></span>
                                                     <?php esc_html_e('Error', 'ai-post-scheduler'); ?>
                                                 </span>
                                             <?php else : ?>
                                                 <span class="aips-badge aips-badge-info">
-                                                    <span class="dashicons dashicons-info"></span>
+                                                    <span class="dashicons dashicons-info" aria-hidden="true"></span>
                                                     <?php esc_html_e('Info', 'ai-post-scheduler'); ?>
                                                 </span>
                                             <?php endif; ?>
@@ -126,7 +126,7 @@ if (!defined('ABSPATH')) {
             <div class="aips-status-actions-sections">
             <div class="aips-content-panel">
                 <div class="aips-panel-header">
-                    <h2><span class="dashicons dashicons-chart-area"></span> <?php esc_html_e('Unified Operations Health', 'ai-post-scheduler'); ?></h2>
+                    <h2><span class="dashicons dashicons-chart-area" aria-hidden="true"></span> <?php esc_html_e('Unified Operations Health', 'ai-post-scheduler'); ?></h2>
                 </div>
                 <div class="aips-panel-body">
                     <p><?php esc_html_e('Single-page visibility for telemetry, cron health, queue depth, failed jobs, and dependency status. Use the one-click operations below for safe recovery workflows.', 'ai-post-scheduler'); ?></p>
@@ -158,7 +158,7 @@ if (!defined('ABSPATH')) {
                 <div class="aips-content-panel">
                     <div class="aips-panel-header">
                         <h2>
-                            <span class="dashicons dashicons-clock"></span>
+                            <span class="dashicons dashicons-clock" aria-hidden="true"></span>
                             <?php esc_html_e('Cron Status', 'ai-post-scheduler'); ?>
                         </h2>
                     </div>
@@ -168,7 +168,7 @@ if (!defined('ABSPATH')) {
                         if ($next_scheduled) : ?>
                             <p class="aips-status-message aips-status-success">
                                 <span class="aips-badge aips-badge-success">
-                                    <span class="dashicons dashicons-yes-alt"></span>
+                                    <span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
                                     <?php esc_html_e('Active', 'ai-post-scheduler'); ?>
                                 </span>
                                 <?php
@@ -181,7 +181,7 @@ if (!defined('ABSPATH')) {
                         <?php else : ?>
                             <p class="aips-status-message aips-status-error">
                                 <span class="aips-badge aips-badge-warning">
-                                    <span class="dashicons dashicons-warning"></span>
+                                    <span class="dashicons dashicons-warning" aria-hidden="true"></span>
                                     <?php esc_html_e('Inactive', 'ai-post-scheduler'); ?>
                                 </span>
                                 <?php esc_html_e('Cron job is not scheduled. Try deactivating and reactivating the plugin.', 'ai-post-scheduler'); ?>
@@ -192,7 +192,7 @@ if (!defined('ABSPATH')) {
 
                         <div class="aips-btn-group aips-action-group">
                             <button type="button" class="aips-btn aips-btn-secondary aips-flush-cron">
-                                <span class="dashicons dashicons-controls-repeat"></span>
+                                <span class="dashicons dashicons-controls-repeat" aria-hidden="true"></span>
                                 <?php esc_html_e('Flush WP-Cron Events', 'ai-post-scheduler'); ?>
                             </button>
                         </div>
@@ -205,7 +205,7 @@ if (!defined('ABSPATH')) {
                 <div class="aips-content-panel">
                     <div class="aips-panel-header">
                         <h2>
-                            <span class="dashicons dashicons-admin-plugins"></span>
+                            <span class="dashicons dashicons-admin-plugins" aria-hidden="true"></span>
                             <?php esc_html_e('AI Engine Status', 'ai-post-scheduler'); ?>
                         </h2>
                     </div>
@@ -213,14 +213,14 @@ if (!defined('ABSPATH')) {
                         <?php if (class_exists('Meow_MWAI_Core')): ?>
                             <p class="aips-status-message aips-status-success">
                                 <span class="aips-badge aips-badge-success">
-                                    <span class="dashicons dashicons-yes-alt"></span>
+                                    <span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
                                     <?php esc_html_e('Connected', 'ai-post-scheduler'); ?>
                                 </span>
                                 <?php esc_html_e('AI Engine is installed and active.', 'ai-post-scheduler'); ?>
                             </p>
                             <div class="aips-test-connection-wrapper">
                                 <button type="button" id="aips-test-connection" class="aips-btn aips-btn-secondary">
-                                    <span class="dashicons dashicons-update"></span>
+                                    <span class="dashicons dashicons-update" aria-hidden="true"></span>
                                     <?php esc_html_e('Test Connection', 'ai-post-scheduler'); ?>
                                 </button>
                                 <span class="spinner aips-spinner-inline"></span>
@@ -229,14 +229,14 @@ if (!defined('ABSPATH')) {
                         <?php else: ?>
                             <p class="aips-status-message aips-status-error">
                                 <span class="aips-badge aips-badge-error">
-                                    <span class="dashicons dashicons-dismiss"></span>
+                                    <span class="dashicons dashicons-dismiss" aria-hidden="true"></span>
                                     <?php esc_html_e('Not Found', 'ai-post-scheduler'); ?>
                                 </span>
                                 <?php esc_html_e('AI Engine is not installed or not activated. Please install and activate the AI Engine plugin.', 'ai-post-scheduler'); ?>
                             </p>
                             <p class="aips-ai-engine-download-wrap">
                                 <a href="https://wordpress.org/plugins/ai-engine/" target="_blank" rel="noopener" class="aips-btn aips-btn-primary">
-                                    <span class="dashicons dashicons-download"></span>
+                                    <span class="dashicons dashicons-download" aria-hidden="true"></span>
                                     <?php esc_html_e('Download AI Engine', 'ai-post-scheduler'); ?>
                                 </a>
                             </p>
@@ -251,7 +251,7 @@ if (!defined('ABSPATH')) {
                 <div class="aips-content-panel">
                     <div class="aips-panel-header">
                         <h2>
-                            <span class="dashicons dashicons-database"></span>
+                            <span class="dashicons dashicons-database" aria-hidden="true"></span>
                             <?php esc_html_e('Database Management', 'ai-post-scheduler'); ?>
                         </h2>
                     </div>
@@ -260,22 +260,22 @@ if (!defined('ABSPATH')) {
 
                         <div class="aips-btn-group aips-db-actions">
                             <button type="button" class="aips-btn aips-btn-secondary aips-repair-db">
-                                <span class="dashicons dashicons-hammer"></span>
+                                <span class="dashicons dashicons-hammer" aria-hidden="true"></span>
                                 <?php esc_html_e('Repair DB Tables', 'ai-post-scheduler'); ?>
                             </button>
 
                             <button type="button" class="aips-btn aips-btn-secondary aips-fix-datetime-db">
-                                <span class="dashicons dashicons-clock"></span>
+                                <span class="dashicons dashicons-clock" aria-hidden="true"></span>
                                 <?php esc_html_e('Fix Date/Time Values in DB', 'ai-post-scheduler'); ?>
                             </button>
 
                             <button type="button" class="aips-btn aips-btn-secondary aips-reinstall-db">
-                                <span class="dashicons dashicons-update"></span>
+                                <span class="dashicons dashicons-update" aria-hidden="true"></span>
                                 <?php esc_html_e('Reinstall DB Tables', 'ai-post-scheduler'); ?>
                             </button>
 
                             <button type="button" class="aips-btn aips-btn-danger aips-wipe-db">
-                                <span class="dashicons dashicons-trash"></span>
+                                <span class="dashicons dashicons-trash" aria-hidden="true"></span>
                                 <?php esc_html_e('Wipe Plugin Data', 'ai-post-scheduler'); ?>
                             </button>
                         </div>
@@ -293,7 +293,7 @@ if (!defined('ABSPATH')) {
                 <div class="aips-content-panel">
                     <div class="aips-panel-header">
                         <h2>
-                            <span class="dashicons dashicons-migrate"></span>
+                            <span class="dashicons dashicons-migrate" aria-hidden="true"></span>
                             <?php esc_html_e('Data Management', 'ai-post-scheduler'); ?>
                         </h2>
                     </div>
@@ -312,7 +312,7 @@ if (!defined('ABSPATH')) {
                             <?php endforeach; ?>
                         </select>
                         <button type="button" class="aips-btn aips-btn-secondary aips-export-data">
-                            <span class="dashicons dashicons-download"></span>
+                            <span class="dashicons dashicons-download" aria-hidden="true"></span>
                             <?php esc_html_e('Export Data', 'ai-post-scheduler'); ?>
                         </button>
                     </div>
@@ -336,7 +336,7 @@ if (!defined('ABSPATH')) {
                         </label>
                         <input type="file" id="aips-import-file" class="aips-file-input">
                         <button type="button" class="aips-btn aips-btn-secondary aips-import-data">
-                            <span class="dashicons dashicons-upload"></span>
+                            <span class="dashicons dashicons-upload" aria-hidden="true"></span>
                             <?php esc_html_e('Import Data', 'ai-post-scheduler'); ?>
                         </button>
                     </div>
@@ -349,7 +349,7 @@ if (!defined('ABSPATH')) {
             <div class="aips-content-panel">
                 <div class="aips-panel-header">
                     <h2>
-                        <span class="dashicons dashicons-bell"></span>
+                        <span class="dashicons dashicons-bell" aria-hidden="true"></span>
                         <?php esc_html_e('Notifications Maintenance', 'ai-post-scheduler'); ?>
                     </h2>
                 </div>
@@ -358,7 +358,7 @@ if (!defined('ABSPATH')) {
 
                     <div class="aips-btn-group aips-action-group">
                         <button type="button" class="aips-btn aips-btn-secondary aips-notifications-hygiene">
-                            <span class="dashicons dashicons-admin-tools"></span>
+                            <span class="dashicons dashicons-admin-tools" aria-hidden="true"></span>
                             <?php esc_html_e('Run Notifications Hygiene', 'ai-post-scheduler'); ?>
                         </button>
                     </div>

--- a/ai-post-scheduler/templates/admin/tab-generated-posts.php
+++ b/ai-post-scheduler/templates/admin/tab-generated-posts.php
@@ -63,7 +63,7 @@ if (!defined('ABSPATH')) {
 							</select>
 							<?php endif; ?>
 							<button type="submit" id="aips-filter-submit" class="aips-btn aips-btn-sm aips-btn-secondary">
-								<span class="dashicons dashicons-filter"></span>
+								<span class="dashicons dashicons-filter" aria-hidden="true"></span>
 								<?php esc_html_e('Filter', 'ai-post-scheduler'); ?>
 							</button>
 							<?php if (!empty($author_id) || !empty($template_id) || !empty($campaign_id)): ?>
@@ -74,7 +74,7 @@ if (!defined('ABSPATH')) {
 							<label class="screen-reader-text" for="post-search-input"><?php esc_html_e('Search Posts:', 'ai-post-scheduler'); ?></label>
 							<input type="search" id="post-search-input" name="s" value="<?php echo esc_attr($search_query); ?>" class="aips-form-input" placeholder="<?php esc_attr_e('Search posts...', 'ai-post-scheduler'); ?>">
 							<button type="submit" class="aips-btn aips-btn-sm aips-btn-secondary">
-								<span class="dashicons dashicons-search"></span>
+								<span class="dashicons dashicons-search" aria-hidden="true"></span>
 								<?php esc_html_e('Search', 'ai-post-scheduler'); ?>
 							</button>
 							<?php if (!empty($search_query)): ?>
@@ -128,7 +128,7 @@ if (!defined('ABSPATH')) {
 											<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-edit-post"
 												data-edit-url="<?php echo esc_url($post_data['edit_link']); ?>"
 												title="<?php esc_attr_e('Edit this post', 'ai-post-scheduler'); ?>">
-												<span class="dashicons dashicons-edit"></span>
+												<span class="dashicons dashicons-edit" aria-hidden="true"></span>
 												<?php esc_html_e('Edit', 'ai-post-scheduler'); ?>
 											</button>
 											<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-row-action-overflow-toggle"
@@ -143,14 +143,14 @@ if (!defined('ABSPATH')) {
 											<button type="button" class="aips-row-action-item aips-preview-post"
 												data-post-id="<?php echo esc_attr($post_data['post_id']); ?>"
 												title="<?php esc_attr_e('Preview this post', 'ai-post-scheduler'); ?>">
-												<span class="dashicons dashicons-visibility"></span>
+												<span class="dashicons dashicons-visibility" aria-hidden="true"></span>
 												<span><?php esc_html_e('Preview', 'ai-post-scheduler'); ?></span>
 											</button>
 											<button type="button" class="aips-row-action-item aips-ai-edit-btn"
 												data-post-id="<?php echo esc_attr($post_data['post_id']); ?>"
 												data-history-id="<?php echo esc_attr($post_data['history_id']); ?>"
 												title="<?php esc_attr_e('AI Edit', 'ai-post-scheduler'); ?>">
-												<span class="dashicons dashicons-admin-customizer"></span>
+												<span class="dashicons dashicons-admin-customizer" aria-hidden="true"></span>
 												<span><?php esc_html_e('AI Edit', 'ai-post-scheduler'); ?></span>
 											</button>
 											<?php
@@ -164,13 +164,13 @@ if (!defined('ABSPATH')) {
 												data-history-id="<?php echo esc_attr($post_data['history_id']); ?>"
 												data-post-id="<?php echo esc_attr($post_data['post_id']); ?>"
 												title="<?php esc_attr_e('View history for this post', 'ai-post-scheduler'); ?>">
-												<span class="dashicons dashicons-backup"></span>
+												<span class="dashicons dashicons-backup" aria-hidden="true"></span>
 												<span><?php esc_html_e('History', 'ai-post-scheduler'); ?></span>
 											</a>
 											<button type="button" class="aips-row-action-item aips-view-session"
 												data-history-id="<?php echo esc_attr($post_data['history_id']); ?>"
 												title="<?php esc_attr_e('View Session', 'ai-post-scheduler'); ?>">
-												<span class="dashicons dashicons-visibility"></span>
+												<span class="dashicons dashicons-visibility" aria-hidden="true"></span>
 												<span><?php esc_html_e('View Session', 'ai-post-scheduler'); ?></span>
 											</button>
 										</div>
@@ -188,7 +188,7 @@ if (!defined('ABSPATH')) {
 							<p class="aips-empty-state-description"><?php esc_html_e('No generated posts match your search criteria. Try a different search term.', 'ai-post-scheduler'); ?></p>
 							<div class="aips-empty-state-actions">
 								<a href="<?php echo esc_url(remove_query_arg('s')); ?>" class="aips-btn aips-btn-primary">
-									<span class="dashicons dashicons-dismiss"></span>
+									<span class="dashicons dashicons-dismiss" aria-hidden="true"></span>
 									<?php esc_html_e('Clear Search', 'ai-post-scheduler'); ?>
 								</a>
 							</div>
@@ -200,11 +200,11 @@ if (!defined('ABSPATH')) {
 							<p class="aips-empty-state-description"><?php esc_html_e('No generated posts found. Start creating content by setting up templates and schedules.', 'ai-post-scheduler'); ?></p>
 							<div class="aips-empty-state-actions">
 								<a href="<?php echo esc_url(AIPS_Admin_Menu_Helper::get_page_url('templates')); ?>" class="aips-btn aips-btn-primary">
-									<span class="dashicons dashicons-plus-alt"></span>
+									<span class="dashicons dashicons-plus-alt" aria-hidden="true"></span>
 									<?php esc_html_e('Create Template', 'ai-post-scheduler'); ?>
 								</a>
 								<a href="<?php echo esc_url(AIPS_Admin_Menu_Helper::get_page_url('schedule')); ?>" class="aips-btn aips-btn-secondary">
-									<span class="dashicons dashicons-calendar-alt"></span>
+									<span class="dashicons dashicons-calendar-alt" aria-hidden="true"></span>
 									<?php esc_html_e('Manage Schedules', 'ai-post-scheduler'); ?>
 								</a>
 							</div>
@@ -238,11 +238,11 @@ if (!defined('ABSPATH')) {
 					<div class="aips-history-pagination-links">
 						<?php if ($current > 1): ?>
 							<a class="aips-btn aips-btn-sm aips-btn-secondary aips-history-page-prev" href="<?php echo esc_url($build_generated_posts_page_url($current - 1)); ?>" aria-label="<?php esc_attr_e('Previous page', 'ai-post-scheduler'); ?>">
-								<span class="dashicons dashicons-arrow-left-alt2"></span>
+								<span class="dashicons dashicons-arrow-left-alt2" aria-hidden="true"></span>
 							</a>
 						<?php else: ?>
 							<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-history-page-prev" disabled aria-label="<?php esc_attr_e('Previous page', 'ai-post-scheduler'); ?>">
-								<span class="dashicons dashicons-arrow-left-alt2"></span>
+								<span class="dashicons dashicons-arrow-left-alt2" aria-hidden="true"></span>
 							</button>
 						<?php endif; ?>
 
@@ -268,11 +268,11 @@ if (!defined('ABSPATH')) {
 
 						<?php if ($current < $pages): ?>
 							<a class="aips-btn aips-btn-sm aips-btn-secondary aips-history-page-next" href="<?php echo esc_url($build_generated_posts_page_url($current + 1)); ?>" aria-label="<?php esc_attr_e('Next page', 'ai-post-scheduler'); ?>">
-								<span class="dashicons dashicons-arrow-right-alt2"></span>
+								<span class="dashicons dashicons-arrow-right-alt2" aria-hidden="true"></span>
 							</a>
 						<?php else: ?>
 							<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-history-page-next" disabled aria-label="<?php esc_attr_e('Next page', 'ai-post-scheduler'); ?>">
-								<span class="dashicons dashicons-arrow-right-alt2"></span>
+								<span class="dashicons dashicons-arrow-right-alt2" aria-hidden="true"></span>
 							</button>
 						<?php endif; ?>
 					</div>

--- a/ai-post-scheduler/templates/admin/tab-partial-generations.php
+++ b/ai-post-scheduler/templates/admin/tab-partial-generations.php
@@ -51,7 +51,7 @@ if (!defined('ABSPATH')) {
 							</select>
 							<?php endif; ?>
 							<button type="submit" class="aips-btn aips-btn-sm aips-btn-secondary">
-								<span class="dashicons dashicons-filter"></span>
+								<span class="dashicons dashicons-filter" aria-hidden="true"></span>
 								<?php esc_html_e('Filter', 'ai-post-scheduler'); ?>
 							</button>
 							<?php if (!empty($author_id) || !empty($template_id)): ?>
@@ -62,7 +62,7 @@ if (!defined('ABSPATH')) {
 							<label class="screen-reader-text" for="aips-partial-search-input"><?php esc_html_e('Search Posts:', 'ai-post-scheduler'); ?></label>
 							<input type="search" id="aips-partial-search-input" name="s" value="<?php echo esc_attr($search_query); ?>" class="aips-form-input" placeholder="<?php esc_attr_e('Search posts...', 'ai-post-scheduler'); ?>">
 							<button type="submit" class="aips-btn aips-btn-sm aips-btn-secondary">
-								<span class="dashicons dashicons-search"></span>
+								<span class="dashicons dashicons-search" aria-hidden="true"></span>
 								<?php esc_html_e('Search', 'ai-post-scheduler'); ?>
 							</button>
 							<?php if (!empty($search_query)): ?>
@@ -128,7 +128,7 @@ if (!defined('ABSPATH')) {
 											<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-edit-post"
 												data-edit-url="<?php echo esc_url($post_data['edit_link']); ?>"
 												title="<?php esc_attr_e('Edit this post', 'ai-post-scheduler'); ?>">
-												<span class="dashicons dashicons-edit"></span>
+												<span class="dashicons dashicons-edit" aria-hidden="true"></span>
 												<?php esc_html_e('Edit', 'ai-post-scheduler'); ?>
 											</button>
 											<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-row-action-overflow-toggle"
@@ -143,20 +143,20 @@ if (!defined('ABSPATH')) {
 											<button type="button" class="aips-row-action-item aips-preview-post"
 												data-post-id="<?php echo esc_attr($post_data['post_id']); ?>"
 												title="<?php esc_attr_e('Preview this post', 'ai-post-scheduler'); ?>">
-												<span class="dashicons dashicons-visibility"></span>
+												<span class="dashicons dashicons-visibility" aria-hidden="true"></span>
 												<span><?php esc_html_e('Preview', 'ai-post-scheduler'); ?></span>
 											</button>
 											<button type="button" class="aips-row-action-item aips-ai-edit-btn"
 												data-post-id="<?php echo esc_attr($post_data['post_id']); ?>"
 												data-history-id="<?php echo esc_attr($post_data['history_id']); ?>"
 												title="<?php esc_attr_e('AI Edit', 'ai-post-scheduler'); ?>">
-												<span class="dashicons dashicons-admin-customizer"></span>
+												<span class="dashicons dashicons-admin-customizer" aria-hidden="true"></span>
 												<span><?php esc_html_e('AI Edit', 'ai-post-scheduler'); ?></span>
 											</button>
 											<button type="button" class="aips-row-action-item aips-view-session"
 												data-history-id="<?php echo esc_attr($post_data['history_id']); ?>"
 												title="<?php esc_attr_e('View Session', 'ai-post-scheduler'); ?>">
-												<span class="dashicons dashicons-visibility"></span>
+												<span class="dashicons dashicons-visibility" aria-hidden="true"></span>
 												<span><?php esc_html_e('View Session', 'ai-post-scheduler'); ?></span>
 											</button>
 										</div>
@@ -174,7 +174,7 @@ if (!defined('ABSPATH')) {
 							<p class="aips-empty-state-description"><?php esc_html_e('No partial generations match your search criteria. Try a different search term.', 'ai-post-scheduler'); ?></p>
 							<div class="aips-empty-state-actions">
 								<a href="<?php echo esc_url(remove_query_arg('s')); ?>" class="aips-btn aips-btn-primary">
-									<span class="dashicons dashicons-dismiss"></span>
+									<span class="dashicons dashicons-dismiss" aria-hidden="true"></span>
 									<?php esc_html_e('Clear Search', 'ai-post-scheduler'); ?>
 								</a>
 							</div>

--- a/ai-post-scheduler/templates/admin/tab-pending-review.php
+++ b/ai-post-scheduler/templates/admin/tab-pending-review.php
@@ -36,7 +36,7 @@ if (!defined('ABSPATH')) {
 								<?php endforeach; ?>
 							</select>
 							<button type="submit" class="aips-btn aips-btn-sm aips-btn-secondary">
-								<span class="dashicons dashicons-filter"></span>
+								<span class="dashicons dashicons-filter" aria-hidden="true"></span>
 								<?php esc_html_e('Filter', 'ai-post-scheduler'); ?>
 							</button>
 							<?php if (!empty($template_id)): ?>
@@ -48,7 +48,7 @@ if (!defined('ABSPATH')) {
 							<label class="screen-reader-text" for="aips-post-search-input"><?php esc_html_e('Search Posts:', 'ai-post-scheduler'); ?></label>
 							<input type="search" id="aips-post-search-input" name="s" value="<?php echo esc_attr($search_query); ?>" class="aips-form-input" placeholder="<?php esc_attr_e('Search posts...', 'ai-post-scheduler'); ?>">
 							<button type="submit" id="aips-post-search-btn" class="aips-btn aips-btn-sm aips-btn-secondary">
-								<span class="dashicons dashicons-search"></span>
+								<span class="dashicons dashicons-search" aria-hidden="true"></span>
 								<?php esc_html_e('Search', 'ai-post-scheduler'); ?>
 							</button>
 							<?php if (!empty($search_query)): ?>
@@ -72,7 +72,7 @@ if (!defined('ABSPATH')) {
 						</div>
 						<div class="aips-toolbar-right">
 							<button type="button" id="aips-reload-posts-btn" class="aips-btn aips-btn-sm aips-btn-secondary">
-								<span class="dashicons dashicons-update"></span>
+								<span class="dashicons dashicons-update" aria-hidden="true"></span>
 								<?php esc_html_e('Reload', 'ai-post-scheduler'); ?>
 							</button>
 						</div>
@@ -119,7 +119,7 @@ if (!defined('ABSPATH')) {
 													class="aips-btn aips-btn-sm aips-btn-primary aips-publish-post"
 													data-post-id="<?php echo esc_attr($item->post_id); ?>"
 													title="<?php esc_attr_e('Publish this post', 'ai-post-scheduler'); ?>">
-													<span class="dashicons dashicons-upload"></span>
+													<span class="dashicons dashicons-upload" aria-hidden="true"></span>
 													<?php esc_html_e('Publish', 'ai-post-scheduler'); ?>
 												</button>
 												<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-row-action-overflow-toggle"
@@ -134,20 +134,20 @@ if (!defined('ABSPATH')) {
 												<button type="button" class="aips-row-action-item aips-edit-post"
 													data-edit-url="<?php echo esc_url(get_edit_post_link($item->post_id)); ?>"
 													title="<?php esc_attr_e('Edit this post', 'ai-post-scheduler'); ?>">
-													<span class="dashicons dashicons-edit"></span>
+													<span class="dashicons dashicons-edit" aria-hidden="true"></span>
 													<span><?php esc_html_e('Edit', 'ai-post-scheduler'); ?></span>
 												</button>
 												<button type="button" class="aips-row-action-item aips-preview-post"
 													data-post-id="<?php echo esc_attr($item->post_id); ?>"
 													title="<?php esc_attr_e('Preview this post', 'ai-post-scheduler'); ?>">
-													<span class="dashicons dashicons-visibility"></span>
+													<span class="dashicons dashicons-visibility" aria-hidden="true"></span>
 													<span><?php esc_html_e('Preview', 'ai-post-scheduler'); ?></span>
 												</button>
 												<button type="button" class="aips-row-action-item aips-ai-edit-btn"
 													data-post-id="<?php echo esc_attr($item->post_id); ?>"
 													data-history-id="<?php echo esc_attr($item->id); ?>"
 													title="<?php esc_attr_e('AI Edit - Regenerate components', 'ai-post-scheduler'); ?>">
-													<span class="dashicons dashicons-admin-customizer"></span>
+													<span class="dashicons dashicons-admin-customizer" aria-hidden="true"></span>
 													<span><?php esc_html_e('AI Edit', 'ai-post-scheduler'); ?></span>
 												</button>
 												<?php
@@ -161,20 +161,20 @@ if (!defined('ABSPATH')) {
 													data-history-id="<?php echo esc_attr($item->id); ?>"
 													data-post-id="<?php echo esc_attr($item->post_id); ?>"
 													title="<?php esc_attr_e('View history for this post', 'ai-post-scheduler'); ?>">
-													<span class="dashicons dashicons-backup"></span>
+													<span class="dashicons dashicons-backup" aria-hidden="true"></span>
 													<span><?php esc_html_e('History', 'ai-post-scheduler'); ?></span>
 												</a>
 												<button type="button" class="aips-row-action-item aips-view-session"
 													data-history-id="<?php echo esc_attr($item->id); ?>"
 													title="<?php esc_attr_e('View generation session', 'ai-post-scheduler'); ?>">
-													<span class="dashicons dashicons-visibility"></span>
+													<span class="dashicons dashicons-visibility" aria-hidden="true"></span>
 													<span><?php esc_html_e('View Session', 'ai-post-scheduler'); ?></span>
 												</button>
 												<button type="button" class="aips-row-action-item aips-regenerate-post"
 													data-history-id="<?php echo esc_attr($item->id); ?>"
 													data-post-id="<?php echo esc_attr($item->post_id); ?>"
 													title="<?php esc_attr_e('Regenerate this post', 'ai-post-scheduler'); ?>">
-													<span class="dashicons dashicons-update"></span>
+													<span class="dashicons dashicons-update" aria-hidden="true"></span>
 													<span><?php esc_html_e('Re-generate', 'ai-post-scheduler'); ?></span>
 												</button>
 											</div>
@@ -195,7 +195,7 @@ if (!defined('ABSPATH')) {
 						<p class="aips-empty-state-description"><?php esc_html_e('No draft posts match your search criteria. Try a different search term.', 'ai-post-scheduler'); ?></p>
 						<div class="aips-empty-state-actions">
 							<a href="<?php echo esc_url(remove_query_arg('s')); ?>" class="aips-btn aips-btn-primary">
-								<span class="dashicons dashicons-dismiss"></span>
+								<span class="dashicons dashicons-dismiss" aria-hidden="true"></span>
 								<?php esc_html_e('Clear Search', 'ai-post-scheduler'); ?>
 							</a>
 						</div>
@@ -207,7 +207,7 @@ if (!defined('ABSPATH')) {
 						<p class="aips-empty-state-description"><?php esc_html_e('There are no draft posts waiting for review. All generated posts have been published or deleted.', 'ai-post-scheduler'); ?></p>
 						<div class="aips-empty-state-actions">
 							<a href="<?php echo esc_url(AIPS_Admin_Menu_Helper::get_page_url('schedule')); ?>" class="aips-btn aips-btn-secondary">
-								<span class="dashicons dashicons-calendar-alt"></span>
+								<span class="dashicons dashicons-calendar-alt" aria-hidden="true"></span>
 								<?php esc_html_e('Manage Schedules', 'ai-post-scheduler'); ?>
 							</a>
 						</div>
@@ -237,11 +237,11 @@ if (!defined('ABSPATH')) {
 					<div class="aips-history-pagination-links">
 						<?php if ($review_current_page > 1): ?>
 							<a class="aips-btn aips-btn-sm aips-btn-secondary" href="<?php echo esc_url($build_review_page_url($review_current_page - 1)); ?>" aria-label="<?php esc_attr_e('Previous page', 'ai-post-scheduler'); ?>">
-								<span class="dashicons dashicons-arrow-left-alt2"></span>
+								<span class="dashicons dashicons-arrow-left-alt2" aria-hidden="true"></span>
 							</a>
 						<?php else: ?>
 							<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary" disabled aria-label="<?php esc_attr_e('Previous page', 'ai-post-scheduler'); ?>">
-								<span class="dashicons dashicons-arrow-left-alt2"></span>
+								<span class="dashicons dashicons-arrow-left-alt2" aria-hidden="true"></span>
 							</button>
 						<?php endif; ?>
 
@@ -267,11 +267,11 @@ if (!defined('ABSPATH')) {
 
 						<?php if ($review_current_page < $draft_posts['pages']): ?>
 							<a class="aips-btn aips-btn-sm aips-btn-secondary" href="<?php echo esc_url($build_review_page_url($review_current_page + 1)); ?>" aria-label="<?php esc_attr_e('Next page', 'ai-post-scheduler'); ?>">
-								<span class="dashicons dashicons-arrow-right-alt2"></span>
+								<span class="dashicons dashicons-arrow-right-alt2" aria-hidden="true"></span>
 							</a>
 						<?php else: ?>
 							<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary" disabled aria-label="<?php esc_attr_e('Next page', 'ai-post-scheduler'); ?>">
-								<span class="dashicons dashicons-arrow-right-alt2"></span>
+								<span class="dashicons dashicons-arrow-right-alt2" aria-hidden="true"></span>
 							</button>
 						<?php endif; ?>
 					</div>

--- a/ai-post-scheduler/templates/admin/taxonomy.php
+++ b/ai-post-scheduler/templates/admin/taxonomy.php
@@ -33,7 +33,7 @@ $is_embedded_taxonomy_view = !empty($embedded);
 				</div>
 				<div class="aips-page-actions">
 					<button class="aips-btn aips-btn-primary aips-generate-taxonomy" id="aips-open-generate-modal">
-						<span class="dashicons dashicons-update"></span>
+						<span class="dashicons dashicons-update" aria-hidden="true"></span>
 						<?php esc_html_e('Generate Taxonomy', 'ai-post-scheduler'); ?>
 					</button>
 				</div>

--- a/ai-post-scheduler/templates/admin/telemetry.php
+++ b/ai-post-scheduler/templates/admin/telemetry.php
@@ -28,7 +28,7 @@ if (!defined('ABSPATH')) {
 				<div class="aips-content-panel aips-telemetry-records-panel">
 					<div class="aips-panel-header aips-telemetry-records-header">
 						<h2>
-							<span class="dashicons dashicons-list-view"></span>
+							<span class="dashicons dashicons-list-view" aria-hidden="true"></span>
 							<?php esc_html_e('Records', 'ai-post-scheduler'); ?>
 						</h2>
 						<div class="aips-telemetry-header-actions">
@@ -41,7 +41,7 @@ if (!defined('ABSPATH')) {
 								</select>
 							</label>
 							<button type="button" class="aips-btn aips-btn-secondary aips-telemetry-refresh">
-								<span class="dashicons dashicons-update"></span>
+								<span class="dashicons dashicons-update" aria-hidden="true"></span>
 								<?php esc_html_e('Refresh', 'ai-post-scheduler'); ?>
 							</button>
 						</div>
@@ -96,11 +96,11 @@ if (!defined('ABSPATH')) {
 							<div class="aips-telemetry-filter-actions">
 								<div class="aips-telemetry-filter-buttons">
 									<button type="button" class="aips-btn aips-btn-primary" id="aips-telemetry-apply-filters">
-										<span class="dashicons dashicons-filter"></span>
+										<span class="dashicons dashicons-filter" aria-hidden="true"></span>
 										<?php esc_html_e('Filter', 'ai-post-scheduler'); ?>
 									</button>
 									<button type="button" class="aips-btn aips-btn-secondary" id="aips-telemetry-reset-filters">
-										<span class="dashicons dashicons-update"></span>
+										<span class="dashicons dashicons-update" aria-hidden="true"></span>
 										<?php esc_html_e('Reset Filters', 'ai-post-scheduler'); ?>
 									</button>
 								</div>
@@ -136,11 +136,11 @@ if (!defined('ABSPATH')) {
 							</div>
 							<div class="aips-toolbar-right aips-btn-group">
 								<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary" id="aips-telemetry-prev" disabled>
-									<span class="dashicons dashicons-arrow-left-alt2"></span>
+									<span class="dashicons dashicons-arrow-left-alt2" aria-hidden="true"></span>
 									<span class="screen-reader-text"><?php esc_html_e('Previous page', 'ai-post-scheduler'); ?></span>
 								</button>
 								<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary" id="aips-telemetry-next" disabled>
-									<span class="dashicons dashicons-arrow-right-alt2"></span>
+									<span class="dashicons dashicons-arrow-right-alt2" aria-hidden="true"></span>
 									<span class="screen-reader-text"><?php esc_html_e('Next page', 'ai-post-scheduler'); ?></span>
 								</button>
 							</div>
@@ -152,7 +152,7 @@ if (!defined('ABSPATH')) {
 				<div class="aips-content-panel aips-telemetry-charts-panel">
 					<div class="aips-panel-header">
 						<h2>
-							<span class="dashicons dashicons-chart-area"></span>
+							<span class="dashicons dashicons-chart-area" aria-hidden="true"></span>
 							<?php esc_html_e('Charts', 'ai-post-scheduler'); ?>
 						</h2>
 					</div>
@@ -207,7 +207,7 @@ if (!defined('ABSPATH')) {
 </script>
 
 <script type="text/html" id="aips-tmpl-telemetry-refresh-button-content">
-	<span class="dashicons dashicons-update"></span>
+	<span class="dashicons dashicons-update" aria-hidden="true"></span>
 	{{label}}
 </script>
 
@@ -222,7 +222,7 @@ if (!defined('ABSPATH')) {
 		<td>{{inserted_at}}</td>
 		<td>
 			<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-telemetry-view-details" data-telemetry-id="{{raw_id}}" aria-label="{{view_details_label}}">
-				<span class="dashicons dashicons-visibility"></span>
+				<span class="dashicons dashicons-visibility" aria-hidden="true"></span>
 			</button>
 		</td>
 	</tr>

--- a/ai-post-scheduler/templates/admin/templates.php
+++ b/ai-post-scheduler/templates/admin/templates.php
@@ -16,7 +16,7 @@ $is_embedded_templates_view = !empty($embedded);
                 </div>
                 <div class="aips-page-actions">
                     <button class="aips-btn aips-btn-primary aips-add-template-btn">
-                        <span class="dashicons dashicons-plus-alt"></span>
+                        <span class="dashicons dashicons-plus-alt" aria-hidden="true"></span>
                         <?php esc_html_e('Add Template', 'ai-post-scheduler'); ?>
                     </button>
                 </div>
@@ -128,12 +128,12 @@ $is_embedded_templates_view = !empty($embedded);
                             <td>
                                 <?php if ($template->is_active): ?>
                                 <span class="aips-badge aips-badge-success">
-                                    <span class="dashicons dashicons-yes-alt"></span>
+                                    <span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
                                     <?php esc_html_e('Active', 'ai-post-scheduler'); ?>
                                 </span>
                                 <?php else: ?>
                                 <span class="aips-badge aips-badge-neutral">
-                                    <span class="dashicons dashicons-minus"></span>
+                                    <span class="dashicons dashicons-minus" aria-hidden="true"></span>
                                     <?php esc_html_e('Inactive', 'ai-post-scheduler'); ?>
                                 </span>
                                 <?php endif; ?>
@@ -141,23 +141,23 @@ $is_embedded_templates_view = !empty($embedded);
                             <td>
                                 <div class="cell-actions">
                                     <button class="aips-btn aips-btn-sm aips-btn-secondary aips-edit-template" data-id="<?php echo esc_attr($template->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
-                                        <span class="dashicons dashicons-edit"></span>
+                                        <span class="dashicons dashicons-edit" aria-hidden="true"></span>
                                         <?php esc_html_e('Edit', 'ai-post-scheduler'); ?>
                                     </button>
                                     <button class="aips-btn aips-btn-sm aips-btn-secondary aips-run-now" data-id="<?php echo esc_attr($template->id); ?>" title="<?php esc_attr_e('Run Now', 'ai-post-scheduler'); ?>">
-                                        <span class="dashicons dashicons-controls-play"></span>
+                                        <span class="dashicons dashicons-controls-play" aria-hidden="true"></span>
                                         <?php esc_html_e('Run Now', 'ai-post-scheduler'); ?>
                                     </button>
                                     <a class="aips-btn aips-btn-sm aips-btn-ghost" href="<?php echo esc_url(AIPS_Admin_Menu_Helper::get_page_url('schedule', array('schedule_template' => $template->id))); ?>" title="<?php esc_attr_e('Schedule', 'ai-post-scheduler'); ?>">
-                                        <span class="dashicons dashicons-calendar-alt"></span>
+                                        <span class="dashicons dashicons-calendar-alt" aria-hidden="true"></span>
                                         <span class="screen-reader-text"><?php esc_html_e('Schedule', 'ai-post-scheduler'); ?></span>
                                     </a>
                                     <button class="aips-btn aips-btn-sm aips-btn-ghost aips-clone-template" data-id="<?php echo esc_attr($template->id); ?>" title="<?php esc_attr_e('Clone', 'ai-post-scheduler'); ?>">
-                                        <span class="dashicons dashicons-admin-page"></span>
+                                        <span class="dashicons dashicons-admin-page" aria-hidden="true"></span>
                                         <span class="screen-reader-text"><?php esc_html_e('Clone', 'ai-post-scheduler'); ?></span>
                                     </button>
                                     <button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-template" data-id="<?php echo esc_attr($template->id); ?>" title="<?php echo !empty($template->campaign_id) ? esc_attr__('This template cannot be deleted here because it belongs to a campaign. Delete it from the Campaigns page.', 'ai-post-scheduler') : esc_attr__('Delete', 'ai-post-scheduler'); ?>" <?php disabled(!empty($template->campaign_id)); ?>>
-                                        <span class="dashicons dashicons-trash"></span>
+                                        <span class="dashicons dashicons-trash" aria-hidden="true"></span>
                                         <span class="screen-reader-text"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></span>
                                     </button>
                                 </div>
@@ -174,7 +174,7 @@ $is_embedded_templates_view = !empty($embedded);
                     <p class="aips-empty-state-description"><?php esc_html_e('No templates match your search criteria. Try a different search term.', 'ai-post-scheduler'); ?></p>
                     <div class="aips-empty-state-actions">
                         <button type="button" class="aips-btn aips-btn-primary aips-clear-search-btn">
-                            <span class="dashicons dashicons-dismiss"></span>
+                            <span class="dashicons dashicons-dismiss" aria-hidden="true"></span>
                             <?php esc_html_e('Clear Search', 'ai-post-scheduler'); ?>
                         </button>
                     </div>
@@ -210,7 +210,7 @@ $is_embedded_templates_view = !empty($embedded);
                     <p class="aips-empty-state-description"><?php esc_html_e('Templates define how your AI-generated posts are structured. Create your first template to start generating content automatically.', 'ai-post-scheduler'); ?></p>
                     <div class="aips-empty-state-actions">
                         <button class="aips-btn aips-btn-primary aips-add-template-btn">
-                            <span class="dashicons dashicons-plus-alt"></span>
+                            <span class="dashicons dashicons-plus-alt" aria-hidden="true"></span>
                             <?php esc_html_e('Create Template', 'ai-post-scheduler'); ?>
                         </button>
                     </div>
@@ -303,7 +303,7 @@ $is_embedded_templates_view = !empty($embedded);
                         <!-- AI Variables Panel -->
                         <div class="aips-form-row aips-ai-variables-panel" style="display: none;">
                             <div class="aips-ai-variables-header">
-                                <span class="dashicons dashicons-admin-generic"></span>
+                                <span class="dashicons dashicons-admin-generic" aria-hidden="true"></span>
                                 <strong><?php esc_html_e('AI Variables Detected', 'ai-post-scheduler'); ?></strong>
                                 <span class="aips-ai-variables-hint"><?php esc_html_e('(Click to copy)', 'ai-post-scheduler'); ?></span>
                             </div>
@@ -312,7 +312,7 @@ $is_embedded_templates_view = !empty($embedded);
                             </div>
                             <div class="aips-ai-variables-info">
                                 <p class="description">
-                                    <span class="dashicons dashicons-info"></span>
+                                    <span class="dashicons dashicons-info" aria-hidden="true"></span>
                                     <?php esc_html_e('These variables will be dynamically resolved by AI based on your generated content. Each post generation may produce different values.', 'ai-post-scheduler'); ?>
                                 </p>
                             </div>
@@ -321,7 +321,7 @@ $is_embedded_templates_view = !empty($embedded);
                         <div class="aips-form-row aips-ai-variables-instructions">
                             <details class="aips-collapsible">
                                 <summary>
-                                    <span class="dashicons dashicons-editor-help"></span>
+                                    <span class="dashicons dashicons-editor-help" aria-hidden="true"></span>
                                     <?php esc_html_e('How to use AI Variables', 'ai-post-scheduler'); ?>
                                 </summary>
                                 <div class="aips-collapsible-content">
@@ -569,15 +569,15 @@ $is_embedded_templates_view = !empty($embedded);
                             
                             <div class="aips-next-steps-grid" style="display: flex; gap: 16px; justify-content: center; flex-wrap: wrap; max-width: 600px; margin: 0 auto;">
                                 <a href="#" id="aips-quick-schedule-btn" class="aips-btn aips-btn-primary" style="display: inline-flex; align-items: center; gap: 6px; padding: 10px 20px; font-size: 14px; text-decoration: none;">
-                                    <span class="dashicons dashicons-calendar-alt"></span>
+                                    <span class="dashicons dashicons-calendar-alt" aria-hidden="true"></span>
                                     <?php esc_html_e('Schedule This Template', 'ai-post-scheduler'); ?>
                                 </a>
                                 <button type="button" id="aips-quick-run-now-btn" class="aips-btn aips-btn-secondary" style="display: inline-flex; align-items: center; gap: 6px; padding: 10px 20px; font-size: 14px;">
-                                    <span class="dashicons dashicons-controls-play"></span>
+                                    <span class="dashicons dashicons-controls-play" aria-hidden="true"></span>
                                     <?php esc_html_e('Run Now', 'ai-post-scheduler'); ?>
                                 </button>
                                 <button type="button" id="aips-post-save-done-btn" class="aips-btn aips-btn-ghost" style="display: inline-flex; align-items: center; gap: 6px; padding: 10px 20px; font-size: 14px;">
-                                    <span class="dashicons dashicons-dismiss"></span>
+                                    <span class="dashicons dashicons-dismiss" aria-hidden="true"></span>
                                     <?php esc_html_e('Done', 'ai-post-scheduler'); ?>
                                 </button>
                             </div>
@@ -588,21 +588,21 @@ $is_embedded_templates_view = !empty($embedded);
             <div class="aips-modal-footer aips-wizard-footer">
                 <div class="aips-footer-left">
                     <button type="button" class="aips-btn aips-btn-secondary aips-wizard-back" style="display: none;">
-                        <span class="dashicons dashicons-arrow-left-alt2"></span>
+                        <span class="dashicons dashicons-arrow-left-alt2" aria-hidden="true"></span>
                         <?php esc_html_e('Back', 'ai-post-scheduler'); ?>
                     </button>
                 </div>
                 <div class="aips-footer-center">
                     <button type="button" class="aips-btn aips-btn-secondary aips-save-draft-template" title="<?php esc_attr_e('Save current progress as inactive template', 'ai-post-scheduler'); ?>">
-                        <span class="dashicons dashicons-cloud-saved"></span>
+                        <span class="dashicons dashicons-cloud-saved" aria-hidden="true"></span>
                         <?php esc_html_e('Save Draft', 'ai-post-scheduler'); ?>
                     </button>
                     <button type="button" class="aips-btn aips-btn-secondary aips-test-template" title="<?php esc_attr_e('Generate a sample post using current settings', 'ai-post-scheduler'); ?>">
-                        <span class="dashicons dashicons-controls-play"></span>
+                        <span class="dashicons dashicons-controls-play" aria-hidden="true"></span>
                         <?php esc_html_e('Test Generation', 'ai-post-scheduler'); ?>
                     </button>
                     <button type="button" class="aips-btn aips-btn-secondary aips-preview-prompts" title="<?php esc_attr_e('Preview the prompts that will be sent to AI', 'ai-post-scheduler'); ?>">
-                        <span class="dashicons dashicons-visibility"></span>
+                        <span class="dashicons dashicons-visibility" aria-hidden="true"></span>
                         <?php esc_html_e('Preview Prompts', 'ai-post-scheduler'); ?>
                     </button>
                 </div>
@@ -612,7 +612,7 @@ $is_embedded_templates_view = !empty($embedded);
                     </button>
                     <button type="button" class="aips-btn aips-btn-primary aips-wizard-next">
                         <?php esc_html_e('Next', 'ai-post-scheduler'); ?>
-                        <span class="dashicons dashicons-arrow-right-alt2"></span>
+                        <span class="dashicons dashicons-arrow-right-alt2" aria-hidden="true"></span>
                     </button>
                     <button type="button" class="aips-btn aips-btn-secondary aips-save-template aips-wizard-save-btn">
                         <?php esc_html_e('Save Template', 'ai-post-scheduler'); ?>
@@ -624,7 +624,7 @@ $is_embedded_templates_view = !empty($embedded);
             <div class="aips-preview-drawer" id="aips-preview-drawer">
                 <div class="aips-preview-drawer-toggle">
                     <button type="button" class="aips-preview-drawer-handle" aria-label="<?php esc_attr_e('Toggle preview drawer', 'ai-post-scheduler'); ?>">
-                        <span class="dashicons dashicons-arrow-down-alt2"></span>
+                        <span class="dashicons dashicons-arrow-down-alt2" aria-hidden="true"></span>
                         <span class="aips-preview-drawer-label"><?php esc_html_e('Prompt Preview', 'ai-post-scheduler'); ?></span>
                     </button>
                 </div>
@@ -721,7 +721,7 @@ $is_embedded_templates_view = !empty($embedded);
             </div>
             <div class="aips-modal-body">
                 <div class="aips-post-success-summary">
-                    <span class="dashicons dashicons-yes-alt aips-post-success-icon"></span>
+                    <span class="dashicons dashicons-yes-alt aips-post-success-icon" aria-hidden="true"></span>
                     <p class="aips-post-success-message" id="aips-success-message"><?php esc_html_e('1 post has been generated.', 'ai-post-scheduler'); ?></p>
                     <p id="aips-success-note" class="description aips-post-success-note" style="display: none;"></p>
                 </div>

--- a/ai-post-scheduler/templates/admin/voices.php
+++ b/ai-post-scheduler/templates/admin/voices.php
@@ -16,7 +16,7 @@ if (!defined('ABSPATH')) {
                 </div>
                 <div class="aips-page-actions">
                     <button class="aips-btn aips-btn-primary aips-add-voice-btn">
-                        <span class="dashicons dashicons-plus-alt2"></span>
+                        <span class="dashicons dashicons-plus-alt2" aria-hidden="true"></span>
                         <?php esc_html_e('Add Voice', 'ai-post-scheduler'); ?>
                     </button>
                 </div>
@@ -63,12 +63,12 @@ if (!defined('ABSPATH')) {
                                 <td class="column-status">
                                     <?php if ($voice->is_active): ?>
                                         <span class="aips-badge aips-badge-success">
-                                            <span class="dashicons dashicons-yes-alt"></span>
+                                            <span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
                                             <?php esc_html_e('Active', 'ai-post-scheduler'); ?>
                                         </span>
                                     <?php else: ?>
                                         <span class="aips-badge aips-badge-neutral">
-                                            <span class="dashicons dashicons-minus"></span>
+                                            <span class="dashicons dashicons-minus" aria-hidden="true"></span>
                                             <?php esc_html_e('Inactive', 'ai-post-scheduler'); ?>
                                         </span>
                                     <?php endif; ?>
@@ -76,11 +76,11 @@ if (!defined('ABSPATH')) {
                                 <td class="column-actions">
                                     <div class="aips-action-buttons">
                                         <button class="aips-btn aips-btn-sm aips-edit-voice" data-id="<?php echo esc_attr($voice->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
-                                            <span class="dashicons dashicons-edit"></span>
+                                            <span class="dashicons dashicons-edit" aria-hidden="true"></span>
                                             <span class="screen-reader-text"><?php esc_html_e('Edit', 'ai-post-scheduler'); ?></span>
                                         </button>
                                         <button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-voice" data-id="<?php echo esc_attr($voice->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
-                                            <span class="dashicons dashicons-trash"></span>
+                                            <span class="dashicons dashicons-trash" aria-hidden="true"></span>
                                             <span class="screen-reader-text"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></span>
                                         </button>
                                     </div>
@@ -105,7 +105,7 @@ if (!defined('ABSPATH')) {
                     <p class="aips-empty-state-description"><?php esc_html_e('No voices match your search criteria.', 'ai-post-scheduler'); ?></p>
                     <div class="aips-empty-state-actions">
                         <button type="button" class="aips-btn aips-btn-primary aips-clear-voice-search-btn">
-                            <span class="dashicons dashicons-dismiss"></span>
+                            <span class="dashicons dashicons-dismiss" aria-hidden="true"></span>
                             <?php esc_html_e('Clear Search', 'ai-post-scheduler'); ?>
                         </button>
                     </div>
@@ -119,7 +119,7 @@ if (!defined('ABSPATH')) {
                     <p class="aips-empty-state-description"><?php esc_html_e('Create a voice to establish consistent tone and style for your generated posts.', 'ai-post-scheduler'); ?></p>
                     <div class="aips-empty-state-actions">
                         <button class="aips-btn aips-btn-primary aips-btn-lg aips-add-voice-btn">
-                            <span class="dashicons dashicons-plus-alt2"></span>
+                            <span class="dashicons dashicons-plus-alt2" aria-hidden="true"></span>
                             <?php esc_html_e('Create Voice', 'ai-post-scheduler'); ?>
                         </button>
                     </div>


### PR DESCRIPTION
**What:**
Added `aria-hidden="true"` to all decorative Dashicon `<span class="dashicons ...">` elements across the WordPress admin templates in the plugin.

**Why:**
Screen readers will often attempt to read out the icon font characters (sometimes pronouncing them as confusing Unicode names or random letters) if they are not explicitly hidden from the accessibility tree. By adding `aria-hidden="true"`, we ensure that these decorative visual elements are ignored by assistive technologies, providing a cleaner and less confusing experience for users relying on screen readers.

**Accessibility:**
This directly addresses WCAG standards regarding decorative imagery by preventing screen readers from announcing non-essential icon fonts. It correctly complements the existing `aria-label`s on buttons and standard visible text labels in the templates.

**Verification:**
1. Checkout this branch.
2. Visit any admin page within the plugin (e.g. Dashboard, Structures, Templates).
3. Inspect any Dashicon element (`<span class="dashicons...">`) and verify it now contains `aria-hidden="true"`.
4. Run a screen reader (like VoiceOver or NVDA) and navigate through the elements to confirm the icons are silently skipped.

---
*PR created automatically by Jules for task [16840778655216056804](https://jules.google.com/task/16840778655216056804) started by @rpnunez*