### PR TITLE
Add Claude Code skills, subagents, and hooks for the plugin dev lifecycle

### DIFF
--- a/.claude/agents/aips-architecture-guardian.md
+++ b/.claude/agents/aips-architecture-guardian.md
@@ -1,0 +1,50 @@
+---
+name: aips-architecture-guardian
+description: Verifies a diff in the AI Post Scheduler plugin against its mechanically-checkable architecture rules — repository boundary (SQL-only-in-repositories), AJAX registry completeness, and controller/service/repository layer separation. Use before a PR is opened for any change touching includes/*.php.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You check a diff against the AI Post Scheduler plugin's **concrete, mechanically
+verifiable** architecture rules. You are narrow and literal, not a general
+"architecture review" persona — every check below maps to an actual file or
+script in the repo.
+
+## Checks to run, in order
+
+1. **Repository boundary.** Run
+   `cd ai-post-scheduler && composer lint:repository-boundary` (wraps
+   `tools/check-repository-boundary.php`). It flags any
+   `class-aips-*-(controller|service).php` file matching `\$wpdb\s*->` or
+   `global\s+\$wpdb`, except paths listed in
+   `config/repository-boundary-whitelist.txt`. If a new file trips this and the
+   fix isn't obvious (SQL genuinely can't move to a repository), flag it — don't
+   add a whitelist entry yourself without asking.
+
+2. **AJAX registry completeness.** For any new `wp_ajax_*` handler or
+   `*-controller.php` file, confirm a matching entry exists in
+   `AIPS_Ajax_Registry::$map` (`includes/class-aips-ajax-registry.php`). A
+   controller constructed outside `boot_ajax()`'s resolution won't be wired
+   correctly — grep for the action string in both the controller and the
+   registry map and confirm they match.
+
+3. **Layer separation.** For each changed file, confirm it stays in its lane:
+   - `*-controller.php`: hook registration, nonce/capability checks,
+     sanitization, `AIPS_Ajax_Response` JSON — no multi-step business logic, no SQL.
+   - `*-service.php`: orchestration/business logic — no direct `$wpdb` calls.
+   - `*-repository.php`: all SQL for its table — no business rules.
+   - `templates/admin/*.php`: presentation only — no SQL, no heavy logic.
+
+4. **Context object usage in generation paths.** If the diff touches generation
+   code, confirm it goes through `AIPS_Template_Context` /
+   `AIPS_Topic_Context` / `AIPS_Generation_Context` (via
+   `AIPS_Generation_Context_Factory`) rather than ad hoc parameters, and that
+   prompt assembly uses shared builders rather than string concatenation.
+
+## Report format
+
+For each check: **pass**, or **violation** with the exact file/line and what
+rule it breaks. End with a one-line verdict: clean, or N violations to fix
+before this is PR-ready. Don't editorialize beyond that — this is a mechanical
+gate, not a style review (defer style/simplification concerns to the
+`simplify` skill, and security concerns to the `security-review` skill).

--- a/.claude/agents/aips-qa.md
+++ b/.claude/agents/aips-qa.md
@@ -1,0 +1,57 @@
+---
+name: aips-qa
+description: Test planning and verification for the AI Post Scheduler plugin. Use when a change needs a test plan, new/updated PHPUnit coverage, or a pre-merge verification pass — grounded in this repo's actual test conventions rather than generic testing advice.
+tools: Read, Grep, Glob, Bash, Edit, Write
+model: sonnet
+---
+
+You are a QA specialist for the **AI Post Scheduler** WordPress plugin
+(`ai-post-scheduler/`). You plan and write tests using this repo's actual
+conventions — not generic PHPUnit boilerplate.
+
+## What's actually true about this test suite
+
+- Tests extend `WP_UnitTestCase` directly. There is **no shared base TestCase
+  class** in this repo — don't invent one.
+- Two naming conventions coexist; match whichever the feature area already uses:
+  `Test_AIPS_<Feature>.php` (majority) or `AIPS_<Feature>_Test.php`.
+- Controller tests use a `call_ajax()` harness: mock the injected
+  service/repository via `getMockBuilder()`, construct the controller with the
+  mock, `ob_start()`, invoke the AJAX callback, catch `WPAjaxDieContinueException`
+  / `WPAjaxDieStopException`, then `json_decode` the captured output.
+- Run via `composer test` / `composer test:verbose` / `composer test:coverage`
+  from `ai-post-scheduler/`, or a single file with
+  `vendor/bin/phpunit tests/<file>.php`. `bash scripts/run-wp-tests-docker.sh`
+  handles DB setup automatically; `AIPS_WP_TEST_SKIP_DB_CREATE=true` skips DB
+  creation when unavailable.
+
+## Testing policy — do not violate this
+
+Per `AGENTS.md`/`CLAUDE.md`: **do not run `composer test` or the full PHPUnit
+suite unless the user explicitly asks or the task requires it.** Prefer:
+
+- Static/syntax review of touched files.
+- A concrete, written test plan (what should be tested, what the existing
+  coverage already handles, what's missing).
+- A single targeted test file run when verifying one specific change, not the
+  full suite.
+- If tests genuinely need to run and weren't, say so explicitly rather than
+  silently skipping verification.
+
+## Workflow
+
+1. Read the changed code and any existing tests covering that class/feature.
+2. Identify what's covered, what's new, and what edge cases are missing —
+   happy path, boundary values, WordPress capability/nonce denial paths,
+   partial-generation/reconciliation states where relevant.
+3. Write or extend tests following the existing file's conventions exactly
+   (mock style, assertion style, naming).
+4. Report which tests you added/changed, which existing tests you verified
+   still apply, and whether the full suite was run or deliberately deferred.
+
+## Anti-patterns
+
+- Don't create a new base TestCase or testing utility "for consistency" — match
+  what's there.
+- Don't write tests that pass regardless of implementation.
+- Don't silently run the full `composer test` suite when the policy says not to.

--- a/.claude/agents/aips-release-prep.md
+++ b/.claude/agents/aips-release-prep.md
@@ -1,0 +1,57 @@
+---
+name: aips-release-prep
+description: Checks performance-regression thresholds via bin/benchmark.php and version-bump consistency (Version header + AIPS_VERSION) before a release or a schema/perf-sensitive change ships in the AI Post Scheduler plugin.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You verify two things before a release-worthy change ships in the **AI Post
+Scheduler** plugin: performance regressions and version-bump consistency.
+
+## Performance benchmark
+
+Run from `ai-post-scheduler/`:
+
+```bash
+php bin/benchmark.php --wp-core-dir=/tmp/wordpress
+```
+
+The script boots real WordPress and measures 5 named benchmarks (admin dashboard
+load, frontend page load, plugin admin page, AJAX endpoint/template list, heavy
+schedule-check query), each capturing `$wpdb->num_queries` delta, memory
+delta/peak, and wall time.
+
+With a baseline file:
+
+```bash
+php bin/benchmark.php --wp-core-dir=/tmp/wordpress \
+  --baseline-file=../.github/performance-baseline.json --fail-on-regression
+```
+
+Regression thresholds: queries +20%, memory +25%, wall time +30%.
+
+**Known gap: no baseline JSON is currently checked into the repo.** Before this
+check can be meaningful in CI or repeat local runs, a baseline needs to be
+established once via `--output-file=<path>` and committed at the path
+`.github/performance-baseline.json` referenced above. If asked to "check for
+regressions" and no baseline exists yet, say so explicitly and offer to
+generate one rather than silently skipping the comparison.
+
+## Version-bump consistency
+
+For any schema change (see the `aips-db-schema-change` skill) or release:
+
+1. Confirm the `Version:` header in `ai-post-scheduler/ai-post-scheduler.php`
+   and the `AIPS_VERSION` constant in the same file match.
+2. Confirm they were actually bumped (not left at the pre-change value) when the
+   diff includes a schema change.
+3. Cross-check `CHANGELOG.md` mentions the change if the project's convention
+   is to log it there (check recent entries for the pattern before assuming).
+
+## Report format
+
+State clearly: benchmark run/not-run and why, regression status per metric
+(with numbers) if a baseline exists, and version-bump status (in sync /
+out of sync, bumped / not bumped). Don't run the full benchmark suite against a
+production-like WordPress install without confirming `--wp-core-dir` points to
+a disposable environment.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,20 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "f=$(jq -r '.tool_input.file_path // empty'); case \"$f\" in *ai-post-scheduler/includes/class-aips-*-controller.php|*ai-post-scheduler/includes/class-aips-*-service.php) COMPOSER_ALLOW_SUPERUSER=1 bash -c 'cd ai-post-scheduler && composer lint:repository-boundary' ;; esac",
+            "statusMessage": "Checking repository boundary..."
+          },
+          {
+            "type": "command",
+            "command": "f=$(jq -r '.tool_input.file_path // empty'); case \"$f\" in *ai-post-scheduler/includes/class-aips-db-manager.php) echo \"{\\\"systemMessage\\\": \\\"Reminder: schema changes require bumping both the \\`Version:\\` header and \\`AIPS_VERSION\\` constant in ai-post-scheduler/ai-post-scheduler.php.\\\"}\" ;; esac"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/aips-admin-ui-js/SKILL.md
+++ b/.claude/skills/aips-admin-ui-js/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: aips-admin-ui-js
+description: Use when changing admin templates or JavaScript in the AI Post Scheduler plugin (ai-post-scheduler/) — anything under templates/admin/*.php or assets/js/*.js, admin markup, toasts, modals, or confirm dialogs.
+---
+
+# Admin UI / JS workflow
+
+## Required workflow
+
+1. **Follow the JS module pattern.** Every file in `assets/js/` follows the same
+   shape:
+   ```js
+   (function($) {
+     'use strict';
+     window.AIPS = window.AIPS || {};
+     var AIPS = window.AIPS;
+
+     AIPS.ModuleName = {
+       init() { this.bindEvents(); },
+       bindEvents() { $(document).on('event', '.selector', this.handler.bind(this)); },
+       handler(e) { ... }
+     };
+
+     $(document).ready(function() { AIPS.ModuleName.init(); });
+   })(jQuery);
+   ```
+2. **Generate HTML only through the template helper.** Use `AIPS.Templates.render(id, data)`
+   (auto-escaped) or `AIPS.Templates.renderRaw(id, data)` (trusted HTML only). Never
+   build HTML via string concatenation.
+3. **Use the shared UI primitives, not browser dialogs.** `AIPS.Utilities.showToast(message, type)`
+   instead of `alert()`; `AIPS.Utilities.confirm(message, heading, buttons)` instead of
+   `confirm()`.
+4. **Refresh via re-fetch + re-render, not `location.reload()`.** After a mutating
+   AJAX call, re-fetch the affected data and re-render with `AIPS.Templates` rather
+   than reloading the page.
+5. **Follow the template layout structure.** Admin pages nest
+   `div.wrap.aips-wrap` → `div.aips-page-container` → `div.aips-page-header` /
+   `div.aips-content-panel`. Buttons use `aips-btn` with variants
+   (`aips-btn-primary`, `aips-btn-danger`, ...). Tables use `table.aips-table`.
+   Modals nest `.aips-modal` → `.aips-modal-content` → `.aips-modal-header` /
+   `.aips-modal-body` / `.aips-modal-footer`.
+6. **Templates stay presentation-only.** `templates/admin/*.php` must not contain
+   SQL or heavy business logic — pull data from a controller/service before
+   rendering.
+
+## Guardrails
+
+- An admin UI change almost always warrants the `admin-ui` + `needs-browser-test`
+  PR labels — see `aips-pr-prep`. Actually open the page in a browser (or via the
+  Docker dev environment at `http://localhost:8080/wp-admin`) to confirm the change
+  before calling it done — type checks don't catch broken markup/JS wiring.
+
+## Reference files
+
+- `ai-post-scheduler/assets/js/` (any existing module as a pattern reference)
+- `ai-post-scheduler/templates/admin/`

--- a/.claude/skills/aips-ajax-endpoint/SKILL.md
+++ b/.claude/skills/aips-ajax-endpoint/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: aips-ajax-endpoint
+description: Use when adding, changing, or reviewing an AJAX action in the AI Post Scheduler plugin (ai-post-scheduler/) — anything involving wp_ajax_* handlers, AIPS_Ajax_Registry, or a *-controller.php file.
+---
+
+# AJAX endpoint workflow
+
+This plugin routes every AJAX action through a single registry rather than ad hoc
+`add_action('wp_ajax_...')` calls scattered across the codebase.
+
+## Required workflow
+
+1. **Register the action.** Add `'aips_action_name' => 'AIPS_ClassName'` to
+   `AIPS_Ajax_Registry::$map` in `includes/class-aips-ajax-registry.php`. `boot_ajax()`
+   reads `$_REQUEST['action']`, resolves the controller from this map, and constructs
+   it — the constructor registers the real WordPress hook. Never register a
+   `wp_ajax_*` action outside this map.
+2. **Controller owns the request boundary.** The controller class
+   (`class-aips-*-controller.php`) is responsible for nonce verification, a
+   `current_user_can()` capability check, input sanitization, and returning JSON via
+   `AIPS_Ajax_Response`. See `includes/class-aips-schedule-controller.php` for the
+   reference shape (constructor takes optional service/repository-interface
+   dependencies with nullable defaults; methods like `ajax_save_schedule()`,
+   `ajax_delete_schedule()` do the request-boundary work only).
+3. **Business logic goes in a service, not the controller.** Orchestration belongs in
+   a `class-aips-*-service.php` (e.g. `AIPS_Unified_Schedule_Service`). Controllers
+   call the service; they don't contain multi-step logic themselves.
+4. **SQL goes in a repository, not the controller or service.** All `$wpdb` access
+   lives in a `class-aips-*-repository.php` implementing an `*_Repository_Interface`
+   (e.g. `AIPS_Schedule_Repository implements AIPS_Schedule_Repository_Interface`).
+   See the `aips-repository-boundary` skill for the enforcement mechanism.
+5. **Write or extend a controller test.** Tests follow the `Test_AIPS_*_Controller_*.php`
+   naming convention (e.g. `Test_AIPS_Schedule_Controller_Save.php`) and extend
+   `WP_UnitTestCase` directly (no shared base TestCase in this repo). The standard
+   pattern: mock the injected service/repository with `getMockBuilder()`, construct
+   the controller with the mock, then use a `call_ajax()` helper that `ob_start()`s,
+   invokes the AJAX callback, catches `WPAjaxDieContinueException` /
+   `WPAjaxDieStopException`, and `json_decode`s the captured output.
+
+## Guardrails
+
+- Never bypass `AIPS_Ajax_Registry` — a controller instantiated outside `boot_ajax()`
+  won't be wired to the right context boot (see `AI_Post_Scheduler::init()`).
+- Don't skip the capability/nonce check even for read-only actions.
+- Don't run the full test suite proactively — per the repo's testing policy, only run
+  `composer test` when explicitly asked or required by the task; targeted single-file
+  runs (`vendor/bin/phpunit tests/<file>.php`) are fine when verifying a specific change.
+
+## Reference files
+
+- `ai-post-scheduler/includes/class-aips-ajax-registry.php`
+- `ai-post-scheduler/includes/class-aips-schedule-controller.php`
+- `ai-post-scheduler/includes/class-aips-unified-schedule-service.php`
+- `ai-post-scheduler/includes/class-aips-schedule-repository.php`
+- `ai-post-scheduler/tests/Test_AIPS_Schedule_Controller_Save.php`

--- a/.claude/skills/aips-bulk-batch-job/SKILL.md
+++ b/.claude/skills/aips-bulk-batch-job/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: aips-bulk-batch-job
+description: Use when adding a new bulk/batch job type or changing how batches are processed in the AI Post Scheduler plugin (ai-post-scheduler/) — anything touching AIPS_Bulk_Batch_Processor, AIPS_Bulk_Batch_Job_Store, or the aips_process_bulk_batch cron hook.
+---
+
+# Bulk/batch job workflow
+
+Bulk work runs as single-event cron slices dispatched by one processor, with job
+types registered as pluggable strategies rather than separate cron hooks per type.
+
+## Required workflow
+
+1. **Register a new job type as a strategy.** In `boot_cron()`
+   (`ai-post-scheduler.php`), call
+   `AIPS_Bulk_Batch_Processor::instance()->register(string $job_type, callable $handler)`.
+   The three existing types — `author_topic_post`, `planner_post`,
+   `trending_topic_post` — are the reference implementations to model a new one on.
+2. **Don't add a new cron hook per job type.** All bulk work is dispatched through
+   the single `aips_process_bulk_batch` single-event hook; the processor slices work
+   and re-schedules itself. Adding a parallel hook duplicates the batching/retry
+   machinery.
+3. **Persist job state through the store, not ad hoc options/tables.** Use
+   `AIPS_Bulk_Batch_Job_Store` for progress/status — don't invent a second state
+   mechanism for a new job type.
+4. **Keep the handler idempotent and resumable.** Since work is processed in slices
+   across multiple cron ticks, a handler must tolerate being invoked again on a
+   partially-completed batch.
+
+## Guardrails
+
+- A bulk/batch change almost always warrants the `cron` PR label — see `aips-pr-prep`.
+- SQL for job state still belongs in a repository, not directly in the processor or
+  handler callable — see `aips-repository-boundary`.
+
+## Reference files
+
+- `ai-post-scheduler/includes/class-aips-bulk-batch-processor.php`
+- `ai-post-scheduler/includes/class-aips-bulk-batch-job-store.php`
+- `ai-post-scheduler/ai-post-scheduler.php` (`boot_cron()`, existing `register()` calls)
+- `ai-post-scheduler/includes/job/`

--- a/.claude/skills/aips-db-schema-change/SKILL.md
+++ b/.claude/skills/aips-db-schema-change/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: aips-db-schema-change
+description: Use when adding or changing a database table, column, or index in the AI Post Scheduler plugin (ai-post-scheduler/) — anything touching AIPS_DB_Manager, AIPS_DB_Migrations, or plugin schema/version bumps.
+---
+
+# Database schema change workflow
+
+## Required workflow
+
+1. **Update the schema definition.** Add/modify the table in
+   `AIPS_DB_Manager::get_schema()` (`includes/class-aips-db-manager.php`).
+   `install_tables()` + WordPress `dbDelta` apply it — there is no separate
+   migrations directory to wire up for a brand-new table.
+2. **Add migration logic only if altering existing data/columns.** Use
+   `AIPS_DB_Migrations::check_and_run()` (`includes/class-aips-db-migrations.php`) as
+   the entry point. `class-aips-upgrades.php` is a compatibility alias, not a second
+   place to add logic.
+3. **Prefer additive, backward-compatible changes.** Don't drop or rename columns
+   without a compatibility bridge — existing installs upgrade in place via `dbDelta`,
+   there's no forward-only migration runway.
+4. **Bump the version.** Update both the `Version:` header and `AIPS_VERSION`
+   constant in `ai-post-scheduler/ai-post-scheduler.php`. These two must stay in sync.
+5. **Create a repository class for any new table.** Every table gets its own
+   `class-aips-*-repository.php` — this is also what the repository-boundary lint
+   expects (see `aips-repository-boundary` skill).
+6. **Write/extend schema and migration tests.** Reference:
+   `tests/Test_AIPS_DB_Schema.php`, `tests/Test_AIPS_DB_Migrations.php`.
+
+## Guardrails
+
+- Target PHP 8.2+ / WP 5.8+, tabs + `array()` syntax, and the
+  `if (!defined('ABSPATH')) { exit; }` guard on any new PHP file.
+- Don't add SQL to controllers or services — only repositories (and
+  `AIPS_DB_Manager`/`AIPS_DB_Migrations` themselves, which are whitelisted for direct
+  `$wpdb` use in `config/repository-boundary-whitelist.txt`).
+- A schema change almost always warrants the `schema-change` PR label — see
+  `aips-pr-prep`.
+
+## Reference files
+
+- `ai-post-scheduler/includes/class-aips-db-manager.php`
+- `ai-post-scheduler/includes/class-aips-db-migrations.php`
+- `ai-post-scheduler/ai-post-scheduler.php` (`Version:` header, `AIPS_VERSION`)
+- `ai-post-scheduler/tests/Test_AIPS_DB_Schema.php`
+- `ai-post-scheduler/tests/Test_AIPS_DB_Migrations.php`
+- `ai-post-scheduler/config/repository-boundary-whitelist.txt`

--- a/.claude/skills/aips-generation-pipeline/SKILL.md
+++ b/.claude/skills/aips-generation-pipeline/SKILL.md
@@ -21,11 +21,15 @@ lists, and every path through it must stay observable.
 3. **Assemble prompts through shared builders.** Never concatenate prompt strings in
    a caller; use the existing shared prompt builder(s) so template/voice/structure
    rules apply uniformly.
-4. **Preserve observability.** Any new or changed generation path must keep emitting
-   through `AIPS_Generation_Logger`, `AIPS_History_Service`, and
-   `AIPS_Correlation_Id` — these are what let a failed/partial generation be traced
-   and reconciled later (see `AIPS_Partial_Generation_State_Reconciler` /
-   `AIPS_Partial_Generation_Notifications` in `docs/AI_AGENT_REFERENCE.md`).
+4. **Preserve observability.** Any new or changed generation path must keep logging
+   through `AIPS_Logger_Interface` (`AIPS_Logger`) and `AIPS_History_Service_Interface`
+   (`AIPS_History_Service`) — both `AIPS_Generator` and `AIPS_Generation_Execution_Runner`
+   take these as constructor dependencies, resolved via the container when not
+   injected. This is what lets a failed/partial generation be traced and reconciled
+   later (see `AIPS_Partial_Generation_State_Reconciler` /
+   `AIPS_Partial_Generation_Notifications` in `docs/AI_AGENT_REFERENCE.md`). Note:
+   `AIPS_Correlation_Id` exists as a class but has no current call sites — don't
+   treat it as part of the active observability path.
 5. **Check resilience wiring.** If the change can fail transiently (external API
    calls), confirm it goes through `AIPS_Resilience_Service::retry_with_backoff()`
    rather than a bespoke retry loop.
@@ -39,8 +43,12 @@ lists, and every path through it must stay observable.
 
 ## Reference files
 
-- `ai-post-scheduler/includes/` — `class-aips-generation-context*.php`,
-  `class-aips-template-context.php`, `class-aips-topic-context.php`,
-  `class-aips-generator.php`, `class-aips-generation-logger.php`,
-  `class-aips-history-service.php`, `class-aips-correlation-id.php`,
-  `class-aips-resilience-service.php`
+- `ai-post-scheduler/includes/interface-aips-generation-context.php` (contract)
+- `ai-post-scheduler/includes/class-aips-generation-context-factory.php`
+- `ai-post-scheduler/includes/class-aips-template-context.php`
+- `ai-post-scheduler/includes/class-aips-topic-context.php`
+- `ai-post-scheduler/includes/class-aips-generator.php`
+- `ai-post-scheduler/includes/class-aips-generation-execution-runner.php`
+- `ai-post-scheduler/includes/class-aips-logger.php` / `interface-aips-logger-interface.php`
+- `ai-post-scheduler/includes/class-aips-history-service.php`
+- `ai-post-scheduler/includes/class-aips-resilience-service.php`

--- a/.claude/skills/aips-generation-pipeline/SKILL.md
+++ b/.claude/skills/aips-generation-pipeline/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: aips-generation-pipeline
+description: Use when changing the AI content-generation flow in the AI Post Scheduler plugin (ai-post-scheduler/) — anything touching AIPS_Generator, AIPS_Template_Context, AIPS_Topic_Context, AIPS_Generation_Context, prompt assembly, or generation logging/history.
+---
+
+# Generation pipeline workflow
+
+The core content-generation flow is built on context objects, not ad hoc parameter
+lists, and every path through it must stay observable.
+
+## Required workflow
+
+1. **Use the context objects, not raw parameters.** `AIPS_Template_Context`,
+   `AIPS_Topic_Context`, and `AIPS_Generation_Context` (built via
+   `AIPS_Generation_Context_Factory`) carry generation state. Adding a new input to
+   generation means extending a context object and its factory, not threading a new
+   parameter through every call site.
+2. **Drive generation through `AIPS_Generator`.** Don't call the underlying AI Engine
+   integration directly from a controller or service — go through the generator so
+   logging/retry/observability stay consistent.
+3. **Assemble prompts through shared builders.** Never concatenate prompt strings in
+   a caller; use the existing shared prompt builder(s) so template/voice/structure
+   rules apply uniformly.
+4. **Preserve observability.** Any new or changed generation path must keep emitting
+   through `AIPS_Generation_Logger`, `AIPS_History_Service`, and
+   `AIPS_Correlation_Id` — these are what let a failed/partial generation be traced
+   and reconciled later (see `AIPS_Partial_Generation_State_Reconciler` /
+   `AIPS_Partial_Generation_Notifications` in `docs/AI_AGENT_REFERENCE.md`).
+5. **Check resilience wiring.** If the change can fail transiently (external API
+   calls), confirm it goes through `AIPS_Resilience_Service::retry_with_backoff()`
+   rather than a bespoke retry loop.
+
+## Guardrails
+
+- A generation-pipeline change almost always warrants the `generation-pipeline` PR
+  label — see `aips-pr-prep`.
+- Don't bypass the context/factory pattern even for a "quick" one-off generation
+  path — inconsistent context objects are what break partial-generation recovery.
+
+## Reference files
+
+- `ai-post-scheduler/includes/` — `class-aips-generation-context*.php`,
+  `class-aips-template-context.php`, `class-aips-topic-context.php`,
+  `class-aips-generator.php`, `class-aips-generation-logger.php`,
+  `class-aips-history-service.php`, `class-aips-correlation-id.php`,
+  `class-aips-resilience-service.php`

--- a/.claude/skills/aips-pr-prep/SKILL.md
+++ b/.claude/skills/aips-pr-prep/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: aips-pr-prep
+description: Use before opening or updating a pull request against the AI Post Scheduler repo — determining which risk labels apply, what verification to run, and whether docs need updating, per .github/pull_request_template.md.
+---
+
+# PR prep workflow
+
+`.github/pull_request_template.md` defines the checklist reviewers expect. Work
+through it before a PR is opened, rather than leaving it for CI/review to catch.
+
+## Verification
+
+- Run `composer test` (or a targeted `vendor/bin/phpunit tests/<file>.php`) for the
+  changed behavior — but only when explicitly asked or the task requires it, per the
+  repo's testing policy (AGENTS.md/CLAUDE.md). If not run, say so explicitly in the
+  PR/response rather than silently skipping it.
+- Run `cd ai-post-scheduler && composer lint:repository-boundary` if any
+  controller/service file changed.
+- Manually verify changed admin/runtime paths where practical.
+- Update documentation if behavior or workflow changed (`docs/AI_AGENT_REFERENCE.md`,
+  `docs/DEVELOPMENT_GUIDELINES.md`, `CLAUDE.md`/`AGENTS.md` as appropriate — don't
+  duplicate content across them).
+
+## Risk labels — derive from touched files
+
+| Files touched | Label(s) |
+|---|---|
+| `class-aips-db-manager.php`, `class-aips-db-migrations.php`, `Version:`/`AIPS_VERSION` | `schema-change` |
+| `templates/admin/*.php`, `assets/js/*.js`, admin CSS | `admin-ui` + `needs-browser-test` |
+| `class-aips-ajax-registry.php`, any `*-controller.php` | `ajax-registry` |
+| `class-aips-bulk-batch-processor.php`, `class-aips-bulk-batch-job-store.php`, scheduler/cron classes | `cron` |
+| `class-aips-generation-context*.php`, `class-aips-generator.php`, prompt builders | `generation-pipeline` |
+| Nonce/capability checks, auth, data sanitization/escaping paths | `security-sensitive` |
+| Any change that duplicates existing logic/tables/endpoints | `duplicate-risk` (must be addressed before merge, not just labeled) |
+
+## Guardrails
+
+- This skill only determines labels/checklist status — actually applying GitHub
+  labels and opening the PR follows the normal PR-creation flow (draft PR, template
+  sections filled from the diff).
+- Don't skip the risk-checklist reasoning just because a change looks small —
+  e.g. a one-line schema tweak still needs the version bump and `schema-change`
+  label.
+
+## Reference files
+
+- `.github/pull_request_template.md`

--- a/.claude/skills/aips-repository-boundary/SKILL.md
+++ b/.claude/skills/aips-repository-boundary/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: aips-repository-boundary
+description: Use when writing or reviewing any $wpdb/SQL code in the AI Post Scheduler plugin (ai-post-scheduler/), or when composer lint:repository-boundary needs to be understood, satisfied, or whitelisted.
+---
+
+# Repository boundary enforcement
+
+This plugin enforces "SQL lives only in repositories" mechanically, not just by
+convention.
+
+## What the lint actually checks
+
+`composer lint:repository-boundary` runs `tools/check-repository-boundary.php`,
+which:
+
+1. Recursively scans `includes/` for files matching
+   `class-aips-*-(controller|service).php`.
+2. Flags any such file whose content matches the regex `\$wpdb\s*->|global\s+\$wpdb`.
+3. Skips files listed in `config/repository-boundary-whitelist.txt` (one relative
+   path per line, `#`-comments allowed).
+4. Exits non-zero and lists violations if any are found.
+
+## Required workflow
+
+1. **If you're writing SQL, put it in a repository.** A `class-aips-*-repository.php`
+   file (implementing an `*_Repository_Interface`) is the only place `$wpdb` should
+   appear outside the whitelist.
+2. **If a controller/service seems to need direct SQL, that's a signal to add a
+   repository method instead**, not to reach for `$wpdb` inline.
+3. **Only whitelist as a last resort, with rationale.** Add the relative path to
+   `config/repository-boundary-whitelist.txt` and explain why in the PR description
+   — currently only `includes/class-aips-telemetry.php` and
+   `includes/class-aips-db-migrations.php` are whitelisted, both for specific
+   structural reasons (telemetry write-path performance, migration bootstrapping
+   before repositories are wired).
+4. **Run the lint before considering a controller/service change done:**
+   ```bash
+   cd ai-post-scheduler && composer lint:repository-boundary
+   ```
+
+## Reference files
+
+- `ai-post-scheduler/tools/check-repository-boundary.php`
+- `ai-post-scheduler/config/repository-boundary-whitelist.txt`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 `AGENTS.md` is the canonical cross-agent instruction source — read it first. This file adds Claude Code-specific orientation and does not duplicate what is already there.
 
+## Claude Code skills and subagents
+
+`.claude/skills/` and `.claude/agents/` encode this plugin's recurring workflows (AJAX endpoints, schema changes, generation pipeline, bulk batch jobs, admin UI/JS, repository-boundary enforcement, PR prep) so they auto-trigger instead of relying on prose recall. See the catalog in `docs/AI_AGENT_REFERENCE.md` — don't duplicate that inventory here.
+
 ## Commands
 
 All Composer and PHPUnit commands run from `ai-post-scheduler/`.

--- a/docs/AI_AGENT_REFERENCE.md
+++ b/docs/AI_AGENT_REFERENCE.md
@@ -64,3 +64,35 @@ Single-event hooks:
 - `aips_process_bulk_batch`
 - `aips_process_author_embeddings`
 - `aips_index_posts_batch`
+
+## Claude Code skills and subagents
+
+`.claude/skills/` and `.claude/agents/` give Claude Code auto-triggering, repo-grounded
+knowledge of this plugin's recurring workflows. These complement (don't replace)
+`AGENTS.md`/`CLAUDE.md`; see those files for the underlying architecture rules these
+implement. Equivalent tooling for other agents lives in `.codex/skills/` and
+`.github/agents/` — the two are maintained independently.
+
+Skills (`.claude/skills/<name>/SKILL.md`, auto-trigger by description):
+
+| Skill | Use for |
+|---|---|
+| `aips-ajax-endpoint` | Adding/reviewing an AJAX action: registry entry, controller, service, repository, test. |
+| `aips-db-schema-change` | Schema/table/index changes: `AIPS_DB_Manager`, `AIPS_DB_Migrations`, version bump. |
+| `aips-generation-pipeline` | Content-generation flow changes: context objects, `AIPS_Generator`, prompt builders, logging. |
+| `aips-bulk-batch-job` | New bulk/batch job types: `AIPS_Bulk_Batch_Processor` strategy registration. |
+| `aips-admin-ui-js` | Admin template/JS changes: module pattern, `AIPS.Templates`/`AIPS.Utilities`, layout structure. |
+| `aips-repository-boundary` | Understanding/satisfying `composer lint:repository-boundary`. |
+| `aips-pr-prep` | Pre-PR checklist: verification steps and risk labels from `.github/pull_request_template.md`. |
+
+Subagents (`.claude/agents/<name>.md`, invoked explicitly or by task match):
+
+| Subagent | Role |
+|---|---|
+| `aips-qa` | Test planning/verification using this repo's actual test conventions. |
+| `aips-architecture-guardian` | Mechanical diff check: repository boundary, AJAX registry completeness, layer separation. |
+| `aips-release-prep` | Performance-regression check (`bin/benchmark.php`) and version-bump consistency. |
+
+For roles Claude Code already ships (janitor/simplification, security review, PR
+triage, architecture planning), reuse the built-in `simplify` and `security-review`
+skills and the `Explore`/`Plan` agents rather than adding new ones.


### PR DESCRIPTION
## Summary
- What changed? Added `.claude/skills/` (7 skills), `.claude/agents/` (3 subagents), and `.claude/settings.json` (2 PostToolUse hooks) so Claude Code has native, auto-triggering knowledge of this plugin's recurring workflows — AJAX endpoint scaffolding, schema/migration changes, the generation pipeline, bulk batch jobs, admin UI/JS conventions, repository-boundary enforcement, and PR prep. Added a short catalog to `docs/AI_AGENT_REFERENCE.md` and a pointer in `CLAUDE.md`, following the existing documentation-ownership convention (inventories live in `docs/AI_AGENT_REFERENCE.md`, not in `AGENTS.md`/`CLAUDE.md`).
- Why now? The repo already has mature Copilot/Codex-specific agent tooling (`.github/agents/`, `.codex/skills/`) but had zero Claude-Code-specific config. This closes that gap with content grounded in the actual classes/files (verified via direct reads of `class-aips-ajax-registry.php`, `class-aips-schedule-controller.php`, `tools/check-repository-boundary.php`, `bin/benchmark.php`, etc.) rather than generic WordPress boilerplate.

Scope note: this is local/interactive tooling only (skills, subagents, hooks used during Claude Code sessions) — no new CI/GitHub Actions automation was added.

Follow-up (not part of this PR): several personas in `.github/agents/` are generic boilerplate unrelated to this repo (`wordpress-developer.agent.md`, `thinking-beast-mode.agent.md`, `ultimate-beast-agent.md`, `prompt-engineer.agent.md`, `search-ai-optimization-expert.agent.md`, `php-mcp-expert.agent.md`) and `PR Oracle v2.agent.md` is an unfinished stub duplicating the complete `Pull Request Oracle.agent.md`. Recommend reviewing these for removal/rewrite in a separate pass — that's a different tool's config and out of scope here.

## Verification
- [x] No PHP/JS runtime code changed — this PR only adds Markdown/JSON configuration under `.claude/` and doc updates, so `composer test` is not applicable.
- [x] `.claude/settings.json` validated as syntactically-correct JSON (`jq empty`) and each hook command verified with `jq -e` against the exact schema path Claude Code reads.
- [x] Both hook commands pipe-tested against synthesized stdin payloads matching real file paths (a controller file, a repository file as a negative case, and `class-aips-db-manager.php`), confirming correct match/no-match behavior and that `composer lint:repository-boundary` runs cleanly.
- [x] Live-fire verification of the hooks was attempted via a temporary sentinel-prefixed command + a real Edit; it did not trigger because the settings watcher wasn't tracking `.claude/` (it didn't exist when this session started) — expected per Claude Code's hook-reload behavior. The hook logic itself is verified correct via the pipe-tests above; it activates on the next `/hooks` reload or session restart. Test artifacts (sentinel prefixes, temp edit) were fully reverted.
- [ ] Manual verification of admin/runtime paths — not applicable, no admin/runtime code touched.
- [x] Documentation updated (`docs/AI_AGENT_REFERENCE.md` catalog table, `CLAUDE.md` pointer).

## Risk Checklist
- [ ] `schema-change` — not applicable, no DB schema touched.
- [ ] `admin-ui` / `needs-browser-test` — not applicable, no admin templates/JS touched.
- [ ] `ajax-registry` — not applicable, no AJAX registry/controllers touched.
- [ ] `cron` — not applicable, no cron/queue/retry paths touched.
- [ ] `generation-pipeline` — not applicable, no generation flow touched.
- [ ] `security-sensitive` — not applicable, no auth/nonce/capability/data-safety paths touched.
- [ ] duplicate-risk — none identified; this tooling is additive and namespaced under `.claude/`, distinct from the existing `.codex/`/`.github/agents/` assets for other tools.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DJg5KaczWG7mGiDKtzaPET)_