### PR TITLE
Add Docker-based CI workflow; fix Linux path bug in test script

### DIFF
--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -1,0 +1,145 @@
+name: Docker Environment Tests
+
+# Runs the plugin's test suite against the same Docker Compose stack used for
+# local development (docker-compose.yml / start-dev.sh / Makefile), instead of
+# the ad hoc `mysql:8.0` GitHub Actions service used by phpunit-tests.yml /
+# ci-pr.yml. That gives two things those workflows don't:
+#   - DB parity: tests run against MariaDB 10.6, the same engine every
+#     developer runs locally, not a different MySQL major version/vendor.
+#   - A real boot smoke test: builds the actual WordPress+Apache image from
+#     the repo's own Dockerfile and confirms the plugin activates and the
+#     site responds, which isolated PHPUnit tests don't exercise.
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+  workflow_dispatch:
+
+concurrency:
+  group: docker-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker-phpunit:
+    name: PHPUnit via Docker Compose (MariaDB)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: mbstring, intl, xml, curl, zip, dom, fileinfo
+          coverage: xdebug
+          tools: composer:v2
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y subversion mariadb-client
+
+      - name: Cache Composer
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/composer
+            ~/.composer/cache
+          key: ${{ runner.os }}-composer-${{ hashFiles('ai-post-scheduler/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install Composer dependencies
+        run: cd ai-post-scheduler && composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Start the Docker DB service (MariaDB)
+        run: docker compose up -d db
+
+      - name: Wait for the DB container to report healthy
+        run: |
+          for _ in $(seq 1 60); do
+            STATUS="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' wp-ai-scheduler-db 2>/dev/null || true)"
+            if [ "$STATUS" = "healthy" ]; then
+              echo "DB is healthy."
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::DB container never became healthy."
+          docker compose logs db
+          exit 1
+
+      - name: Run the full WordPress PHPUnit suite (Docker-backed)
+        run: bash scripts/run-wp-tests-docker.sh test
+
+      - name: Generate code coverage report
+        if: always()
+        continue-on-error: true
+        run: bash scripts/run-wp-tests-docker.sh coverage
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-coverage-report
+          path: ai-post-scheduler/coverage/
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Tear down Docker services
+        if: always()
+        run: docker compose down
+
+  docker-boot-smoke-test:
+    name: Full Docker Dev Environment Boot Smoke Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build the WordPress/Apache image and start the full stack
+        run: |
+          docker compose build
+          docker compose up -d
+
+      - name: Wait for the WordPress container to report healthy
+        run: |
+          for _ in $(seq 1 40); do
+            STATUS="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' wp-ai-scheduler-web 2>/dev/null || true)"
+            if [ "$STATUS" = "healthy" ]; then
+              echo "WordPress container is healthy."
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::WordPress container never became healthy."
+          docker compose logs web
+          exit 1
+
+      - name: Verify the plugin activated without a fatal error
+        run: |
+          docker compose exec -T web wp core is-installed --allow-root
+          docker compose exec -T web wp plugin is-active ai-post-scheduler --allow-root
+
+      - name: Check container logs for PHP fatal/parse errors
+        run: |
+          if docker compose logs web | grep -Ei "PHP (Fatal|Parse) error"; then
+            echo "::error::Found a PHP fatal/parse error in the web container logs."
+            exit 1
+          fi
+
+      - name: Verify the site responds
+        run: curl -sf http://localhost:8080/ -o /dev/null
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: docker compose logs
+
+      - name: Tear down Docker services
+        if: always()
+        run: docker compose down -v

--- a/scripts/run-wp-tests-docker.sh
+++ b/scripts/run-wp-tests-docker.sh
@@ -26,13 +26,20 @@ DB_USER="${AIPS_WP_TEST_DB_USER:-root}"
 DB_PASS="${AIPS_WP_TEST_DB_PASS:-root}"
 DB_HOST="${AIPS_WP_TEST_DB_HOST:-127.0.0.1:3307}"
 WP_VERSION="${AIPS_WP_TEST_WP_VERSION:-latest}"
-WP_TESTS_DIR_WIN="${WP_TESTS_DIR:-C:/tmp/wordpress-tests-lib-docker}"
-WP_CORE_DIR_WIN="${WP_CORE_DIR:-C:/tmp/wordpress-docker}"
 
+# Default paths are only Windows-style (C:/tmp/...) on Git-Bash/Cygwin, where
+# cygpath is available to translate them back to a Unix path below. On native
+# Linux/macOS (no cygpath), a C:/tmp/... default would be treated as a
+# relative path (no leading /) and silently resolve under the plugin
+# directory -- so default to a real absolute /tmp path there instead.
 if command -v cygpath >/dev/null 2>&1; then
+  WP_TESTS_DIR_WIN="${WP_TESTS_DIR:-C:/tmp/wordpress-tests-lib-docker}"
+  WP_CORE_DIR_WIN="${WP_CORE_DIR:-C:/tmp/wordpress-docker}"
   WP_TESTS_DIR_UNIX="$(cygpath -u "$WP_TESTS_DIR_WIN")"
   WP_CORE_DIR_UNIX="$(cygpath -u "$WP_CORE_DIR_WIN")"
 else
+  WP_TESTS_DIR_WIN="${WP_TESTS_DIR:-/tmp/wordpress-tests-lib-docker}"
+  WP_CORE_DIR_WIN="${WP_CORE_DIR:-/tmp/wordpress-docker}"
   WP_TESTS_DIR_UNIX="$WP_TESTS_DIR_WIN"
   WP_CORE_DIR_UNIX="$WP_CORE_DIR_WIN"
 fi


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/docker-tests.yml`, a new CI workflow that runs the plugin's tests against the same Docker Compose stack used for local development (`docker-compose.yml` / `start-dev.sh` / `Makefile`), instead of the ad hoc `mysql:8.0` GitHub Actions service the existing `phpunit-tests.yml`/`ci-pr.yml` use:
  - `docker-phpunit` — runs the full WordPress PHPUnit suite via `scripts/run-wp-tests-docker.sh` against MariaDB 10.6, the same engine every local developer runs, closing a DB-engine parity gap with the existing `mysql:8.0` service container.
  - `docker-boot-smoke-test` — builds the actual WordPress+Apache image from the repo's own `Dockerfile`, brings up the full stack, and verifies the plugin activates without a PHP fatal/parse error and the site responds. This is a real boot/integration check that isolated PHPUnit tests don't exercise.
- Fixes a real bug in `scripts/run-wp-tests-docker.sh`: it defaulted `WP_TESTS_DIR`/`WP_CORE_DIR` to Windows-style paths (`C:/tmp/...`) unconditionally, only translating them via `cygpath` when that tool is present (Git-Bash/Cygwin). On native Linux/macOS, with no override supplied, the raw `C:/tmp/...` string has no leading slash, so PHP resolved it as a path relative to the plugin directory instead of an absolute one — the WP install ran against the wrong directory and the test run failed outright. Fixed by choosing OS-appropriate defaults (`/tmp/...` when `cygpath` isn't available).

## Why now?
Split out of #1869 at the user's request, since that PR is a pure JS/admin-asset refactor and this is unrelated CI/tooling infrastructure that's useful independent of it.

## Verification
- [x] Ran the full suite via `bash scripts/run-wp-tests-docker.sh test` locally with **no env-var overrides** (exercising the exact defaults this fix changes) — completed successfully end-to-end on native Linux, which it did not do before this fix.
- [x] `bash -n scripts/run-wp-tests-docker.sh` (shell syntax check)
- [x] `docker-tests.yml` validated as well-formed YAML
- [ ] The two new workflow jobs have not yet completed a real run on GitHub-hosted runners — this repo's Actions runs have been failing to dispatch to any runner at all (`runner_id: 0`, jobs complete in ~3s with no logs) across every workflow, including pre-existing ones unrelated to this change. That looks like an account/repo-level Actions availability or billing issue, not a workflow-config problem; see the "Risk / follow-up" note below.
- [ ] Manual verification completed for changed admin/runtime paths — not applicable, no admin/runtime code touched (CI/tooling only)
- [ ] Documentation updated (if behavior or workflow changed) — not applicable beyond in-file comments

## Risk Checklist
- [ ] `schema-change` — not applicable
- [ ] `admin-ui` / `needs-browser-test` — not applicable, no admin UI touched
- [ ] `ajax-registry` — not applicable
- [ ] `cron` — not applicable
- [ ] `generation-pipeline` — not applicable
- [ ] `security-sensitive` — not applicable
- [ ] `duplicate-risk` — not applicable

## Follow-up note
This repo's GitHub Actions runs (including this workflow's first run) have been failing to ever reach a runner (`runner_id: 0`, ~3s "completion" with no logs), on every workflow, not just new ones. That's very likely a GitHub Actions spending-limit/quota or Actions-enablement setting at the org/repo level (Settings → Actions → General, Settings → Billing → Actions minutes) rather than anything fixable in workflow YAML. Worth checking before expecting this workflow (or the pre-existing ones) to actually execute on GitHub-hosted runners.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ca3WV1PnAvaXyUpB6jcE2A)_