### PR TITLE
Add Ability Workflows: multi-step automation built on WordPress Abilities

### DIFF
--- a/ai-post-scheduler/ai-post-scheduler.php
+++ b/ai-post-scheduler/ai-post-scheduler.php
@@ -418,6 +418,11 @@ final class AI_Post_Scheduler {
         $container->singleton(AIPS_Template_Repository::class, function( $container ) {
             return AIPS_Template_Repository::instance();
         });
+
+        // Register AIPS_Ability_Workflow_Repository
+        $container->singleton(AIPS_Ability_Workflow_Repository::class, function( $container ) {
+            return AIPS_Ability_Workflow_Repository::instance();
+        });
     }
 
     /**

--- a/ai-post-scheduler/ai-post-scheduler.php
+++ b/ai-post-scheduler/ai-post-scheduler.php
@@ -428,6 +428,15 @@ final class AI_Post_Scheduler {
         $container->singleton(AIPS_Ability_Catalog_Service::class, function( $container ) {
             return new AIPS_Ability_Catalog_Service($container->make(AIPS_Ability_Service::class));
         });
+
+        // Register AIPS_Ability_Workflow_Executor
+        $container->singleton(AIPS_Ability_Workflow_Executor::class, function( $container ) {
+            return new AIPS_Ability_Workflow_Executor(
+                $container->make(AIPS_Ability_Workflow_Repository::class),
+                $container->make(AIPS_Ability_Catalog_Service::class),
+                $container->make(AIPS_Ability_Service::class)
+            );
+        });
     }
 
     /**
@@ -736,6 +745,19 @@ final class AI_Post_Scheduler {
                 return $post_id;
             }
         );
+
+        // Ability Workflow run execution/continuation: a dedicated single-event
+        // hook, deliberately NOT registered through AIPS_Bulk_Batch_Processor's
+        // strategy registry — workflow steps run in dependency order with
+        // conditional branching that can only be resolved once earlier steps
+        // have produced output, so they cannot be pre-sliced like a flat,
+        // order-independent batch job. The executor reschedules this same
+        // hook itself to continue a run across invocations (time budget or
+        // retry backoff).
+        // Args: run_id, correlation_id.
+        add_action('aips_run_ability_workflow', function( $run_id, $correlation_id = '' ) {
+            (new AIPS_Ability_Workflow_Executor())->process_run((int) $run_id, (string) $correlation_id);
+        }, 10, 2);
 
         // Daily cleanup of completed/failed bulk-batch job rows.
         add_action('aips_cleanup_bulk_batch_jobs', function() {

--- a/ai-post-scheduler/ai-post-scheduler.php
+++ b/ai-post-scheduler/ai-post-scheduler.php
@@ -3,7 +3,7 @@
  * Plugin Name: AI Post Scheduler
  * Plugin URI: https://nunezserver.com/nunezscheduler
  * Description: Schedule AI-generated posts using advanced features & scheduling options.
- * Version: 3.1.0
+ * Version: 3.2.0
  * Author: Raymond Nunez
  * Author URI: https://nunezserver.com
  * License: GPL v2 or later
@@ -44,7 +44,7 @@ if (!defined('AIPS_TELEMETRY_QUERY_SAMPLE_LIMIT')) {
 
 // Define plugin constants
 if (!defined('AIPS_VERSION')) {
-    define('AIPS_VERSION', '3.1.0');
+    define('AIPS_VERSION', '3.2.0');
 }
 
 if (!defined('AIPS_PLUGIN_DIR')) {

--- a/ai-post-scheduler/ai-post-scheduler.php
+++ b/ai-post-scheduler/ai-post-scheduler.php
@@ -423,6 +423,11 @@ final class AI_Post_Scheduler {
         $container->singleton(AIPS_Ability_Workflow_Repository::class, function( $container ) {
             return AIPS_Ability_Workflow_Repository::instance();
         });
+
+        // Register AIPS_Ability_Catalog_Service
+        $container->singleton(AIPS_Ability_Catalog_Service::class, function( $container ) {
+            return new AIPS_Ability_Catalog_Service($container->make(AIPS_Ability_Service::class));
+        });
     }
 
     /**

--- a/ai-post-scheduler/assets/js/admin-ability-workflow-builder.js
+++ b/ai-post-scheduler/assets/js/admin-ability-workflow-builder.js
@@ -191,8 +191,36 @@
 			this.populateDependsOnSelect(step.depends_on || [], index);
 			this.openInputMapRows(step.input_map || {});
 			this.openConditionRules(step.condition_tree || {});
+			this.warnIfStepHasUneditableStructure(step);
 
 			$('#aips-step-modal').css('display', 'flex');
+		},
+
+		/**
+		 * This builder's condition-rule editor only renders/collects flat
+		 * rules (nested AND/OR groups are skipped on load), and nested
+		 * input-map values get flattened into a JSON-string text field.
+		 * Saving a step without touching those fields would otherwise
+		 * silently simplify/discard that structure. Warn up front so an
+		 * admin editing an existing step built via direct API/import isn't
+		 * surprised by a silent change on save.
+		 *
+		 * @param {Object} step Step being opened for editing.
+		 */
+		warnIfStepHasUneditableStructure(step) {
+			var hasNestedCondition = !!(step.condition_tree && Array.isArray(step.condition_tree.rules) &&
+				step.condition_tree.rules.some(function(rule) { return !!rule.rules; }));
+
+			var hasNestedInputMap = !!(step.input_map && Object.keys(step.input_map).some(function(key) {
+				return step.input_map[key] !== null && typeof step.input_map[key] === 'object';
+			}));
+
+			if (hasNestedCondition || hasNestedInputMap) {
+				AIPS.Utilities.showToast(
+					'This step has advanced conditions or nested inputs that this editor cannot fully display. Saving this step will simplify them.',
+					'warning'
+				);
+			}
 		},
 
 		resetStepForm() {

--- a/ai-post-scheduler/assets/js/admin-ability-workflow-builder.js
+++ b/ai-post-scheduler/assets/js/admin-ability-workflow-builder.js
@@ -1,0 +1,536 @@
+(function($) {
+	'use strict';
+
+	window.AIPS = window.AIPS || {};
+	var AIPS = window.AIPS;
+
+	AIPS.AbilityWorkflowBuilder = {
+		workflowId: 0,
+		steps: [],
+		abilities: [],
+		editingStepIndex: -1,
+		runsLoaded: false,
+
+		init() {
+			this.workflowId = window.aipsAbilityWorkflowId || 0;
+
+			if (!this.workflowId) {
+				return;
+			}
+
+			this.bindEvents();
+			this.loadAbilities();
+			this.loadWorkflow();
+		},
+
+		bindEvents() {
+			$(document).on('click', '.aips-tab-link', this.switchTab.bind(this));
+
+			$(document).on('click', '#aips-add-step-btn', this.openAddStepModal.bind(this));
+			$(document).on('click', '.aips-edit-step', this.openEditStepModal.bind(this));
+			$(document).on('click', '.aips-remove-step', this.removeStep.bind(this));
+			$(document).on('click', '.aips-move-step-up', this.moveStepUp.bind(this));
+			$(document).on('click', '.aips-move-step-down', this.moveStepDown.bind(this));
+
+			$(document).on('click', '#aips-step-modal .aips-modal-close', this.closeStepModal.bind(this));
+			$(document).on('click', '#aips-save-step-btn', this.saveStep.bind(this));
+
+			$(document).on('click', '#aips-add-input-map-row-btn', this.addInputMapRow.bind(this));
+			$(document).on('click', '.aips-remove-input-map-row', this.removeInputMapRow.bind(this));
+
+			$(document).on('click', '#aips-add-condition-rule-btn', this.addConditionRuleRow.bind(this));
+			$(document).on('click', '.aips-remove-condition-rule', this.removeConditionRuleRow.bind(this));
+
+			$(document).on('click', '#aips-save-steps-btn', this.saveSteps.bind(this));
+			$(document).on('click', '#aips-builder-run-now-btn', this.runNow.bind(this));
+
+			$(document).on('click', '#aips-run-detail-modal .aips-modal-close', function() {
+				$('#aips-run-detail-modal').hide();
+			});
+			$(document).on('click', '.aips-view-run', this.viewRun.bind(this));
+		},
+
+		switchTab(e) {
+			e.preventDefault();
+			var tab = $(e.currentTarget).data('tab');
+
+			$('.aips-tab-link').removeClass('active');
+			$(e.currentTarget).addClass('active');
+
+			$('#aips-builder-tab-steps').toggle(tab === 'steps');
+			$('#aips-builder-tab-runs').toggle(tab === 'runs');
+
+			if (tab === 'runs' && !this.runsLoaded) {
+				this.loadRuns();
+			}
+		},
+
+		// -------------------------------------------------------------------
+		// Workflow + steps loading
+		// -------------------------------------------------------------------
+
+		loadWorkflow() {
+			var self = this;
+
+			$.post(aipsAjax.ajaxUrl, {
+				action: 'aips_get_ability_workflow',
+				nonce: aipsAjax.nonce,
+				workflow_id: this.workflowId
+			}, function(response) {
+				if (!response.success) {
+					AIPS.Utilities.showToast((response.data && response.data.message) || aipsAbilityWorkflowBuilderL10n.loadRunsFailed, 'error');
+					return;
+				}
+
+				$('#aips-builder-workflow-name').text(response.data.workflow.name);
+				self.steps = response.data.steps || [];
+				self.renderSteps();
+			});
+		},
+
+		loadAbilities() {
+			var self = this;
+
+			$.post(aipsAjax.ajaxUrl, {
+				action: 'aips_list_abilities',
+				nonce: aipsAjax.nonce
+			}, function(response) {
+				if (!response.success) {
+					AIPS.Utilities.showToast(aipsAbilityWorkflowBuilderL10n.loadAbilitiesFailed, 'error');
+					return;
+				}
+
+				self.abilities = response.data.abilities || [];
+			});
+		},
+
+		renderSteps() {
+			var $body = $('#aips-steps-table-body');
+			$body.empty();
+
+			this.steps.forEach(function(step, index) {
+				var html = AIPS.Templates.render('aips-tmpl-step-row', {
+					index: index,
+					step_key: step.step_key,
+					name: step.name || '',
+					ability_name: step.ability_name,
+					output_alias: step.output_alias || ''
+				});
+				$body.append(html);
+			});
+
+			$('#aips-steps-empty').toggle(this.steps.length === 0);
+		},
+
+		// -------------------------------------------------------------------
+		// Step modal
+		// -------------------------------------------------------------------
+
+		populateAbilitySelect(selectedValue) {
+			var $select = $('#aips-step-ability');
+			$select.empty();
+
+			this.abilities.forEach(function(ability) {
+				var $option = $('<option></option>').val(ability.name).text(ability.label + ' (' + ability.provider + ')');
+				if (ability.name === selectedValue) {
+					$option.prop('selected', true);
+				}
+				$select.append($option);
+			});
+		},
+
+		populateDependsOnSelect(selectedValues, excludeIndex) {
+			var $select = $('#aips-step-depends-on');
+			$select.empty();
+			selectedValues = selectedValues || [];
+
+			this.steps.forEach(function(step, index) {
+				if (index === excludeIndex) {
+					return;
+				}
+
+				var $option = $('<option></option>').val(step.step_key).text(step.step_key);
+				if (selectedValues.indexOf(step.step_key) !== -1) {
+					$option.prop('selected', true);
+				}
+				$select.append($option);
+			});
+		},
+
+		openAddStepModal() {
+			this.editingStepIndex = -1;
+			$('#aips-step-modal-title').text(aipsAbilityWorkflowBuilderL10n.addStep);
+			this.resetStepForm();
+			this.populateAbilitySelect('');
+			this.populateDependsOnSelect([], -1);
+			this.openInputMapRows({});
+			this.openConditionRules({});
+			$('#aips-step-modal').css('display', 'flex');
+		},
+
+		openEditStepModal(e) {
+			var index = parseInt($(e.currentTarget).data('index'), 10);
+			var step = this.steps[index];
+
+			if (!step) {
+				return;
+			}
+
+			this.editingStepIndex = index;
+			$('#aips-step-modal-title').text(aipsAbilityWorkflowBuilderL10n.editStep);
+			$('#aips-step-index').val(index);
+			$('#aips-step-key').val(step.step_key);
+			$('#aips-step-name').val(step.name || '');
+			$('#aips-step-output-alias').val(step.output_alias || '');
+			$('#aips-step-on-success').val((step.on_success && step.on_success.strategy) || 'continue');
+			$('#aips-step-on-failure').val((step.on_failure && step.on_failure.strategy) || 'stop');
+			$('#aips-step-retry-attempts').val((step.retry_policy && step.retry_policy.attempts) || 0);
+			$('#aips-step-retry-backoff').val((step.retry_policy && step.retry_policy.backoff_seconds) || 5);
+
+			this.populateAbilitySelect(step.ability_name);
+			this.populateDependsOnSelect(step.depends_on || [], index);
+			this.openInputMapRows(step.input_map || {});
+			this.openConditionRules(step.condition_tree || {});
+
+			$('#aips-step-modal').css('display', 'flex');
+		},
+
+		resetStepForm() {
+			$('#aips-step-form')[0].reset();
+			$('#aips-step-index').val(-1);
+		},
+
+		closeStepModal() {
+			$('#aips-step-modal').hide();
+		},
+
+		saveStep() {
+			var stepKey = $('#aips-step-key').val().trim();
+			var abilityName = $('#aips-step-ability').val();
+
+			if (!stepKey) {
+				AIPS.Utilities.showToast(aipsAbilityWorkflowBuilderL10n.stepKeyRequired, 'error');
+				return;
+			}
+
+			if (!abilityName) {
+				AIPS.Utilities.showToast(aipsAbilityWorkflowBuilderL10n.abilityRequired, 'error');
+				return;
+			}
+
+			var step = {
+				step_key: stepKey,
+				name: $('#aips-step-name').val(),
+				ability_name: abilityName,
+				depends_on: $('#aips-step-depends-on').val() || [],
+				output_alias: $('#aips-step-output-alias').val(),
+				input_map: this.collectInputMap(),
+				condition_tree: this.collectConditionTree(),
+				on_success: { strategy: $('#aips-step-on-success').val() },
+				on_failure: { strategy: $('#aips-step-on-failure').val() },
+				retry_policy: {
+					attempts: parseInt($('#aips-step-retry-attempts').val(), 10) || 0,
+					backoff_seconds: parseInt($('#aips-step-retry-backoff').val(), 10) || 5
+				}
+			};
+
+			if (this.editingStepIndex === -1) {
+				this.steps.push(step);
+			} else {
+				this.steps[this.editingStepIndex] = step;
+			}
+
+			this.renderSteps();
+			this.closeStepModal();
+		},
+
+		removeStep(e) {
+			var index = parseInt($(e.currentTarget).data('index'), 10);
+			var self = this;
+
+			AIPS.Utilities.confirm(
+				aipsAbilityWorkflowBuilderL10n.removeStepConfirm,
+				'Remove Step',
+				[
+					{ label: 'Cancel', className: 'aips-btn aips-btn-secondary' },
+					{ label: 'Remove', className: 'aips-btn aips-btn-danger', action: function() {
+						self.steps.splice(index, 1);
+						self.renderSteps();
+					} }
+				]
+			);
+		},
+
+		moveStepUp(e) {
+			var index = parseInt($(e.currentTarget).data('index'), 10);
+			if (index <= 0) {
+				return;
+			}
+			var tmp = this.steps[index - 1];
+			this.steps[index - 1] = this.steps[index];
+			this.steps[index] = tmp;
+			this.renderSteps();
+		},
+
+		moveStepDown(e) {
+			var index = parseInt($(e.currentTarget).data('index'), 10);
+			if (index >= this.steps.length - 1) {
+				return;
+			}
+			var tmp = this.steps[index + 1];
+			this.steps[index + 1] = this.steps[index];
+			this.steps[index] = tmp;
+			this.renderSteps();
+		},
+
+		// -------------------------------------------------------------------
+		// Input map row builder
+		// -------------------------------------------------------------------
+
+		openInputMapRows(inputMap) {
+			var $body = $('#aips-input-map-table-body');
+			$body.empty();
+
+			var rowIndex = 0;
+			Object.keys(inputMap).forEach(function(field) {
+				var value = inputMap[field];
+				var html = AIPS.Templates.render('aips-tmpl-input-map-row', {
+					row_index: rowIndex++,
+					field: field,
+					value: typeof value === 'string' ? value : JSON.stringify(value)
+				});
+				$body.append(html);
+			});
+		},
+
+		addInputMapRow() {
+			var $body = $('#aips-input-map-table-body');
+			var nextIndex = $body.find('tr').length;
+			var html = AIPS.Templates.render('aips-tmpl-input-map-row', { row_index: nextIndex, field: '', value: '' });
+			$body.append(html);
+		},
+
+		removeInputMapRow(e) {
+			$(e.currentTarget).closest('tr').remove();
+		},
+
+		collectInputMap() {
+			var map = {};
+
+			$('#aips-input-map-table-body tr').each(function() {
+				var field = $(this).find('.aips-input-map-field').val();
+				var value = $(this).find('.aips-input-map-value').val();
+
+				if (field) {
+					map[field] = value;
+				}
+			});
+
+			return map;
+		},
+
+		// -------------------------------------------------------------------
+		// Condition rule builder
+		// -------------------------------------------------------------------
+
+		openConditionRules(conditionTree) {
+			$('#aips-condition-operator').val(conditionTree.operator || 'AND');
+
+			var $body = $('#aips-condition-rules-table-body');
+			$body.empty();
+
+			var rules = Array.isArray(conditionTree.rules) ? conditionTree.rules : [];
+			var rowIndex = 0;
+
+			rules.forEach(function(rule) {
+				if (rule.rules) {
+					// Nested groups are not editable in this builder; skip.
+					return;
+				}
+
+				var html = AIPS.Templates.render('aips-tmpl-condition-rule-row', {
+					row_index: rowIndex++,
+					left: rule.left || '',
+					right: rule.right === undefined || rule.right === null ? '' : String(rule.right)
+				});
+				var $row = $(html);
+				$row.find('.aips-rule-operator').val(rule.operator || 'equals');
+				$body.append($row);
+			});
+		},
+
+		addConditionRuleRow() {
+			var $body = $('#aips-condition-rules-table-body');
+			var nextIndex = $body.find('tr').length;
+			var html = AIPS.Templates.render('aips-tmpl-condition-rule-row', { row_index: nextIndex, left: '', right: '' });
+			$body.append(html);
+		},
+
+		removeConditionRuleRow(e) {
+			$(e.currentTarget).closest('tr').remove();
+		},
+
+		collectConditionTree() {
+			var rules = [];
+
+			$('#aips-condition-rules-table-body tr').each(function() {
+				var left = $(this).find('.aips-rule-left').val();
+				var operator = $(this).find('.aips-rule-operator').val();
+				var right = $(this).find('.aips-rule-right').val();
+
+				if (left) {
+					rules.push({ left: left, operator: operator, right: right });
+				}
+			});
+
+			if (!rules.length) {
+				return {};
+			}
+
+			return { operator: $('#aips-condition-operator').val(), rules: rules };
+		},
+
+		// -------------------------------------------------------------------
+		// Save steps / run now
+		// -------------------------------------------------------------------
+
+		saveSteps() {
+			var self = this;
+			var payload = this.steps.map(function(step, index) {
+				return $.extend({}, step, { position: index });
+			});
+
+			$.post(aipsAjax.ajaxUrl, {
+				action: 'aips_save_ability_workflow_steps',
+				nonce: aipsAjax.nonce,
+				workflow_id: this.workflowId,
+				steps: JSON.stringify(payload)
+			}, function(response) {
+				if (!response.success) {
+					var message = (response.data && response.data.message) || aipsAbilityWorkflowBuilderL10n.saveFailed;
+					if (response.data && response.data.errors && response.data.errors.length) {
+						message += ' ' + response.data.errors.join(' ');
+					}
+					AIPS.Utilities.showToast(message, 'error');
+					return;
+				}
+
+				AIPS.Utilities.showToast(response.data.message || aipsAbilityWorkflowBuilderL10n.saveSteps, 'success');
+				self.steps = response.data.steps || self.steps;
+				self.renderSteps();
+			}).fail(function() {
+				AIPS.Utilities.showToast(aipsAbilityWorkflowBuilderL10n.saveFailed, 'error');
+			});
+		},
+
+		runNow() {
+			$.post(aipsAjax.ajaxUrl, {
+				action: 'aips_run_ability_workflow_now',
+				nonce: aipsAjax.nonce,
+				workflow_id: this.workflowId
+			}, function(response) {
+				if (!response.success) {
+					AIPS.Utilities.showToast((response.data && response.data.message) || aipsAbilityWorkflowBuilderL10n.saveFailed, 'error');
+					return;
+				}
+
+				AIPS.Utilities.showToast(response.data.message, 'success');
+				AIPS.AbilityWorkflowBuilder.runsLoaded = false;
+			});
+		},
+
+		// -------------------------------------------------------------------
+		// Runs tab
+		// -------------------------------------------------------------------
+
+		loadRuns() {
+			var self = this;
+
+			$.post(aipsAjax.ajaxUrl, {
+				action: 'aips_list_ability_workflow_runs',
+				nonce: aipsAjax.nonce,
+				workflow_id: this.workflowId,
+				per_page: 50
+			}, function(response) {
+				if (!response.success) {
+					AIPS.Utilities.showToast(aipsAbilityWorkflowBuilderL10n.loadRunsFailed, 'error');
+					return;
+				}
+
+				self.runsLoaded = true;
+				self.renderRuns(response.data.runs || []);
+			});
+		},
+
+		renderRuns(runs) {
+			var $body = $('#aips-runs-table-body');
+			$body.empty();
+
+			var statusMeta = {
+				queued: 'aips-badge-neutral',
+				running: 'aips-badge-warning',
+				completed: 'aips-badge-success',
+				failed: 'aips-badge-error',
+				cancelled: 'aips-badge-neutral'
+			};
+
+			runs.forEach(function(run) {
+				var html = AIPS.Templates.render('aips-tmpl-run-row', {
+					id: run.id,
+					status: run.status,
+					status_badge_class: statusMeta[run.status] || 'aips-badge-neutral',
+					started_display: run.started_at ? new Date(run.started_at * 1000).toLocaleString() : '',
+					finished_display: run.finished_at ? new Date(run.finished_at * 1000).toLocaleString() : ''
+				});
+				$body.append(html);
+			});
+
+			$('#aips-runs-empty').toggle(runs.length === 0);
+		},
+
+		viewRun(e) {
+			var runId = $(e.currentTarget).data('id');
+
+			$.post(aipsAjax.ajaxUrl, {
+				action: 'aips_get_ability_workflow_run',
+				nonce: aipsAjax.nonce,
+				run_id: runId
+			}, function(response) {
+				if (!response.success) {
+					AIPS.Utilities.showToast(aipsAbilityWorkflowBuilderL10n.loadRunsFailed, 'error');
+					return;
+				}
+
+				var $body = $('#aips-run-detail-table-body');
+				$body.empty();
+
+				var statusMeta = {
+					pending: 'aips-badge-neutral',
+					running: 'aips-badge-warning',
+					completed: 'aips-badge-success',
+					failed: 'aips-badge-error',
+					skipped: 'aips-badge-neutral'
+				};
+
+				(response.data.step_runs || []).forEach(function(stepRun) {
+					var payload = stepRun.status === 'failed' ? stepRun.error : stepRun.output_snapshot;
+
+					var html = AIPS.Templates.render('aips-tmpl-step-run-row', {
+						step_key: stepRun.step_key,
+						ability_name: stepRun.ability_name,
+						status: stepRun.status,
+						status_badge_class: statusMeta[stepRun.status] || 'aips-badge-neutral',
+						payload: JSON.stringify(payload || {}, null, 2)
+					});
+					$body.append(html);
+				});
+
+				$('#aips-run-detail-modal').css('display', 'flex');
+			});
+		}
+	};
+
+	$(document).ready(function() {
+		AIPS.AbilityWorkflowBuilder.init();
+	});
+})(jQuery);

--- a/ai-post-scheduler/assets/js/admin-ability-workflows.js
+++ b/ai-post-scheduler/assets/js/admin-ability-workflows.js
@@ -1,0 +1,243 @@
+(function($) {
+	'use strict';
+
+	window.AIPS = window.AIPS || {};
+	var AIPS = window.AIPS;
+
+	AIPS.AbilityWorkflows = {
+		searchTimer: null,
+
+		init() {
+			this.bindEvents();
+			this.loadWorkflows();
+		},
+
+		bindEvents() {
+			$(document).on('click', '#aips-add-workflow-btn, #aips-add-workflow-empty-btn', this.openCreateModal.bind(this));
+			$(document).on('click', '#aips-workflow-modal .aips-modal-close', this.closeModal.bind(this));
+			$(document).on('click', '#aips-save-workflow-btn', this.saveWorkflow.bind(this));
+
+			$(document).on('click', '.aips-run-workflow-now', this.runWorkflowNow.bind(this));
+			$(document).on('click', '.aips-duplicate-workflow', this.duplicateWorkflow.bind(this));
+			$(document).on('click', '.aips-archive-workflow', this.archiveWorkflow.bind(this));
+			$(document).on('click', '.aips-delete-workflow', this.deleteWorkflow.bind(this));
+
+			$(document).on('input', '#aips-workflow-search', this.onFilterChange.bind(this));
+			$(document).on('change', '#aips-workflow-status-filter', this.onFilterChange.bind(this));
+		},
+
+		onFilterChange() {
+			var self = this;
+			clearTimeout(this.searchTimer);
+			this.searchTimer = setTimeout(function() {
+				self.loadWorkflows();
+			}, 300);
+		},
+
+		loadWorkflows() {
+			var self = this;
+
+			$.post(aipsAjax.ajaxUrl, {
+				action: 'aips_list_ability_workflows',
+				nonce: aipsAjax.nonce,
+				search: $('#aips-workflow-search').val() || '',
+				status: $('#aips-workflow-status-filter').val() || '',
+				per_page: 100
+			}, function(response) {
+				if (!response.success) {
+					AIPS.Utilities.showToast((response.data && response.data.message) || aipsAbilityWorkflowsL10n.saveFailed, 'error');
+					return;
+				}
+
+				self.renderWorkflows(response.data.workflows || []);
+			}).fail(function() {
+				AIPS.Utilities.showToast(aipsAbilityWorkflowsL10n.saveFailed, 'error');
+			});
+		},
+
+		renderWorkflows(workflows) {
+			var $body = $('#aips-ability-workflows-table-body');
+			$body.empty();
+
+			var statusMeta = {
+				draft: { label: 'Draft', cls: 'aips-badge-neutral' },
+				active: { label: 'Active', cls: 'aips-badge-success' },
+				paused: { label: 'Paused', cls: 'aips-badge-warning' },
+				archived: { label: 'Archived', cls: 'aips-badge-neutral' }
+			};
+
+			workflows.forEach(function(workflow) {
+				var meta = statusMeta[workflow.status] || statusMeta.draft;
+				var builderUrl = window.aipsAbilityWorkflowBuilderBaseUrl + '&workflow_id=' + encodeURIComponent(workflow.id);
+
+				var html = AIPS.Templates.render('aips-tmpl-workflow-row', {
+					id: workflow.id,
+					status: workflow.status,
+					name: workflow.name,
+					description: workflow.description || '',
+					trigger_type: workflow.trigger_type,
+					status_badge_class: meta.cls,
+					status_label: meta.label,
+					updated_display: workflow.updated_at ? new Date(workflow.updated_at * 1000).toLocaleString() : '',
+					builder_url: builderUrl
+				});
+
+				$body.append(html);
+			});
+
+			$('#aips-ability-workflows-count').text(workflows.length + (workflows.length === 1 ? ' workflow' : ' workflows'));
+			$('#aips-ability-workflows-empty').toggle(workflows.length === 0);
+		},
+
+		openCreateModal() {
+			$('#aips-workflow-form')[0].reset();
+			$('#aips-workflow-id').val('0');
+			$('#aips-workflow-modal-title').text(aipsAbilityWorkflowsL10n.addNewWorkflow);
+			this.openModal();
+		},
+
+		openModal() {
+			$('#aips-workflow-modal').css('display', 'flex');
+		},
+
+		closeModal() {
+			$('#aips-workflow-modal').hide();
+		},
+
+		saveWorkflow() {
+			var name = $('#aips-workflow-name').val();
+
+			if (!name || !name.trim()) {
+				AIPS.Utilities.showToast(aipsAbilityWorkflowsL10n.nameRequired, 'error');
+				return;
+			}
+
+			var settings = {
+				max_steps: parseInt($('#aips-workflow-max-steps').val(), 10) || 20,
+				max_runtime_seconds: parseInt($('#aips-workflow-max-runtime').val(), 10) || 120,
+				allow_destructive_abilities: $('#aips-workflow-allow-destructive').is(':checked'),
+				log_payloads: $('#aips-workflow-log-payloads').is(':checked')
+			};
+
+			$.post(aipsAjax.ajaxUrl, {
+				action: 'aips_save_ability_workflow',
+				nonce: aipsAjax.nonce,
+				workflow_id: $('#aips-workflow-id').val(),
+				name: name,
+				description: $('#aips-workflow-description').val(),
+				status: $('#aips-workflow-status').val(),
+				trigger_type: $('#aips-workflow-trigger-type').val(),
+				trigger_config: JSON.stringify({}),
+				settings: JSON.stringify(settings)
+			}, function(response) {
+				if (!response.success) {
+					AIPS.Utilities.showToast((response.data && response.data.message) || aipsAbilityWorkflowsL10n.saveFailed, 'error');
+					return;
+				}
+
+				AIPS.Utilities.showToast(response.data.message || aipsAbilityWorkflowsL10n.saveWorkflow, 'success');
+				AIPS.AbilityWorkflows.closeModal();
+				AIPS.AbilityWorkflows.loadWorkflows();
+			}).fail(function() {
+				AIPS.Utilities.showToast(aipsAbilityWorkflowsL10n.saveFailed, 'error');
+			});
+		},
+
+		runWorkflowNow(e) {
+			var id = $(e.currentTarget).data('id');
+
+			$.post(aipsAjax.ajaxUrl, {
+				action: 'aips_run_ability_workflow_now',
+				nonce: aipsAjax.nonce,
+				workflow_id: id
+			}, function(response) {
+				if (!response.success) {
+					AIPS.Utilities.showToast((response.data && response.data.message) || aipsAbilityWorkflowsL10n.runFailed, 'error');
+					return;
+				}
+
+				AIPS.Utilities.showToast(response.data.message || aipsAbilityWorkflowsL10n.runStarted, 'success');
+			}).fail(function() {
+				AIPS.Utilities.showToast(aipsAbilityWorkflowsL10n.runFailed, 'error');
+			});
+		},
+
+		duplicateWorkflow(e) {
+			var id = $(e.currentTarget).data('id');
+
+			$.post(aipsAjax.ajaxUrl, {
+				action: 'aips_duplicate_ability_workflow',
+				nonce: aipsAjax.nonce,
+				workflow_id: id
+			}, function(response) {
+				if (!response.success) {
+					AIPS.Utilities.showToast((response.data && response.data.message) || aipsAbilityWorkflowsL10n.duplicateFailed, 'error');
+					return;
+				}
+
+				AIPS.Utilities.showToast(response.data.message, 'success');
+				AIPS.AbilityWorkflows.loadWorkflows();
+			}).fail(function() {
+				AIPS.Utilities.showToast(aipsAbilityWorkflowsL10n.duplicateFailed, 'error');
+			});
+		},
+
+		archiveWorkflow(e) {
+			var id = $(e.currentTarget).data('id');
+
+			AIPS.Utilities.confirm(
+				'Archive this workflow? It will stop running on its trigger until reactivated.',
+				'Archive Workflow',
+				[
+					{ label: 'Cancel', className: 'aips-btn aips-btn-secondary' },
+					{ label: 'Archive', className: 'aips-btn aips-btn-primary', action: function() {
+						$.post(aipsAjax.ajaxUrl, {
+							action: 'aips_archive_ability_workflow',
+							nonce: aipsAjax.nonce,
+							workflow_id: id
+						}, function(response) {
+							if (!response.success) {
+								AIPS.Utilities.showToast((response.data && response.data.message) || aipsAbilityWorkflowsL10n.archiveFailed, 'error');
+								return;
+							}
+
+							AIPS.Utilities.showToast(response.data.message, 'success');
+							AIPS.AbilityWorkflows.loadWorkflows();
+						});
+					} }
+				]
+			);
+		},
+
+		deleteWorkflow(e) {
+			var id = $(e.currentTarget).data('id');
+
+			AIPS.Utilities.confirm(
+				aipsAbilityWorkflowsL10n.deleteConfirm,
+				'Delete Workflow',
+				[
+					{ label: 'Cancel', className: 'aips-btn aips-btn-secondary' },
+					{ label: 'Delete', className: 'aips-btn aips-btn-danger', action: function() {
+						$.post(aipsAjax.ajaxUrl, {
+							action: 'aips_delete_ability_workflow',
+							nonce: aipsAjax.nonce,
+							workflow_id: id
+						}, function(response) {
+							if (!response.success) {
+								AIPS.Utilities.showToast((response.data && response.data.message) || aipsAbilityWorkflowsL10n.deleteFailed, 'error');
+								return;
+							}
+
+							AIPS.Utilities.showToast(response.data.message, 'success');
+							AIPS.AbilityWorkflows.loadWorkflows();
+						});
+					} }
+				]
+			);
+		}
+	};
+
+	$(document).ready(function() {
+		AIPS.AbilityWorkflows.init();
+	});
+})(jQuery);

--- a/ai-post-scheduler/includes/class-aips-ability-catalog-controller.php
+++ b/ai-post-scheduler/includes/class-aips-ability-catalog-controller.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Ability Catalog Controller
+ *
+ * Read-only AJAX endpoint for browsing available Abilities (used by the
+ * workflow builder's step picker). Kept separate from the workflow CRUD
+ * controllers since it has no workflow-specific state and is reusable
+ * anywhere the plugin needs to surface the ability catalog.
+ *
+ * @package AI_Post_Scheduler
+ * @since 3.2.0
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+/**
+ * Class AIPS_Ability_Catalog_Controller
+ */
+class AIPS_Ability_Catalog_Controller {
+
+	/**
+	 * @var AIPS_Ability_Catalog_Service
+	 */
+	private $catalog;
+
+	/**
+	 * Constructor. Registers all wp_ajax_* hooks owned by this controller.
+	 *
+	 * @param AIPS_Ability_Catalog_Service|null $catalog Catalog service.
+	 */
+	public function __construct( $catalog = null ) {
+		$this->catalog = $catalog ?: new AIPS_Ability_Catalog_Service();
+
+		add_action( 'wp_ajax_aips_list_abilities', array( $this, 'ajax_list_abilities' ) );
+	}
+
+	/**
+	 * List available abilities for the step picker.
+	 */
+	public function ajax_list_abilities() {
+		if ( ! check_ajax_referer( 'aips_ajax_nonce', 'nonce', false ) ) {
+			AIPS_Ajax_Response::error( __( 'Invalid nonce.', 'ai-post-scheduler' ) );
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			AIPS_Ajax_Response::permission_denied();
+		}
+
+		$args = array(
+			'category' => isset( $_POST['category'] ) ? sanitize_key( wp_unslash( $_POST['category'] ) ) : '',
+			'search'   => isset( $_POST['search'] ) ? sanitize_text_field( wp_unslash( $_POST['search'] ) ) : '',
+		);
+
+		$abilities = $this->catalog->list_abilities( $args );
+
+		if ( is_wp_error( $abilities ) ) {
+			AIPS_Ajax_Response::error( $abilities->get_error_message() );
+		}
+
+		AIPS_Ajax_Response::success( array( 'abilities' => array_values( $abilities ) ) );
+	}
+}

--- a/ai-post-scheduler/includes/class-aips-ability-catalog-service.php
+++ b/ai-post-scheduler/includes/class-aips-ability-catalog-service.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * Ability Catalog Service
+ *
+ * The only class the workflow UI/AJAX layer and executor should call for
+ * ability discovery. Wraps AIPS_Ability_Service and normalizes its output
+ * into a stable shape the workflow builder and executor can depend on.
+ *
+ * Never re-implements ability provider discovery — that lives entirely in
+ * AIPS_Ability_Service.
+ *
+ * @package AI_Post_Scheduler
+ * @since 3.2.0
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+/**
+ * Class AIPS_Ability_Catalog_Service
+ */
+class AIPS_Ability_Catalog_Service {
+
+	/**
+	 * @var AIPS_Ability_Service
+	 */
+	private $ability_service;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param AIPS_Ability_Service|null $ability_service Ability service adapter.
+	 */
+	public function __construct( ?AIPS_Ability_Service $ability_service = null ) {
+		if ( $ability_service ) {
+			$this->ability_service = $ability_service;
+			return;
+		}
+
+		$container = AIPS_Container::get_instance();
+		$this->ability_service = $container->has( AIPS_Ability_Service::class )
+			? $container->make( AIPS_Ability_Service::class )
+			: new AIPS_Ability_Service();
+	}
+
+	/**
+	 * List available abilities, normalized.
+	 *
+	 * @param array $args {
+	 *     @type string $category Optional category filter.
+	 *     @type string $search   Optional label/description/name search.
+	 * }
+	 * @return array|WP_Error Array of normalized ability arrays keyed by name, or WP_Error.
+	 */
+	public function list_abilities( array $args = array() ) {
+		$abilities = $this->ability_service->list_available();
+
+		if ( is_wp_error( $abilities ) ) {
+			return $abilities;
+		}
+
+		$normalized = array();
+
+		foreach ( $abilities as $slug => $raw_ability ) {
+			$normalized[ $slug ] = $this->normalize_ability( is_array( $raw_ability ) ? $raw_ability : array( 'slug' => $slug ) );
+		}
+
+		if ( ! empty( $args['category'] ) ) {
+			$category   = (string) $args['category'];
+			$normalized = array_filter(
+				$normalized,
+				function ( $ability ) use ( $category ) {
+					return $ability['category'] === $category;
+				}
+			);
+		}
+
+		if ( ! empty( $args['search'] ) ) {
+			$search     = strtolower( (string) $args['search'] );
+			$normalized = array_filter(
+				$normalized,
+				function ( $ability ) use ( $search ) {
+					$haystack = strtolower( $ability['name'] . ' ' . $ability['label'] . ' ' . $ability['description'] );
+					return false !== strpos( $haystack, $search );
+				}
+			);
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Get a single normalized ability.
+	 *
+	 * @param string $ability_name Ability slug.
+	 * @return array|WP_Error
+	 */
+	public function get_ability( string $ability_name ) {
+		$abilities = $this->list_abilities();
+
+		if ( is_wp_error( $abilities ) ) {
+			return $abilities;
+		}
+
+		if ( ! isset( $abilities[ $ability_name ] ) ) {
+			return new WP_Error(
+				'ability_not_found',
+				/* translators: %s: ability name */
+				sprintf( __( 'Ability "%s" was not found.', 'ai-post-scheduler' ), $ability_name )
+			);
+		}
+
+		return $abilities[ $ability_name ];
+	}
+
+	/**
+	 * Normalize a raw ability array (from AIPS_Ability_Service::list_available())
+	 * into the stable shape the UI/executor depend on.
+	 *
+	 * @param array $raw_ability Raw ability data.
+	 * @return array {
+	 *     @type string      $name                 Ability slug.
+	 *     @type string      $label                Human-readable label.
+	 *     @type string      $description          Description text.
+	 *     @type string      $provider             Provider label/source.
+	 *     @type string      $category             Category, defaults to 'general'.
+	 *     @type array       $input_schema         Input schema, if provided by the raw ability.
+	 *     @type array       $output_schema        Output schema, if provided by the raw ability.
+	 *     @type string|null $permission_callback  Permission callback identifier, if any.
+	 *     @type bool        $is_destructive       Whether invoking this ability mutates state destructively.
+	 *     @type bool        $is_available         Whether this ability is currently invocable.
+	 *     @type array       $metadata             Any remaining raw fields, for forward-compat display.
+	 * }
+	 */
+	public function normalize_ability( array $raw_ability ): array {
+		$slug = isset( $raw_ability['slug'] ) ? (string) $raw_ability['slug'] : ( isset( $raw_ability['name'] ) ? (string) $raw_ability['name'] : '' );
+
+		$known_keys = array(
+			'slug', 'name', 'label', 'description', 'provider', 'category',
+			'input_schema', 'output_schema', 'permission_callback',
+			'is_destructive', 'destructive', 'is_available',
+		);
+
+		return array(
+			'name'                 => $slug,
+			'label'                => ! empty( $raw_ability['label'] ) ? (string) $raw_ability['label'] : $this->humanize_slug( $slug ),
+			'description'          => isset( $raw_ability['description'] ) ? (string) $raw_ability['description'] : '',
+			'provider'             => isset( $raw_ability['provider'] ) ? (string) $raw_ability['provider'] : __( 'Unknown', 'ai-post-scheduler' ),
+			'category'             => ! empty( $raw_ability['category'] ) ? (string) $raw_ability['category'] : 'general',
+			'input_schema'         => isset( $raw_ability['input_schema'] ) && is_array( $raw_ability['input_schema'] ) ? $raw_ability['input_schema'] : array(),
+			'output_schema'        => isset( $raw_ability['output_schema'] ) && is_array( $raw_ability['output_schema'] ) ? $raw_ability['output_schema'] : array(),
+			'permission_callback'  => isset( $raw_ability['permission_callback'] ) ? $raw_ability['permission_callback'] : null,
+			'is_destructive'       => ! empty( $raw_ability['is_destructive'] ) || ! empty( $raw_ability['destructive'] ),
+			'is_available'         => array_key_exists( 'is_available', $raw_ability ) ? (bool) $raw_ability['is_available'] : true,
+			'metadata'             => array_diff_key( $raw_ability, array_flip( $known_keys ) ),
+		);
+	}
+
+	/**
+	 * Validate that an ability is currently available for invocation.
+	 *
+	 * @param string $ability_name Ability slug.
+	 * @return true|WP_Error
+	 */
+	public function validate_ability_available( string $ability_name ) {
+		$available = $this->ability_service->is_available( $ability_name );
+
+		if ( is_wp_error( $available ) ) {
+			return $available;
+		}
+
+		if ( ! $available ) {
+			return new WP_Error(
+				'ability_unavailable',
+				/* translators: %s: ability name */
+				sprintf( __( 'Ability "%s" is not available.', 'ai-post-scheduler' ), $ability_name )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get the input schema for an ability.
+	 *
+	 * @param string $ability_name Ability slug.
+	 * @return array|WP_Error
+	 */
+	public function get_input_schema( string $ability_name ) {
+		$ability = $this->get_ability( $ability_name );
+
+		return is_wp_error( $ability ) ? $ability : $ability['input_schema'];
+	}
+
+	/**
+	 * Get the output schema for an ability.
+	 *
+	 * @param string $ability_name Ability slug.
+	 * @return array|WP_Error
+	 */
+	public function get_output_schema( string $ability_name ) {
+		$ability = $this->get_ability( $ability_name );
+
+		return is_wp_error( $ability ) ? $ability : $ability['output_schema'];
+	}
+
+	/**
+	 * Turn a slug like "vendor/create-outline" into a display label.
+	 *
+	 * @param string $slug Ability slug.
+	 * @return string
+	 */
+	private function humanize_slug( string $slug ): string {
+		$label = preg_replace( '/^[^\/]+\//', '', $slug );
+		$label = str_replace( array( '-', '_' ), ' ', $label );
+
+		return ucwords( trim( $label ) );
+	}
+}

--- a/ai-post-scheduler/includes/class-aips-ability-workflow-condition-evaluator.php
+++ b/ai-post-scheduler/includes/class-aips-ability-workflow-condition-evaluator.php
@@ -1,0 +1,279 @@
+<?php
+/**
+ * Ability Workflow Condition Evaluator
+ *
+ * Pure logic for evaluating and validating AND/OR condition trees used by
+ * workflow steps. No DB, HTTP, or ability calls — safe to unit test in
+ * isolation and reused by both the executor (runtime) and the document
+ * validator (save-time validation).
+ *
+ * Condition tree shape:
+ *   array(
+ *       'operator' => 'AND'|'OR',
+ *       'rules'    => array(
+ *           array( 'left' => '{{steps.outline.output.sections_count}}', 'operator' => '>', 'right' => 0 ),
+ *           array( 'operator' => 'OR', 'rules' => array( ... ) ), // nested group
+ *       ),
+ *   )
+ *
+ * An empty tree (no rules) always evaluates to true — a step with no
+ * conditions always runs.
+ *
+ * @package AI_Post_Scheduler
+ * @since 3.2.0
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+/**
+ * Class AIPS_Ability_Workflow_Condition_Evaluator
+ */
+class AIPS_Ability_Workflow_Condition_Evaluator {
+
+	/**
+	 * Supported rule operators.
+	 */
+	const RULE_OPERATORS = array(
+		'equals',
+		'not_equals',
+		'contains',
+		'not_contains',
+		'greater_than',
+		'less_than',
+		'is_empty',
+		'is_not_empty',
+		'in',
+		'not_in',
+		// Symbolic aliases accepted from the spec's example document.
+		'>',
+		'<',
+		'==',
+		'!=',
+	);
+
+	/**
+	 * @var AIPS_Ability_Workflow_Variable_Resolver
+	 */
+	private $resolver;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param AIPS_Ability_Workflow_Variable_Resolver|null $resolver Variable resolver.
+	 */
+	public function __construct( ?AIPS_Ability_Workflow_Variable_Resolver $resolver = null ) {
+		$this->resolver = $resolver ?: new AIPS_Ability_Workflow_Variable_Resolver();
+	}
+
+	/**
+	 * Evaluate a condition tree against a variable bag.
+	 *
+	 * @param array $condition_tree Condition tree (see class docblock).
+	 * @param array $variables      Variable bag (trigger/steps).
+	 * @return bool
+	 */
+	public function evaluate( array $condition_tree, array $variables ): bool {
+		if ( empty( $condition_tree ) || empty( $condition_tree['rules'] ) ) {
+			return true;
+		}
+
+		$operator = strtoupper( isset( $condition_tree['operator'] ) ? (string) $condition_tree['operator'] : 'AND' );
+		$results  = array();
+
+		foreach ( $condition_tree['rules'] as $rule ) {
+			if ( ! is_array( $rule ) ) {
+				continue;
+			}
+
+			$results[] = $this->is_nested_group( $rule )
+				? $this->evaluate( $rule, $variables )
+				: $this->evaluate_rule( $rule, $variables );
+		}
+
+		if ( empty( $results ) ) {
+			return true;
+		}
+
+		return 'OR' === $operator ? in_array( true, $results, true ) : ! in_array( false, $results, true );
+	}
+
+	/**
+	 * Evaluate a single leaf rule.
+	 *
+	 * @param array $rule      { left, operator, right }.
+	 * @param array $variables Variable bag.
+	 * @return bool
+	 */
+	public function evaluate_rule( array $rule, array $variables ): bool {
+		$left     = $this->resolve_operand( $rule['left'] ?? null, $variables );
+		$operator = isset( $rule['operator'] ) ? (string) $rule['operator'] : 'equals';
+
+		if ( in_array( $operator, array( 'is_empty' ), true ) ) {
+			return $this->is_empty_value( $left );
+		}
+
+		if ( in_array( $operator, array( 'is_not_empty' ), true ) ) {
+			return ! $this->is_empty_value( $left );
+		}
+
+		$right = $this->resolve_operand( $rule['right'] ?? null, $variables );
+
+		switch ( $operator ) {
+			case 'equals':
+			case '==':
+				return $this->loose_compare( $left, $right ) === 0;
+			case 'not_equals':
+			case '!=':
+				return $this->loose_compare( $left, $right ) !== 0;
+			case 'contains':
+				return is_string( $left ) && is_scalar( $right ) && false !== strpos( $left, (string) $right );
+			case 'not_contains':
+				return ! ( is_string( $left ) && is_scalar( $right ) && false !== strpos( $left, (string) $right ) );
+			case 'greater_than':
+			case '>':
+				return is_numeric( $left ) && is_numeric( $right ) && (float) $left > (float) $right;
+			case 'less_than':
+			case '<':
+				return is_numeric( $left ) && is_numeric( $right ) && (float) $left < (float) $right;
+			case 'in':
+				return in_array( $left, $this->to_list( $right ), false );
+			case 'not_in':
+				return ! in_array( $left, $this->to_list( $right ), false );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Structurally validate a condition tree (does not evaluate it).
+	 *
+	 * @param array $condition_tree Condition tree to validate.
+	 * @return true|WP_Error
+	 */
+	public function validate_condition_tree( array $condition_tree ) {
+		if ( empty( $condition_tree ) ) {
+			return true;
+		}
+
+		if ( isset( $condition_tree['operator'] ) && ! in_array( strtoupper( (string) $condition_tree['operator'] ), array( 'AND', 'OR' ), true ) ) {
+			return new WP_Error( 'ability_workflow_condition_invalid', __( 'Condition group operator must be AND or OR.', 'ai-post-scheduler' ) );
+		}
+
+		if ( ! isset( $condition_tree['rules'] ) ) {
+			return true;
+		}
+
+		if ( ! is_array( $condition_tree['rules'] ) ) {
+			return new WP_Error( 'ability_workflow_condition_invalid', __( 'Condition rules must be an array.', 'ai-post-scheduler' ) );
+		}
+
+		foreach ( $condition_tree['rules'] as $rule ) {
+			if ( ! is_array( $rule ) ) {
+				return new WP_Error( 'ability_workflow_condition_invalid', __( 'Each condition rule must be an array.', 'ai-post-scheduler' ) );
+			}
+
+			if ( $this->is_nested_group( $rule ) ) {
+				$nested_result = $this->validate_condition_tree( $rule );
+				if ( is_wp_error( $nested_result ) ) {
+					return $nested_result;
+				}
+				continue;
+			}
+
+			if ( ! array_key_exists( 'left', $rule ) || ! isset( $rule['operator'] ) ) {
+				return new WP_Error( 'ability_workflow_condition_invalid', __( 'Each condition rule requires "left" and "operator".', 'ai-post-scheduler' ) );
+			}
+
+			if ( ! in_array( (string) $rule['operator'], self::RULE_OPERATORS, true ) ) {
+				return new WP_Error(
+					'ability_workflow_condition_invalid',
+					/* translators: %s: operator name */
+					sprintf( __( 'Unsupported condition operator "%s".', 'ai-post-scheduler' ), $rule['operator'] )
+				);
+			}
+
+			if ( is_string( $rule['left'] ) && false !== strpos( $rule['left'], '{{' ) ) {
+				$token_result = $this->resolver->validate_token_string( $rule['left'] );
+				if ( is_wp_error( $token_result ) ) {
+					return $token_result;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Whether a rule array is a nested condition group rather than a leaf rule.
+	 *
+	 * @param array $rule Rule array.
+	 * @return bool
+	 */
+	private function is_nested_group( array $rule ): bool {
+		return isset( $rule['rules'] ) && is_array( $rule['rules'] );
+	}
+
+	/**
+	 * Resolve a rule operand, following {{...}} tokens when the operand is a string.
+	 *
+	 * @param mixed $value     Raw operand.
+	 * @param array $variables Variable bag.
+	 * @return mixed
+	 */
+	private function resolve_operand( $value, array $variables ) {
+		if ( is_string( $value ) ) {
+			return $this->resolver->resolve( $value, $variables );
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Whether a resolved value should be treated as empty.
+	 *
+	 * @param mixed $value Value to check.
+	 * @return bool
+	 */
+	private function is_empty_value( $value ): bool {
+		if ( is_array( $value ) ) {
+			return empty( $value );
+		}
+
+		return null === $value || '' === $value;
+	}
+
+	/**
+	 * Loosely compare two scalar/array values, treating numeric strings as numbers.
+	 *
+	 * @param mixed $left  Left operand.
+	 * @param mixed $right Right operand.
+	 * @return int -1, 0, or 1.
+	 */
+	private function loose_compare( $left, $right ): int {
+		if ( is_numeric( $left ) && is_numeric( $right ) ) {
+			return (float) $left <=> (float) $right;
+		}
+
+		return (string) $left <=> (string) $right;
+	}
+
+	/**
+	 * Coerce a value into a list for in/not_in comparisons.
+	 *
+	 * @param mixed $value Raw value — array, comma-separated string, or scalar.
+	 * @return array
+	 */
+	private function to_list( $value ): array {
+		if ( is_array( $value ) ) {
+			return $value;
+		}
+
+		if ( is_string( $value ) ) {
+			return array_map( 'trim', explode( ',', $value ) );
+		}
+
+		return array( $value );
+	}
+}

--- a/ai-post-scheduler/includes/class-aips-ability-workflow-document-validator.php
+++ b/ai-post-scheduler/includes/class-aips-ability-workflow-document-validator.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * Ability Workflow Document Validator
+ *
+ * Validates a decoded workflow document (a workflow's steps + settings)
+ * before it is persisted. Pure logic composed from the condition evaluator,
+ * variable resolver, and (optionally) the ability catalog — no direct SQL.
+ *
+ * Used by the "save workflow steps" AJAX handler before calling
+ * AIPS_Ability_Workflow_Repository::save_steps().
+ *
+ * @package AI_Post_Scheduler
+ * @since 3.2.0
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+/**
+ * Class AIPS_Ability_Workflow_Document_Validator
+ */
+class AIPS_Ability_Workflow_Document_Validator {
+
+	/**
+	 * Allowed on_success/on_failure strategies.
+	 */
+	const STRATEGIES = array( 'continue', 'stop', 'skip' );
+
+	/**
+	 * @var AIPS_Ability_Workflow_Condition_Evaluator
+	 */
+	private $condition_evaluator;
+
+	/**
+	 * @var AIPS_Ability_Workflow_Variable_Resolver
+	 */
+	private $resolver;
+
+	/**
+	 * @var AIPS_Ability_Catalog_Service|null
+	 */
+	private $catalog;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param AIPS_Ability_Workflow_Condition_Evaluator|null $condition_evaluator Condition evaluator.
+	 * @param AIPS_Ability_Workflow_Variable_Resolver|null   $resolver            Variable resolver.
+	 * @param AIPS_Ability_Catalog_Service|null              $catalog             Ability catalog service.
+	 */
+	public function __construct(
+		?AIPS_Ability_Workflow_Condition_Evaluator $condition_evaluator = null,
+		?AIPS_Ability_Workflow_Variable_Resolver $resolver = null,
+		?AIPS_Ability_Catalog_Service $catalog = null
+	) {
+		$this->resolver            = $resolver ?: new AIPS_Ability_Workflow_Variable_Resolver();
+		$this->condition_evaluator = $condition_evaluator ?: new AIPS_Ability_Workflow_Condition_Evaluator( $this->resolver );
+		$this->catalog             = $catalog;
+	}
+
+	/**
+	 * Validate a workflow document's steps.
+	 *
+	 * @param array $workflow_document {
+	 *     @type array $steps Array of step field arrays.
+	 * }
+	 * @param bool  $skip_ability_check When true, skip catalog ability-availability checks
+	 *                                  (useful offline/in tests where no provider is registered).
+	 * @return true|WP_Error WP_Error data carries a list of per-field errors.
+	 */
+	public function validate( array $workflow_document, bool $skip_ability_check = false ) {
+		$steps = isset( $workflow_document['steps'] ) && is_array( $workflow_document['steps'] ) ? $workflow_document['steps'] : array();
+		$errors = array();
+
+		$seen_keys     = array();
+		$earlier_keys  = array();
+		$earlier_alias = array();
+
+		foreach ( $steps as $index => $step ) {
+			if ( ! is_array( $step ) ) {
+				$errors[] = sprintf( 'Step at index %d must be an array.', $index );
+				continue;
+			}
+
+			$step_key = isset( $step['step_key'] ) ? (string) $step['step_key'] : '';
+
+			if ( '' === $step_key ) {
+				$errors[] = sprintf( 'Step at index %d is missing a step_key.', $index );
+			} elseif ( isset( $seen_keys[ $step_key ] ) ) {
+				$errors[] = sprintf( 'Duplicate step_key "%s".', $step_key );
+			} else {
+				$seen_keys[ $step_key ] = true;
+			}
+
+			if ( empty( $step['ability_name'] ) ) {
+				$errors[] = sprintf( 'Step "%s" is missing an ability_name.', $step_key );
+			} elseif ( ! $skip_ability_check && $this->catalog instanceof AIPS_Ability_Catalog_Service ) {
+				$available = $this->catalog->validate_ability_available( (string) $step['ability_name'] );
+				if ( is_wp_error( $available ) ) {
+					$errors[] = sprintf( 'Step "%s": %s', $step_key, $available->get_error_message() );
+				}
+			}
+
+			foreach ( array( 'depends_on' ) as $ref_field ) {
+				if ( ! empty( $step[ $ref_field ] ) && is_array( $step[ $ref_field ] ) ) {
+					foreach ( $step[ $ref_field ] as $dep_key ) {
+						if ( ! in_array( (string) $dep_key, $earlier_keys, true ) ) {
+							$errors[] = sprintf( 'Step "%s" depends_on unknown or later step "%s".', $step_key, $dep_key );
+						}
+					}
+				}
+			}
+
+			if ( ! empty( $step['condition_tree'] ) && is_array( $step['condition_tree'] ) ) {
+				$condition_result = $this->condition_evaluator->validate_condition_tree( $step['condition_tree'] );
+				if ( is_wp_error( $condition_result ) ) {
+					$errors[] = sprintf( 'Step "%s": %s', $step_key, $condition_result->get_error_message() );
+				}
+			}
+
+			if ( ! empty( $step['input_map'] ) && is_array( $step['input_map'] ) ) {
+				$input_map_errors = $this->validate_input_map( $step['input_map'], $earlier_alias );
+				foreach ( $input_map_errors as $message ) {
+					$errors[] = sprintf( 'Step "%s": %s', $step_key, $message );
+				}
+			}
+
+			foreach ( array( 'on_success', 'on_failure' ) as $strategy_field ) {
+				if ( ! empty( $step[ $strategy_field ]['strategy'] ) && ! in_array( $step[ $strategy_field ]['strategy'], self::STRATEGIES, true ) ) {
+					$errors[] = sprintf( 'Step "%s" has an invalid %s.strategy "%s".', $step_key, $strategy_field, $step[ $strategy_field ]['strategy'] );
+				}
+			}
+
+			if ( ! empty( $step['retry_policy'] ) && is_array( $step['retry_policy'] ) ) {
+				foreach ( array( 'attempts', 'backoff_seconds' ) as $retry_field ) {
+					if ( isset( $step['retry_policy'][ $retry_field ] ) && ( ! is_numeric( $step['retry_policy'][ $retry_field ] ) || (int) $step['retry_policy'][ $retry_field ] < 0 ) ) {
+						$errors[] = sprintf( 'Step "%s" retry_policy.%s must be a non-negative integer.', $step_key, $retry_field );
+					}
+				}
+			}
+
+			if ( '' !== $step_key ) {
+				$earlier_keys[] = $step_key;
+			}
+			if ( ! empty( $step['output_alias'] ) ) {
+				$earlier_alias[] = (string) $step['output_alias'];
+			}
+		}
+
+		if ( ! empty( $errors ) ) {
+			return new WP_Error( 'ability_workflow_validation_failed', __( 'Workflow validation failed.', 'ai-post-scheduler' ), array( 'errors' => $errors ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validate every token in an input map, ensuring tokens are structurally
+	 * valid and — for steps.* tokens — reference only earlier steps' output_alias.
+	 *
+	 * @param array $input_map     Input map (dest field => template value or nested map).
+	 * @param array $earlier_alias Output aliases seen so far, in step order.
+	 * @return string[] Error messages, empty when valid.
+	 */
+	private function validate_input_map( array $input_map, array $earlier_alias ): array {
+		$errors = array();
+
+		array_walk_recursive(
+			$input_map,
+			function ( $value ) use ( &$errors, $earlier_alias ) {
+				if ( ! is_string( $value ) || false === strpos( $value, '{{' ) ) {
+					return;
+				}
+
+				foreach ( $this->resolver->extract_tokens( $value ) as $token ) {
+					$token_result = $this->resolver->validate_token( $token );
+
+					if ( is_wp_error( $token_result ) ) {
+						$errors[] = $token_result->get_error_message();
+						continue;
+					}
+
+					if ( 0 === strpos( $token, 'steps.' ) ) {
+						$alias = explode( '.', $token )[1] ?? '';
+						if ( ! in_array( $alias, $earlier_alias, true ) ) {
+							$errors[] = sprintf( 'Input map references unknown or later step output alias "%s".', $alias );
+						}
+					}
+				}
+			}
+		);
+
+		return $errors;
+	}
+}

--- a/ai-post-scheduler/includes/class-aips-ability-workflow-executor.php
+++ b/ai-post-scheduler/includes/class-aips-ability-workflow-executor.php
@@ -173,6 +173,14 @@ class AIPS_Ability_Workflow_Executor {
 		);
 
 		if ( ! $scheduled ) {
+			// Mark the already-created run row failed instead of leaving it
+			// orphaned at 'queued' forever with nothing to ever process it.
+			$this->repository->update_run_status(
+				$run_id,
+				AIPS_Ability_Workflow_Repository::RUN_STATUS_FAILED,
+				array( 'finished_at' => time() )
+			);
+
 			return new WP_Error( 'ability_workflow_dispatch_failed', __( 'Failed to schedule workflow run.', 'ai-post-scheduler' ) );
 		}
 
@@ -295,7 +303,12 @@ class AIPS_Ability_Workflow_Executor {
 			}
 
 			if ( microtime( true ) >= $deadline ) {
-				$this->schedule_continuation( $run_id, $correlation_id, self::CONTINUATION_DELAY_SECONDS );
+				if ( ! $this->schedule_continuation( $run_id, $correlation_id, self::CONTINUATION_DELAY_SECONDS ) ) {
+					// Without a scheduled continuation nothing will ever
+					// resume this run — fail it now instead of leaving it
+					// stuck at 'running' indefinitely.
+					$this->finish_run( $run_id, AIPS_Ability_Workflow_Repository::RUN_STATUS_FAILED, $history, __( 'Failed to schedule workflow continuation.', 'ai-post-scheduler' ) );
+				}
 				return;
 			}
 
@@ -471,7 +484,18 @@ class AIPS_Ability_Workflow_Executor {
 				)
 			);
 
-			$this->schedule_continuation( $run_id, $correlation_id, $backoff_seconds );
+			if ( ! $this->schedule_continuation( $run_id, $correlation_id, $backoff_seconds ) ) {
+				// No further progress is possible without a scheduled retry —
+				// fail the run outright rather than leaving it stuck at
+				// 'running' forever with nothing left to resume it.
+				$this->finish_run(
+					$run_id,
+					AIPS_Ability_Workflow_Repository::RUN_STATUS_FAILED,
+					$history,
+					/* translators: %s: step key */
+					sprintf( __( 'Failed to schedule a retry for step "%s".', 'ai-post-scheduler' ), $step->step_key )
+				);
+			}
 
 			return array( 'status' => 'failed', 'output' => array(), 'retry_scheduled' => true );
 		}
@@ -608,10 +632,10 @@ class AIPS_Ability_Workflow_Executor {
 	 * @param int    $run_id         Run ID.
 	 * @param string $correlation_id Correlation ID to resume under.
 	 * @param int    $delay_seconds  Delay before the event fires.
-	 * @return void
+	 * @return bool True if the event was scheduled successfully.
 	 */
-	private function schedule_continuation( int $run_id, string $correlation_id, int $delay_seconds ): void {
-		$this->job_scheduler->schedule_simple(
+	private function schedule_continuation( int $run_id, string $correlation_id, int $delay_seconds ): bool {
+		return $this->job_scheduler->schedule_simple(
 			self::HOOK,
 			time() + $delay_seconds,
 			array( $run_id, $correlation_id ),

--- a/ai-post-scheduler/includes/class-aips-ability-workflow-executor.php
+++ b/ai-post-scheduler/includes/class-aips-ability-workflow-executor.php
@@ -281,7 +281,13 @@ class AIPS_Ability_Workflow_Executor {
 		}
 
 		$variables = $this->build_variables( $run, $steps, $existing_step_runs );
-		$skip_keys = array();
+
+		// Rebuilt from persisted step statuses/strategies on every
+		// invocation (not just accumulated within this pass) so a 'skip'
+		// cascade triggered by an earlier invocation isn't lost if the run
+		// was interrupted (time budget / retry backoff) before every
+		// dependent step in the cascade had been reached.
+		$skip_keys = $this->rebuild_skip_cascade( $steps, $resolved_status );
 
 		foreach ( $steps as $step ) {
 			if ( isset( $resolved_status[ $step->step_key ] ) ) {
@@ -521,6 +527,43 @@ class AIPS_Ability_Workflow_Executor {
 				$this->mark_dependents_skipped( $candidate->step_key, $steps, $skip_keys );
 			}
 		}
+	}
+
+	/**
+	 * Reconstruct the full skip-cascade set from persisted step statuses and
+	 * strategies. Called at the start of every run_internal() invocation so
+	 * that a 'skip' strategy's cascade is idempotently rebuilt from durable
+	 * state rather than relying on the in-memory accumulation of a single
+	 * pass through the steps loop — a run can span multiple cron
+	 * invocations (time budget continuations, retry backoff), and without
+	 * this, a cascade only partially applied before an interruption would
+	 * be lost, letting a step that should stay permanently skipped execute
+	 * on a later invocation.
+	 *
+	 * @param AIPS_Ability_Workflow_Step[] $steps           All steps for the workflow.
+	 * @param array                        $resolved_status Map of step_key => resolved status ('completed'/'failed'/'skipped').
+	 * @return array Map of step_key => true for every step that must be treated as skipped.
+	 */
+	private function rebuild_skip_cascade( array $steps, array $resolved_status ): array {
+		$skip_keys = array();
+
+		foreach ( $steps as $step ) {
+			$status = $resolved_status[ $step->step_key ] ?? '';
+
+			if ( 'completed' === $status ) {
+				$strategy = isset( $step->on_success['strategy'] ) ? $step->on_success['strategy'] : 'continue';
+			} elseif ( 'failed' === $status ) {
+				$strategy = isset( $step->on_failure['strategy'] ) ? $step->on_failure['strategy'] : 'stop';
+			} else {
+				continue;
+			}
+
+			if ( 'skip' === $strategy ) {
+				$this->mark_dependents_skipped( $step->step_key, $steps, $skip_keys );
+			}
+		}
+
+		return $skip_keys;
 	}
 
 	/**

--- a/ai-post-scheduler/includes/class-aips-ability-workflow-executor.php
+++ b/ai-post-scheduler/includes/class-aips-ability-workflow-executor.php
@@ -1,0 +1,601 @@
+<?php
+/**
+ * Ability Workflow Executor
+ *
+ * Runs a single Ability Workflow run: resolves step inputs against a
+ * run-scoped variable bag, evaluates AND/OR conditions, invokes abilities
+ * via AIPS_Ability_Service, persists per-step results, and self-chains via
+ * a dedicated cron hook when it runs out of time budget or a step needs a
+ * backoff retry.
+ *
+ * A workflow run is NOT modeled as a bulk-batch job — bulk batch jobs are
+ * flat, order-independent item lists dispatched as pre-scheduled parallel
+ * slices, whereas workflow steps run in dependency order with conditional
+ * branching that can only be evaluated once earlier steps have produced
+ * output. Instead this class registers its own single-event hook
+ * (self::HOOK) and reschedules itself to continue where it left off.
+ *
+ * @package AI_Post_Scheduler
+ * @since 3.2.0
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+/**
+ * Class AIPS_Ability_Workflow_Executor
+ */
+class AIPS_Ability_Workflow_Executor {
+
+	/**
+	 * Single-event cron hook this executor's process_run() is bound to.
+	 */
+	const HOOK = 'aips_run_ability_workflow';
+
+	/**
+	 * Default wall-clock budget (seconds) for a single cron invocation before
+	 * scheduling a continuation event instead of pushing past PHP's
+	 * max_execution_time.
+	 */
+	const DEFAULT_TIME_BUDGET_SECONDS = 20;
+
+	/**
+	 * Delay (seconds) before a continuation event fires when the time budget
+	 * for the current invocation is exhausted mid-run.
+	 */
+	const CONTINUATION_DELAY_SECONDS = 2;
+
+	/**
+	 * Step-run statuses that mean "already resolved, do not re-attempt".
+	 */
+	const RESOLVED_STEP_STATUSES = array( 'completed', 'failed', 'skipped' );
+
+	/**
+	 * @var AIPS_Ability_Workflow_Repository
+	 */
+	private $repository;
+
+	/**
+	 * @var AIPS_Ability_Catalog_Service
+	 */
+	private $catalog;
+
+	/**
+	 * @var AIPS_Ability_Service
+	 */
+	private $ability_service;
+
+	/**
+	 * @var AIPS_Ability_Workflow_Condition_Evaluator
+	 */
+	private $condition_evaluator;
+
+	/**
+	 * @var AIPS_Ability_Workflow_Variable_Resolver
+	 */
+	private $resolver;
+
+	/**
+	 * @var AIPS_Job_Scheduler
+	 */
+	private $job_scheduler;
+
+	/**
+	 * @var AIPS_History_Service_Interface
+	 */
+	private $history_service;
+
+	/**
+	 * @var AIPS_Logger_Interface
+	 */
+	private $logger;
+
+	/**
+	 * Constructor. Every dependency is optional and resolved from the
+	 * container when omitted.
+	 */
+	public function __construct(
+		?AIPS_Ability_Workflow_Repository $repository = null,
+		?AIPS_Ability_Catalog_Service $catalog = null,
+		?AIPS_Ability_Service $ability_service = null,
+		?AIPS_Ability_Workflow_Condition_Evaluator $condition_evaluator = null,
+		?AIPS_Ability_Workflow_Variable_Resolver $resolver = null,
+		?AIPS_Job_Scheduler $job_scheduler = null,
+		?AIPS_History_Service_Interface $history_service = null,
+		?AIPS_Logger_Interface $logger = null
+	) {
+		$container = AIPS_Container::get_instance();
+
+		$this->repository = $repository ?: ( $container->has( AIPS_Ability_Workflow_Repository::class )
+			? $container->make( AIPS_Ability_Workflow_Repository::class )
+			: AIPS_Ability_Workflow_Repository::instance() );
+
+		$this->ability_service = $ability_service ?: ( $container->has( AIPS_Ability_Service::class )
+			? $container->make( AIPS_Ability_Service::class )
+			: new AIPS_Ability_Service() );
+
+		$this->catalog = $catalog ?: ( $container->has( AIPS_Ability_Catalog_Service::class )
+			? $container->make( AIPS_Ability_Catalog_Service::class )
+			: new AIPS_Ability_Catalog_Service( $this->ability_service ) );
+
+		$this->resolver            = $resolver ?: new AIPS_Ability_Workflow_Variable_Resolver();
+		$this->condition_evaluator = $condition_evaluator ?: new AIPS_Ability_Workflow_Condition_Evaluator( $this->resolver );
+		$this->job_scheduler       = $job_scheduler ?: new AIPS_Job_Scheduler();
+
+		$this->history_service = $history_service ?: ( $container->has( AIPS_History_Service_Interface::class )
+			? $container->make( AIPS_History_Service_Interface::class )
+			: new AIPS_History_Service() );
+
+		$this->logger = $logger ?: ( $container->has( AIPS_Logger_Interface::class )
+			? $container->make( AIPS_Logger_Interface::class )
+			: new AIPS_Logger() );
+	}
+
+	// -----------------------------------------------------------------------
+	// Public API
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Dispatch a workflow run to cron. Never executes synchronously — this
+	 * is what "Run Now" and scheduled triggers both call.
+	 *
+	 * @param int   $workflow_id     Workflow ID.
+	 * @param array $trigger_context Trigger context payload (e.g. manual user, or scheduled trigger config).
+	 * @return int|WP_Error New run ID, or WP_Error.
+	 */
+	public function dispatch_run( int $workflow_id, array $trigger_context = array() ) {
+		$workflow = $this->repository->get_workflow( $workflow_id );
+
+		if ( ! $workflow ) {
+			return new WP_Error( 'ability_workflow_not_found', __( 'Workflow not found.', 'ai-post-scheduler' ) );
+		}
+
+		$correlation_id = AIPS_Correlation_ID::generate();
+
+		$run_id = $this->repository->create_run( $workflow_id, $workflow->version, $trigger_context, $correlation_id );
+
+		AIPS_Correlation_ID::reset();
+
+		if ( is_wp_error( $run_id ) ) {
+			return $run_id;
+		}
+
+		$scheduled = $this->job_scheduler->schedule_simple(
+			self::HOOK,
+			time(),
+			array( $run_id, $correlation_id ),
+			array(
+				'job_type'       => 'ability_workflow_run',
+				'correlation_id' => $correlation_id,
+				'metadata'       => array( 'workflow_id' => $workflow_id, 'run_id' => $run_id ),
+			)
+		);
+
+		if ( ! $scheduled ) {
+			return new WP_Error( 'ability_workflow_dispatch_failed', __( 'Failed to schedule workflow run.', 'ai-post-scheduler' ) );
+		}
+
+		return $run_id;
+	}
+
+	/**
+	 * Cron callback bound to self::HOOK. Executes (or resumes) a run.
+	 *
+	 * @param int    $run_id         Run ID.
+	 * @param string $correlation_id Correlation ID to resume under.
+	 * @return void
+	 */
+	public function process_run( int $run_id, string $correlation_id = '' ): void {
+		if ( '' !== $correlation_id ) {
+			AIPS_Correlation_ID::set( $correlation_id );
+		} else {
+			$correlation_id = AIPS_Correlation_ID::generate();
+		}
+
+		$history = $this->history_service->create(
+			'ability_workflow_run',
+			array( 'run_id' => $run_id, 'creation_method' => 'ability_workflow_run' )
+		);
+
+		try {
+			$this->run_internal( $run_id, $correlation_id, $history );
+		} catch ( \Throwable $e ) {
+			$this->logger->log(
+				'Ability workflow run failed with unexpected error: ' . $e->getMessage(),
+				'error',
+				array( 'run_id' => $run_id, 'trace' => $e->getTraceAsString() )
+			);
+
+			if ( $history ) {
+				$history->complete_failure(
+					sprintf( __( 'Unexpected error: %s', 'ai-post-scheduler' ), $e->getMessage() ),
+					array( 'exception_class' => get_class( $e ) )
+				);
+			}
+
+			$this->repository->update_run_status(
+				$run_id,
+				AIPS_Ability_Workflow_Repository::RUN_STATUS_FAILED,
+				array( 'finished_at' => time() )
+			);
+		} finally {
+			AIPS_Correlation_ID::reset();
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Internals
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Execute (or resume) a run's steps within this invocation's time budget.
+	 *
+	 * @param int                      $run_id         Run ID.
+	 * @param string                   $correlation_id Correlation ID.
+	 * @param AIPS_History_Container   $history        History container for this invocation.
+	 * @return void
+	 */
+	private function run_internal( int $run_id, string $correlation_id, $history ): void {
+		$run = $this->repository->get_run( $run_id );
+
+		if ( ! $run || in_array( $run->status, AIPS_Ability_Workflow_Repository::RUN_TERMINAL_STATUSES, true ) ) {
+			return;
+		}
+
+		$workflow = $this->repository->get_workflow( $run->workflow_id );
+
+		if ( ! $workflow ) {
+			$this->repository->update_run_status( $run_id, AIPS_Ability_Workflow_Repository::RUN_STATUS_FAILED, array( 'finished_at' => time() ) );
+			return;
+		}
+
+		if ( AIPS_Ability_Workflow_Repository::RUN_STATUS_QUEUED === $run->status ) {
+			$this->repository->update_run_status( $run_id, AIPS_Ability_Workflow_Repository::RUN_STATUS_RUNNING, array( 'started_at' => time() ) );
+		}
+
+		$steps = $this->repository->get_steps( $run->workflow_id );
+
+		$settings            = $workflow->settings;
+		$max_steps           = isset( $settings['max_steps'] ) ? (int) $settings['max_steps'] : 20;
+		$max_runtime_seconds = isset( $settings['max_runtime_seconds'] ) ? (int) $settings['max_runtime_seconds'] : 120;
+		$allow_destructive   = ! empty( $settings['allow_destructive_abilities'] );
+
+		if ( count( $steps ) > $max_steps ) {
+			$this->finish_run( $run_id, AIPS_Ability_Workflow_Repository::RUN_STATUS_FAILED, $history, __( 'Workflow exceeds the configured max_steps limit.', 'ai-post-scheduler' ) );
+			return;
+		}
+
+		$time_budget = max( 1, min( $max_runtime_seconds, self::DEFAULT_TIME_BUDGET_SECONDS ) );
+		$deadline    = microtime( true ) + $time_budget;
+
+		$existing_step_runs = $this->repository->get_step_runs( $run_id );
+
+		$step_run_by_key = array();
+		$resolved_status  = array();
+		foreach ( $existing_step_runs as $step_run ) {
+			$step_run_by_key[ $step_run->step_key ] = $step_run;
+			if ( in_array( $step_run->status, self::RESOLVED_STEP_STATUSES, true ) ) {
+				$resolved_status[ $step_run->step_key ] = $step_run->status;
+			}
+		}
+
+		$variables = $this->build_variables( $run, $steps, $existing_step_runs );
+		$skip_keys = array();
+
+		foreach ( $steps as $step ) {
+			if ( isset( $resolved_status[ $step->step_key ] ) ) {
+				continue;
+			}
+
+			if ( microtime( true ) >= $deadline ) {
+				$this->schedule_continuation( $run_id, $correlation_id, self::CONTINUATION_DELAY_SECONDS );
+				return;
+			}
+
+			$deps_satisfied = true;
+			foreach ( $step->depends_on as $dep_key ) {
+				if ( ( $resolved_status[ $dep_key ] ?? '' ) !== 'completed' ) {
+					$deps_satisfied = false;
+					break;
+				}
+			}
+
+			if ( isset( $skip_keys[ $step->step_key ] ) || ! $deps_satisfied ) {
+				$this->record_skipped_step( $run_id, $run->workflow_id, $step, $history );
+				$resolved_status[ $step->step_key ] = 'skipped';
+				continue;
+			}
+
+			if ( ! $this->condition_evaluator->evaluate( $step->condition_tree, $variables ) ) {
+				$this->record_skipped_step( $run_id, $run->workflow_id, $step, $history );
+				$resolved_status[ $step->step_key ] = 'skipped';
+				continue;
+			}
+
+			$outcome = $this->execute_step(
+				$run_id,
+				$run->workflow_id,
+				$step,
+				$variables,
+				$allow_destructive,
+				$history,
+				$correlation_id,
+				$step_run_by_key[ $step->step_key ] ?? null
+			);
+
+			if ( ! empty( $outcome['retry_scheduled'] ) ) {
+				return;
+			}
+
+			$resolved_status[ $step->step_key ] = $outcome['status'];
+
+			if ( 'completed' === $outcome['status'] ) {
+				$alias = $step->output_alias ?: $step->step_key;
+				$variables['steps'][ $alias ] = array(
+					'output' => $outcome['output'],
+					'status' => 'completed',
+				);
+
+				$strategy = isset( $step->on_success['strategy'] ) ? $step->on_success['strategy'] : 'continue';
+
+				if ( 'stop' === $strategy ) {
+					$this->finish_run( $run_id, AIPS_Ability_Workflow_Repository::RUN_STATUS_COMPLETED, $history );
+					return;
+				}
+
+				if ( 'skip' === $strategy ) {
+					$this->mark_dependents_skipped( $step->step_key, $steps, $skip_keys );
+				}
+			} else {
+				$strategy = isset( $step->on_failure['strategy'] ) ? $step->on_failure['strategy'] : 'stop';
+
+				if ( 'stop' === $strategy ) {
+					$this->finish_run(
+						$run_id,
+						AIPS_Ability_Workflow_Repository::RUN_STATUS_FAILED,
+						$history,
+						/* translators: %s: step key */
+						sprintf( __( 'Step "%s" failed.', 'ai-post-scheduler' ), $step->step_key )
+					);
+					return;
+				}
+
+				if ( 'skip' === $strategy ) {
+					$this->mark_dependents_skipped( $step->step_key, $steps, $skip_keys );
+				}
+			}
+		}
+
+		$this->finish_run( $run_id, AIPS_Ability_Workflow_Repository::RUN_STATUS_COMPLETED, $history );
+	}
+
+	/**
+	 * Execute a single step: resolve input, enforce destructive-ability
+	 * gating, invoke the ability, persist the outcome. Reuses an in-progress
+	 * step-run row across retries rather than creating a duplicate.
+	 *
+	 * @param int                              $run_id            Run ID.
+	 * @param int                              $workflow_id       Workflow ID.
+	 * @param AIPS_Ability_Workflow_Step       $step              Step to execute.
+	 * @param array                            $variables         Current variable bag.
+	 * @param bool                             $allow_destructive Whether destructive abilities are allowed.
+	 * @param AIPS_History_Container|false     $history           History container for this invocation.
+	 * @param string                           $correlation_id    Correlation ID for this run, threaded into any retry dispatch.
+	 * @param AIPS_Ability_Workflow_Step_Run|null $existing_step_run Existing step-run row, when resuming a retry.
+	 * @return array { status: string, output: array, retry_scheduled: bool }
+	 */
+	private function execute_step( int $run_id, int $workflow_id, AIPS_Ability_Workflow_Step $step, array $variables, bool $allow_destructive, $history, string $correlation_id, ?AIPS_Ability_Workflow_Step_Run $existing_step_run = null ): array {
+		$resolved_input = $this->resolver->resolve_map( $step->input_map, $variables );
+
+		if ( $existing_step_run ) {
+			$attempt     = (int) ( $existing_step_run->error['attempts'] ?? 0 ) + 1;
+			$step_run_id = $existing_step_run->id;
+			$this->repository->update_step_run_status( $step_run_id, 'running', array( 'input_snapshot' => $resolved_input, 'started_at' => time() ) );
+		} else {
+			$attempt     = 1;
+			$step_run_id = $this->repository->create_step_run( $run_id, $workflow_id, $step, $resolved_input );
+
+			if ( is_wp_error( $step_run_id ) ) {
+				return array( 'status' => 'failed', 'output' => array(), 'retry_scheduled' => false );
+			}
+
+			$this->repository->update_step_run_status( $step_run_id, 'running', array( 'started_at' => time() ) );
+		}
+
+		$ability = $this->catalog->get_ability( $step->ability_name );
+
+		if ( is_wp_error( $ability ) ) {
+			return $this->fail_step( $run_id, $step, $step_run_id, $ability->get_error_message(), $attempt, $history, $correlation_id );
+		}
+
+		if ( ! empty( $ability['is_destructive'] ) && ! $allow_destructive ) {
+			return $this->fail_step( $run_id, $step, $step_run_id, __( 'Destructive abilities are not allowed for this workflow.', 'ai-post-scheduler' ), $attempt, $history, $correlation_id );
+		}
+
+		if ( $history ) {
+			/* translators: 1: ability name, 2: step key */
+			$history->record( 'ai_request', sprintf( __( 'Invoking ability "%1$s" for step "%2$s"', 'ai-post-scheduler' ), $step->ability_name, $step->step_key ), $resolved_input );
+		}
+
+		$response = $this->ability_service->invoke( $step->ability_name, $resolved_input );
+
+		if ( is_wp_error( $response ) ) {
+			if ( $history ) {
+				$history->record( 'error', $response->get_error_message(), $resolved_input );
+			}
+
+			return $this->fail_step( $run_id, $step, $step_run_id, $response->get_error_message(), $attempt, $history, $correlation_id );
+		}
+
+		if ( $history ) {
+			/* translators: 1: ability name, 2: step key */
+			$history->record( 'ai_response', sprintf( __( 'Ability "%1$s" completed for step "%2$s"', 'ai-post-scheduler' ), $step->ability_name, $step->step_key ), null, $response );
+		}
+
+		$this->repository->update_step_run_status( $step_run_id, 'completed', array( 'output_snapshot' => $response, 'finished_at' => time() ) );
+
+		return array( 'status' => 'completed', 'output' => $response, 'retry_scheduled' => false );
+	}
+
+	/**
+	 * Handle a failed step attempt: schedule a backoff retry when the
+	 * retry_policy allows another attempt, otherwise mark the step failed.
+	 *
+	 * @param int                        $run_id      Run ID.
+	 * @param AIPS_Ability_Workflow_Step $step        Step that failed.
+	 * @param int                        $step_run_id Step-run row ID.
+	 * @param string                     $message     Failure message.
+	 * @param int                        $attempt     Attempt number just made.
+	 * @param AIPS_History_Container|false $history   History container.
+	 * @param string                     $correlation_id Correlation ID for this run.
+	 * @return array { status: string, output: array, retry_scheduled: bool }
+	 */
+	private function fail_step( int $run_id, AIPS_Ability_Workflow_Step $step, int $step_run_id, string $message, int $attempt, $history, string $correlation_id ): array {
+		$max_attempts    = isset( $step->retry_policy['attempts'] ) ? (int) $step->retry_policy['attempts'] : 0;
+		$backoff_seconds = isset( $step->retry_policy['backoff_seconds'] ) ? max( 1, (int) $step->retry_policy['backoff_seconds'] ) : 5;
+
+		if ( $attempt <= $max_attempts ) {
+			$this->repository->update_step_run_status(
+				$step_run_id,
+				'pending',
+				array(
+					'error'       => array( 'message' => $message, 'attempts' => $attempt, 'next_retry_at' => time() + $backoff_seconds ),
+					'finished_at' => 0,
+				)
+			);
+
+			$this->schedule_continuation( $run_id, $correlation_id, $backoff_seconds );
+
+			return array( 'status' => 'failed', 'output' => array(), 'retry_scheduled' => true );
+		}
+
+		$this->repository->update_step_run_status(
+			$step_run_id,
+			'failed',
+			array(
+				'error'       => array( 'message' => $message, 'attempts' => $attempt ),
+				'finished_at' => time(),
+			)
+		);
+
+		return array( 'status' => 'failed', 'output' => array(), 'retry_scheduled' => false );
+	}
+
+	/**
+	 * Persist a skipped-step row (dependency unmet, condition false, or
+	 * cascaded from an upstream 'skip' strategy).
+	 *
+	 * @param int                        $run_id      Run ID.
+	 * @param int                        $workflow_id Workflow ID.
+	 * @param AIPS_Ability_Workflow_Step $step        Step being skipped.
+	 * @param AIPS_History_Container|false $history   History container.
+	 * @return void
+	 */
+	private function record_skipped_step( int $run_id, int $workflow_id, AIPS_Ability_Workflow_Step $step, $history ): void {
+		$step_run_id = $this->repository->create_step_run( $run_id, $workflow_id, $step, array() );
+
+		if ( ! is_wp_error( $step_run_id ) ) {
+			$this->repository->update_step_run_status( $step_run_id, 'skipped', array( 'started_at' => time(), 'finished_at' => time() ) );
+		}
+
+		if ( $history ) {
+			/* translators: %s: step key */
+			$history->record( 'activity', sprintf( __( 'Step "%s" skipped', 'ai-post-scheduler' ), $step->step_key ) );
+		}
+	}
+
+	/**
+	 * Mark every step that transitively depends on $step_key as skipped for
+	 * the remainder of this run, without touching independent branches.
+	 *
+	 * @param string                       $step_key  Step key whose dependents should be skipped.
+	 * @param AIPS_Ability_Workflow_Step[] $steps     All steps for the workflow.
+	 * @param array                        $skip_keys Accumulator, passed by reference.
+	 * @return void
+	 */
+	private function mark_dependents_skipped( string $step_key, array $steps, array &$skip_keys ): void {
+		foreach ( $steps as $candidate ) {
+			if ( in_array( $step_key, $candidate->depends_on, true ) && ! isset( $skip_keys[ $candidate->step_key ] ) ) {
+				$skip_keys[ $candidate->step_key ] = true;
+				$this->mark_dependents_skipped( $candidate->step_key, $steps, $skip_keys );
+			}
+		}
+	}
+
+	/**
+	 * Build the run's variable bag from trigger context + prior completed step outputs.
+	 *
+	 * @param AIPS_Ability_Workflow_Run        $run       The run.
+	 * @param AIPS_Ability_Workflow_Step[]      $steps     All steps for the workflow (for output_alias lookup).
+	 * @param AIPS_Ability_Workflow_Step_Run[]  $step_runs Existing step-run rows.
+	 * @return array { trigger: array, steps: array }
+	 */
+	private function build_variables( AIPS_Ability_Workflow_Run $run, array $steps, array $step_runs ): array {
+		$steps_by_key = array();
+		foreach ( $steps as $step ) {
+			$steps_by_key[ $step->step_key ] = $step;
+		}
+
+		$variables = array(
+			'trigger' => $run->trigger_context,
+			'steps'   => array(),
+		);
+
+		foreach ( $step_runs as $step_run ) {
+			if ( 'completed' !== $step_run->status ) {
+				continue;
+			}
+
+			$step  = $steps_by_key[ $step_run->step_key ] ?? null;
+			$alias = ( $step && $step->output_alias ) ? $step->output_alias : $step_run->step_key;
+
+			$variables['steps'][ $alias ] = array(
+				'output' => $step_run->output_snapshot,
+				'status' => $step_run->status,
+			);
+		}
+
+		return $variables;
+	}
+
+	/**
+	 * Schedule a single continuation/retry event on self::HOOK.
+	 *
+	 * @param int    $run_id         Run ID.
+	 * @param string $correlation_id Correlation ID to resume under.
+	 * @param int    $delay_seconds  Delay before the event fires.
+	 * @return void
+	 */
+	private function schedule_continuation( int $run_id, string $correlation_id, int $delay_seconds ): void {
+		$this->job_scheduler->schedule_simple(
+			self::HOOK,
+			time() + $delay_seconds,
+			array( $run_id, $correlation_id ),
+			array( 'job_type' => 'ability_workflow_run', 'correlation_id' => $correlation_id )
+		);
+	}
+
+	/**
+	 * Finalize a run's terminal status and complete its history container.
+	 *
+	 * @param int                          $run_id  Run ID.
+	 * @param string                       $status  Terminal status.
+	 * @param AIPS_History_Container|false $history History container.
+	 * @param string                       $failure_message Optional failure message when $status is 'failed'.
+	 * @return void
+	 */
+	private function finish_run( int $run_id, string $status, $history, string $failure_message = '' ): void {
+		$this->repository->update_run_status( $run_id, $status, array( 'finished_at' => time() ) );
+
+		if ( ! $history ) {
+			return;
+		}
+
+		if ( AIPS_Ability_Workflow_Repository::RUN_STATUS_COMPLETED === $status ) {
+			$history->complete_success();
+		} else {
+			$history->complete_failure( '' !== $failure_message ? $failure_message : __( 'Workflow run failed.', 'ai-post-scheduler' ) );
+		}
+	}
+}

--- a/ai-post-scheduler/includes/class-aips-ability-workflow-repository.php
+++ b/ai-post-scheduler/includes/class-aips-ability-workflow-repository.php
@@ -614,13 +614,23 @@ class AIPS_Ability_Workflow_Repository {
 
 		$total = (int) $this->wpdb->get_var( $this->wpdb->prepare( "SELECT COUNT(*) FROM {$this->runs_table} $where_sql", $where_args ) );
 
-		$per_page   = (int) $args['per_page'];
-		$page       = max( 1, (int) $args['page'] );
+		$limit_sql  = '';
 		$limit_args = $where_args;
-		$limit_args[] = $per_page;
-		$limit_args[] = ( $page - 1 ) * $per_page;
+		$per_page   = (int) $args['per_page'];
 
-		$sql  = "SELECT * FROM {$this->runs_table} $where_sql ORDER BY started_at DESC, id DESC LIMIT %d OFFSET %d";
+		// Consistent with list_workflows(): per_page <= 0 means "no limit",
+		// not "LIMIT 0" (which would silently return zero rows).
+		if ( $per_page > 0 ) {
+			$page         = max( 1, (int) $args['page'] );
+			$limit_sql    = 'LIMIT %d OFFSET %d';
+			$limit_args[] = $per_page;
+			$limit_args[] = ( $page - 1 ) * $per_page;
+		}
+
+		// $where_args always has at least the workflow_id filter, so this
+		// always needs prepare() — unlike list_workflows()'s fully optional
+		// WHERE clause.
+		$sql  = "SELECT * FROM {$this->runs_table} $where_sql ORDER BY started_at DESC, id DESC $limit_sql";
 		$rows = $this->wpdb->get_results( $this->wpdb->prepare( $sql, $limit_args ) );
 
 		return array(

--- a/ai-post-scheduler/includes/class-aips-ability-workflow-repository.php
+++ b/ai-post-scheduler/includes/class-aips-ability-workflow-repository.php
@@ -1,0 +1,748 @@
+<?php
+/**
+ * Ability Workflow Repository
+ *
+ * Centralizes all `$wpdb` access for the four Ability Workflow tables:
+ * `aips_ability_workflows`, `aips_ability_workflow_steps`,
+ * `aips_ability_workflow_runs`, and `aips_ability_workflow_step_runs`.
+ *
+ * Controllers, services, and the executor must go through this class for
+ * any persistence — no direct SQL outside this file.
+ *
+ * @package AI_Post_Scheduler
+ * @since 3.2.0
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+/**
+ * Class AIPS_Ability_Workflow_Repository
+ */
+class AIPS_Ability_Workflow_Repository {
+
+	/**
+	 * Run status constants.
+	 */
+	const RUN_STATUS_QUEUED    = 'queued';
+	const RUN_STATUS_RUNNING   = 'running';
+	const RUN_STATUS_COMPLETED = 'completed';
+	const RUN_STATUS_FAILED    = 'failed';
+	const RUN_STATUS_CANCELLED = 'cancelled';
+
+	/**
+	 * Terminal run statuses — once reached, status transitions are ignored.
+	 */
+	const RUN_TERMINAL_STATUSES = array(
+		self::RUN_STATUS_COMPLETED,
+		self::RUN_STATUS_FAILED,
+		self::RUN_STATUS_CANCELLED,
+	);
+
+	/**
+	 * @var self|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * @var wpdb
+	 */
+	private $wpdb;
+
+	/**
+	 * @var string
+	 */
+	private $workflows_table;
+
+	/**
+	 * @var string
+	 */
+	private $steps_table;
+
+	/**
+	 * @var string
+	 */
+	private $runs_table;
+
+	/**
+	 * @var string
+	 */
+	private $step_runs_table;
+
+	/**
+	 * Get singleton instance.
+	 *
+	 * @return self
+	 */
+	public static function instance(): self {
+		if ( self::$instance === null ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		global $wpdb;
+
+		$this->wpdb            = $wpdb;
+		$this->workflows_table = $wpdb->prefix . 'aips_ability_workflows';
+		$this->steps_table     = $wpdb->prefix . 'aips_ability_workflow_steps';
+		$this->runs_table      = $wpdb->prefix . 'aips_ability_workflow_runs';
+		$this->step_runs_table = $wpdb->prefix . 'aips_ability_workflow_step_runs';
+	}
+
+	// -----------------------------------------------------------------------
+	// Workflow CRUD
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Create a new workflow.
+	 *
+	 * @param array $data Workflow fields (name, description, status, trigger_type,
+	 *                     trigger_config, settings, created_by, updated_by).
+	 * @return int|WP_Error New workflow ID, or WP_Error on failure.
+	 */
+	public function create_workflow( array $data ) {
+		if ( empty( $data['name'] ) ) {
+			return new WP_Error( 'ability_workflow_invalid', __( 'Workflow name is required.', 'ai-post-scheduler' ) );
+		}
+
+		$now = time();
+
+		$result = $this->wpdb->insert(
+			$this->workflows_table,
+			array(
+				'uuid'           => wp_generate_uuid4(),
+				'name'           => (string) $data['name'],
+				'description'    => isset( $data['description'] ) ? (string) $data['description'] : null,
+				'status'         => isset( $data['status'] ) ? (string) $data['status'] : 'draft',
+				'trigger_type'   => isset( $data['trigger_type'] ) ? (string) $data['trigger_type'] : 'manual',
+				'trigger_config' => wp_json_encode( isset( $data['trigger_config'] ) && is_array( $data['trigger_config'] ) ? $data['trigger_config'] : array() ),
+				'settings'       => wp_json_encode( isset( $data['settings'] ) && is_array( $data['settings'] ) ? $data['settings'] : array() ),
+				'version'        => 1,
+				'created_by'     => isset( $data['created_by'] ) ? (int) $data['created_by'] : null,
+				'updated_by'     => isset( $data['updated_by'] ) ? (int) $data['updated_by'] : null,
+				'created_at'     => $now,
+				'updated_at'     => $now,
+			),
+			array( '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%d', '%d', '%d', '%d', '%d' )
+		);
+
+		if ( $result === false ) {
+			return $this->build_error( 'ability_workflow_create_failed', __( 'Failed to create workflow.', 'ai-post-scheduler' ) );
+		}
+
+		return (int) $this->wpdb->insert_id;
+	}
+
+	/**
+	 * Update workflow header fields.
+	 *
+	 * @param int   $workflow_id Workflow ID.
+	 * @param array $data        Fields to update (any of: name, description, status,
+	 *                            trigger_type, trigger_config, settings, updated_by).
+	 * @return bool|WP_Error
+	 */
+	public function update_workflow( int $workflow_id, array $data ) {
+		$update_data = array();
+		$format      = array();
+
+		$string_fields = array( 'name', 'description', 'status', 'trigger_type' );
+		foreach ( $string_fields as $field ) {
+			if ( array_key_exists( $field, $data ) ) {
+				$update_data[ $field ] = $data[ $field ] !== null ? (string) $data[ $field ] : null;
+				$format[]              = '%s';
+			}
+		}
+
+		foreach ( array( 'trigger_config', 'settings' ) as $field ) {
+			if ( array_key_exists( $field, $data ) ) {
+				$update_data[ $field ] = wp_json_encode( is_array( $data[ $field ] ) ? $data[ $field ] : array() );
+				$format[]              = '%s';
+			}
+		}
+
+		if ( array_key_exists( 'updated_by', $data ) ) {
+			$update_data['updated_by'] = $data['updated_by'] !== null ? (int) $data['updated_by'] : null;
+			$format[]                  = '%d';
+		}
+
+		if ( empty( $update_data ) ) {
+			return true;
+		}
+
+		$update_data['updated_at'] = time();
+		$format[]                  = '%d';
+
+		$result = $this->wpdb->update(
+			$this->workflows_table,
+			$update_data,
+			array( 'id' => $workflow_id ),
+			$format,
+			array( '%d' )
+		);
+
+		if ( $result === false ) {
+			return $this->build_error( 'ability_workflow_update_failed', __( 'Failed to update workflow.', 'ai-post-scheduler' ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Fetch a workflow by ID.
+	 *
+	 * @param int $workflow_id Workflow ID.
+	 * @return AIPS_Ability_Workflow|null
+	 */
+	public function get_workflow( int $workflow_id ): ?AIPS_Ability_Workflow {
+		$row = $this->wpdb->get_row(
+			$this->wpdb->prepare( "SELECT * FROM {$this->workflows_table} WHERE id = %d", $workflow_id )
+		);
+
+		return $row ? AIPS_Ability_Workflow::from_row( $row ) : null;
+	}
+
+	/**
+	 * Fetch a workflow by UUID.
+	 *
+	 * @param string $uuid Workflow UUID.
+	 * @return AIPS_Ability_Workflow|null
+	 */
+	public function get_workflow_by_uuid( string $uuid ): ?AIPS_Ability_Workflow {
+		$row = $this->wpdb->get_row(
+			$this->wpdb->prepare( "SELECT * FROM {$this->workflows_table} WHERE uuid = %s", $uuid )
+		);
+
+		return $row ? AIPS_Ability_Workflow::from_row( $row ) : null;
+	}
+
+	/**
+	 * List workflows with optional filters and pagination.
+	 *
+	 * @param array $args {
+	 *     @type string $status       Optional status filter.
+	 *     @type string $trigger_type Optional trigger_type filter.
+	 *     @type string $search       Optional name search.
+	 *     @type string $orderby      Column to order by (whitelisted).
+	 *     @type string $order        ASC|DESC.
+	 *     @type int    $per_page     Results per page (0 = no limit).
+	 *     @type int    $page         1-indexed page number.
+	 * }
+	 * @return array { items: AIPS_Ability_Workflow[], total: int }
+	 */
+	public function list_workflows( array $args = array() ): array {
+		$defaults = array(
+			'status'       => '',
+			'trigger_type' => '',
+			'search'       => '',
+			'orderby'      => 'updated_at',
+			'order'        => 'DESC',
+			'per_page'     => 20,
+			'page'         => 1,
+		);
+		$args = wp_parse_args( $args, $defaults );
+
+		$where_clauses = array();
+		$where_args    = array();
+
+		if ( '' !== $args['status'] ) {
+			$where_clauses[] = 'status = %s';
+			$where_args[]    = $args['status'];
+		}
+
+		if ( '' !== $args['trigger_type'] ) {
+			$where_clauses[] = 'trigger_type = %s';
+			$where_args[]    = $args['trigger_type'];
+		}
+
+		if ( '' !== $args['search'] ) {
+			$where_clauses[] = 'name LIKE %s';
+			$where_args[]    = '%' . $this->wpdb->esc_like( $args['search'] ) . '%';
+		}
+
+		$where_sql = empty( $where_clauses ) ? '' : 'WHERE ' . implode( ' AND ', $where_clauses );
+
+		$allowed_orderby = array( 'name', 'status', 'trigger_type', 'created_at', 'updated_at' );
+		$orderby         = in_array( $args['orderby'], $allowed_orderby, true ) ? $args['orderby'] : 'updated_at';
+		$order           = strtoupper( $args['order'] ) === 'ASC' ? 'ASC' : 'DESC';
+
+		$total_sql = "SELECT COUNT(*) FROM {$this->workflows_table} $where_sql";
+		$total     = (int) ( empty( $where_args )
+			? $this->wpdb->get_var( $total_sql )
+			: $this->wpdb->get_var( $this->wpdb->prepare( $total_sql, $where_args ) ) );
+
+		$limit_sql   = '';
+		$limit_args  = $where_args;
+		$per_page    = (int) $args['per_page'];
+		if ( $per_page > 0 ) {
+			$page      = max( 1, (int) $args['page'] );
+			$limit_sql = 'LIMIT %d OFFSET %d';
+			$limit_args[] = $per_page;
+			$limit_args[] = ( $page - 1 ) * $per_page;
+		}
+
+		$sql = "SELECT * FROM {$this->workflows_table} $where_sql ORDER BY $orderby $order $limit_sql";
+
+		$rows = empty( $limit_args )
+			? $this->wpdb->get_results( $sql )
+			: $this->wpdb->get_results( $this->wpdb->prepare( $sql, $limit_args ) );
+
+		$items = array_map( array( 'AIPS_Ability_Workflow', 'from_row' ), $rows ?: array() );
+
+		return array(
+			'items' => $items,
+			'total' => $total,
+		);
+	}
+
+	/**
+	 * Delete a workflow and its steps. Runs/step-runs are preserved for audit history.
+	 *
+	 * @param int $workflow_id Workflow ID.
+	 * @return bool
+	 */
+	public function delete_workflow( int $workflow_id ): bool {
+		$this->delete_steps( $workflow_id );
+
+		return false !== $this->wpdb->delete( $this->workflows_table, array( 'id' => $workflow_id ), array( '%d' ) );
+	}
+
+	/**
+	 * Archive a workflow (soft — sets status to 'archived').
+	 *
+	 * @param int $workflow_id Workflow ID.
+	 * @return bool
+	 */
+	public function archive_workflow( int $workflow_id ): bool {
+		$result = $this->wpdb->update(
+			$this->workflows_table,
+			array(
+				'status'     => 'archived',
+				'updated_at' => time(),
+			),
+			array( 'id' => $workflow_id ),
+			array( '%s', '%d' ),
+			array( '%d' )
+		);
+
+		return false !== $result;
+	}
+
+	/**
+	 * Duplicate a workflow and its steps as a new draft.
+	 *
+	 * @param int         $workflow_id Source workflow ID.
+	 * @param string|null $new_name    Optional new name; defaults to "<name> (Copy)".
+	 * @return int|WP_Error New workflow ID, or WP_Error.
+	 */
+	public function duplicate_workflow( int $workflow_id, ?string $new_name = null ) {
+		$source = $this->get_workflow( $workflow_id );
+
+		if ( ! $source ) {
+			return new WP_Error( 'ability_workflow_not_found', __( 'Workflow not found.', 'ai-post-scheduler' ) );
+		}
+
+		/* translators: %s: original workflow name */
+		$name = $new_name ?: sprintf( __( '%s (Copy)', 'ai-post-scheduler' ), $source->name );
+
+		$new_id = $this->create_workflow(
+			array(
+				'name'           => $name,
+				'description'    => $source->description,
+				'status'         => 'draft',
+				'trigger_type'   => $source->trigger_type,
+				'trigger_config' => $source->trigger_config,
+				'settings'       => $source->settings,
+				'created_by'     => $source->created_by,
+				'updated_by'     => $source->updated_by,
+			)
+		);
+
+		if ( is_wp_error( $new_id ) ) {
+			return $new_id;
+		}
+
+		$steps = $this->get_steps( $workflow_id );
+
+		if ( ! empty( $steps ) ) {
+			$step_payload = array_map(
+				function ( AIPS_Ability_Workflow_Step $step ) {
+					return $step->to_array();
+				},
+				$steps
+			);
+
+			$this->save_steps( $new_id, $step_payload );
+		}
+
+		return $new_id;
+	}
+
+	// -----------------------------------------------------------------------
+	// Step operations
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Replace all steps for a workflow and bump its version.
+	 *
+	 * @param int   $workflow_id Workflow ID.
+	 * @param array $steps       Array of step field arrays (step_key, name, ability_name,
+	 *                            position, depends_on, input_map, condition_tree,
+	 *                            output_alias, on_success, on_failure, retry_policy).
+	 * @return bool|WP_Error
+	 */
+	public function save_steps( int $workflow_id, array $steps ) {
+		$this->delete_steps( $workflow_id );
+
+		$now = time();
+
+		foreach ( $steps as $index => $step ) {
+			if ( empty( $step['step_key'] ) || empty( $step['ability_name'] ) ) {
+				return new WP_Error( 'ability_workflow_step_invalid', __( 'Each step requires a step_key and ability_name.', 'ai-post-scheduler' ) );
+			}
+
+			$result = $this->wpdb->insert(
+				$this->steps_table,
+				array(
+					'workflow_id'    => $workflow_id,
+					'step_key'       => (string) $step['step_key'],
+					'name'           => isset( $step['name'] ) ? (string) $step['name'] : null,
+					'ability_name'   => (string) $step['ability_name'],
+					'position'       => isset( $step['position'] ) ? (int) $step['position'] : $index,
+					'depends_on'     => wp_json_encode( isset( $step['depends_on'] ) && is_array( $step['depends_on'] ) ? $step['depends_on'] : array() ),
+					'input_map'      => wp_json_encode( isset( $step['input_map'] ) && is_array( $step['input_map'] ) ? $step['input_map'] : array() ),
+					'condition_tree' => wp_json_encode( isset( $step['condition_tree'] ) && is_array( $step['condition_tree'] ) ? $step['condition_tree'] : array() ),
+					'output_alias'   => isset( $step['output_alias'] ) ? (string) $step['output_alias'] : null,
+					'on_success'     => wp_json_encode( isset( $step['on_success'] ) && is_array( $step['on_success'] ) ? $step['on_success'] : array( 'strategy' => 'continue' ) ),
+					'on_failure'     => wp_json_encode( isset( $step['on_failure'] ) && is_array( $step['on_failure'] ) ? $step['on_failure'] : array( 'strategy' => 'stop' ) ),
+					'retry_policy'   => wp_json_encode( isset( $step['retry_policy'] ) && is_array( $step['retry_policy'] ) ? $step['retry_policy'] : array( 'attempts' => 0, 'backoff_seconds' => 0 ) ),
+					'created_at'     => $now,
+					'updated_at'     => $now,
+				),
+				array( '%d', '%s', '%s', '%s', '%d', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%d', '%d' )
+			);
+
+			if ( $result === false ) {
+				return $this->build_error( 'ability_workflow_step_save_failed', __( 'Failed to save workflow step.', 'ai-post-scheduler' ) );
+			}
+		}
+
+		$this->wpdb->query(
+			$this->wpdb->prepare(
+				"UPDATE {$this->workflows_table} SET version = version + 1, updated_at = %d WHERE id = %d",
+				$now,
+				$workflow_id
+			)
+		);
+
+		return true;
+	}
+
+	/**
+	 * Get all steps for a workflow, ordered by position.
+	 *
+	 * @param int $workflow_id Workflow ID.
+	 * @return AIPS_Ability_Workflow_Step[]
+	 */
+	public function get_steps( int $workflow_id ): array {
+		$rows = $this->wpdb->get_results(
+			$this->wpdb->prepare( "SELECT * FROM {$this->steps_table} WHERE workflow_id = %d ORDER BY position ASC", $workflow_id )
+		);
+
+		return array_map( array( 'AIPS_Ability_Workflow_Step', 'from_row' ), $rows ?: array() );
+	}
+
+	/**
+	 * Delete all steps for a workflow.
+	 *
+	 * @param int $workflow_id Workflow ID.
+	 * @return bool
+	 */
+	public function delete_steps( int $workflow_id ): bool {
+		return false !== $this->wpdb->delete( $this->steps_table, array( 'workflow_id' => $workflow_id ), array( '%d' ) );
+	}
+
+	/**
+	 * Reorder steps by assigning new positions.
+	 *
+	 * @param int   $workflow_id           Workflow ID.
+	 * @param array $step_id_to_position   Map of step_id => position.
+	 * @return bool
+	 */
+	public function reorder_steps( int $workflow_id, array $step_id_to_position ): bool {
+		foreach ( $step_id_to_position as $step_id => $position ) {
+			$result = $this->wpdb->update(
+				$this->steps_table,
+				array(
+					'position'   => (int) $position,
+					'updated_at' => time(),
+				),
+				array(
+					'id'          => (int) $step_id,
+					'workflow_id' => $workflow_id,
+				),
+				array( '%d', '%d' ),
+				array( '%d', '%d' )
+			);
+
+			if ( $result === false ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	// -----------------------------------------------------------------------
+	// Run operations
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Create a new workflow run.
+	 *
+	 * @param int    $workflow_id      Workflow ID.
+	 * @param int    $workflow_version Workflow version this run was dispatched against.
+	 * @param array  $trigger_context  Trigger context payload.
+	 * @param string $correlation_id   Optional correlation ID.
+	 * @return int|WP_Error New run ID, or WP_Error.
+	 */
+	public function create_run( int $workflow_id, int $workflow_version, array $trigger_context = array(), string $correlation_id = '' ) {
+		$result = $this->wpdb->insert(
+			$this->runs_table,
+			array(
+				'workflow_id'      => $workflow_id,
+				'workflow_version' => $workflow_version,
+				'status'           => self::RUN_STATUS_QUEUED,
+				'trigger_context'  => wp_json_encode( $trigger_context ),
+				'started_at'       => 0,
+				'finished_at'      => 0,
+				'created_by'       => get_current_user_id() ?: null,
+				'correlation_id'   => '' !== $correlation_id ? $correlation_id : null,
+			),
+			array( '%d', '%d', '%s', '%s', '%d', '%d', '%d', '%s' )
+		);
+
+		if ( $result === false ) {
+			return $this->build_error( 'ability_workflow_run_create_failed', __( 'Failed to create workflow run.', 'ai-post-scheduler' ) );
+		}
+
+		return (int) $this->wpdb->insert_id;
+	}
+
+	/**
+	 * Update a run's status. Ignored once the run has reached a terminal status,
+	 * so a late-arriving cron slice can never clobber a failed/completed/cancelled run.
+	 *
+	 * @param int    $run_id Run ID.
+	 * @param string $status New status.
+	 * @param array  $extra  Optional extra columns (started_at, finished_at).
+	 * @return bool
+	 */
+	public function update_run_status( int $run_id, string $status, array $extra = array() ): bool {
+		$update_data = array( 'status' => $status );
+		$format      = array( '%s' );
+
+		if ( array_key_exists( 'started_at', $extra ) ) {
+			$update_data['started_at'] = (int) $extra['started_at'];
+			$format[]                  = '%d';
+		}
+
+		if ( array_key_exists( 'finished_at', $extra ) ) {
+			$update_data['finished_at'] = (int) $extra['finished_at'];
+			$format[]                   = '%d';
+		}
+
+		$set_sql = array();
+		foreach ( $update_data as $column => $value ) {
+			$set_sql[] = "$column = %s";
+		}
+
+		$placeholders   = array_values( $update_data );
+		$terminal_list  = "'" . implode( "','", array_map( 'esc_sql', self::RUN_TERMINAL_STATUSES ) ) . "'";
+		$sql            = "UPDATE {$this->runs_table} SET " . implode( ', ', $set_sql ) . " WHERE id = %d AND status NOT IN ($terminal_list)";
+		$placeholders[] = $run_id;
+
+		$result = $this->wpdb->query( $this->wpdb->prepare( $sql, $placeholders ) );
+
+		return false !== $result;
+	}
+
+	/**
+	 * Fetch a run by ID.
+	 *
+	 * @param int $run_id Run ID.
+	 * @return AIPS_Ability_Workflow_Run|null
+	 */
+	public function get_run( int $run_id ): ?AIPS_Ability_Workflow_Run {
+		$row = $this->wpdb->get_row(
+			$this->wpdb->prepare( "SELECT * FROM {$this->runs_table} WHERE id = %d", $run_id )
+		);
+
+		return $row ? AIPS_Ability_Workflow_Run::from_row( $row ) : null;
+	}
+
+	/**
+	 * List runs for a workflow.
+	 *
+	 * @param int   $workflow_id Workflow ID.
+	 * @param array $args        { status, per_page, page }
+	 * @return array { items: AIPS_Ability_Workflow_Run[], total: int }
+	 */
+	public function list_runs( int $workflow_id, array $args = array() ): array {
+		$defaults = array(
+			'status'   => '',
+			'per_page' => 20,
+			'page'     => 1,
+		);
+		$args = wp_parse_args( $args, $defaults );
+
+		$where_clauses = array( 'workflow_id = %d' );
+		$where_args    = array( $workflow_id );
+
+		if ( '' !== $args['status'] ) {
+			$where_clauses[] = 'status = %s';
+			$where_args[]    = $args['status'];
+		}
+
+		$where_sql = 'WHERE ' . implode( ' AND ', $where_clauses );
+
+		$total = (int) $this->wpdb->get_var( $this->wpdb->prepare( "SELECT COUNT(*) FROM {$this->runs_table} $where_sql", $where_args ) );
+
+		$per_page   = (int) $args['per_page'];
+		$page       = max( 1, (int) $args['page'] );
+		$limit_args = $where_args;
+		$limit_args[] = $per_page;
+		$limit_args[] = ( $page - 1 ) * $per_page;
+
+		$sql  = "SELECT * FROM {$this->runs_table} $where_sql ORDER BY started_at DESC, id DESC LIMIT %d OFFSET %d";
+		$rows = $this->wpdb->get_results( $this->wpdb->prepare( $sql, $limit_args ) );
+
+		return array(
+			'items' => array_map( array( 'AIPS_Ability_Workflow_Run', 'from_row' ), $rows ?: array() ),
+			'total' => $total,
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// Step-run operations
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Create a step-run row.
+	 *
+	 * @param int                        $run_id         Parent run ID.
+	 * @param int                        $workflow_id    Workflow ID.
+	 * @param AIPS_Ability_Workflow_Step $step           The step being executed.
+	 * @param array                      $input_snapshot Resolved input snapshot.
+	 * @return int|WP_Error New step-run ID, or WP_Error.
+	 */
+	public function create_step_run( int $run_id, int $workflow_id, AIPS_Ability_Workflow_Step $step, array $input_snapshot = array() ) {
+		$result = $this->wpdb->insert(
+			$this->step_runs_table,
+			array(
+				'run_id'          => $run_id,
+				'workflow_id'     => $workflow_id,
+				'step_id'         => $step->id,
+				'step_key'        => $step->step_key,
+				'ability_name'    => $step->ability_name,
+				'status'          => 'pending',
+				'input_snapshot'  => wp_json_encode( $input_snapshot ),
+				'output_snapshot' => wp_json_encode( array() ),
+				'error'           => wp_json_encode( array() ),
+				'started_at'      => 0,
+				'finished_at'     => 0,
+			),
+			array( '%d', '%d', '%d', '%s', '%s', '%s', '%s', '%s', '%s', '%d', '%d' )
+		);
+
+		if ( $result === false ) {
+			return $this->build_error( 'ability_workflow_step_run_create_failed', __( 'Failed to create step run.', 'ai-post-scheduler' ) );
+		}
+
+		return (int) $this->wpdb->insert_id;
+	}
+
+	/**
+	 * Update a step-run's status.
+	 *
+	 * @param int    $step_run_id Step-run ID.
+	 * @param string $status      New status.
+	 * @param array  $extra       Optional extra columns (output_snapshot, error, started_at, finished_at).
+	 * @return bool
+	 */
+	public function update_step_run_status( int $step_run_id, string $status, array $extra = array() ): bool {
+		$update_data = array( 'status' => $status );
+		$format      = array( '%s' );
+
+		if ( array_key_exists( 'output_snapshot', $extra ) ) {
+			$update_data['output_snapshot'] = wp_json_encode( is_array( $extra['output_snapshot'] ) ? $extra['output_snapshot'] : array() );
+			$format[]                       = '%s';
+		}
+
+		if ( array_key_exists( 'error', $extra ) ) {
+			$update_data['error'] = wp_json_encode( is_array( $extra['error'] ) ? $extra['error'] : array() );
+			$format[]             = '%s';
+		}
+
+		if ( array_key_exists( 'started_at', $extra ) ) {
+			$update_data['started_at'] = (int) $extra['started_at'];
+			$format[]                  = '%d';
+		}
+
+		if ( array_key_exists( 'finished_at', $extra ) ) {
+			$update_data['finished_at'] = (int) $extra['finished_at'];
+			$format[]                   = '%d';
+		}
+
+		$result = $this->wpdb->update(
+			$this->step_runs_table,
+			$update_data,
+			array( 'id' => $step_run_id ),
+			$format,
+			array( '%d' )
+		);
+
+		return false !== $result;
+	}
+
+	/**
+	 * Get all step-runs for a run, in execution order.
+	 *
+	 * @param int $run_id Run ID.
+	 * @return AIPS_Ability_Workflow_Step_Run[]
+	 */
+	public function get_step_runs( int $run_id ): array {
+		$rows = $this->wpdb->get_results(
+			$this->wpdb->prepare( "SELECT * FROM {$this->step_runs_table} WHERE run_id = %d ORDER BY id ASC", $run_id )
+		);
+
+		return array_map( array( 'AIPS_Ability_Workflow_Step_Run', 'from_row' ), $rows ?: array() );
+	}
+
+	// -----------------------------------------------------------------------
+	// Helpers
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Build a user-safe mutation error, attaching the last DB error when present.
+	 *
+	 * @param string $code    Error code.
+	 * @param string $message Display message.
+	 * @return WP_Error
+	 */
+	private function build_error( $code, $message ) {
+		$error = new WP_Error( $code, $message );
+
+		if ( ! empty( $this->wpdb->last_error ) ) {
+			$error->add_data( array( 'db_error' => $this->wpdb->last_error ) );
+		}
+
+		return $error;
+	}
+}

--- a/ai-post-scheduler/includes/class-aips-ability-workflow-repository.php
+++ b/ai-post-scheduler/includes/class-aips-ability-workflow-repository.php
@@ -680,6 +680,11 @@ class AIPS_Ability_Workflow_Repository {
 		$update_data = array( 'status' => $status );
 		$format      = array( '%s' );
 
+		if ( array_key_exists( 'input_snapshot', $extra ) ) {
+			$update_data['input_snapshot'] = wp_json_encode( is_array( $extra['input_snapshot'] ) ? $extra['input_snapshot'] : array() );
+			$format[]                      = '%s';
+		}
+
 		if ( array_key_exists( 'output_snapshot', $extra ) ) {
 			$update_data['output_snapshot'] = wp_json_encode( is_array( $extra['output_snapshot'] ) ? $extra['output_snapshot'] : array() );
 			$format[]                       = '%s';

--- a/ai-post-scheduler/includes/class-aips-ability-workflow-run.php
+++ b/ai-post-scheduler/includes/class-aips-ability-workflow-run.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Ability Workflow Run DTO
+ *
+ * Immutable value object that wraps a row from the
+ * `aips_ability_workflow_runs` DB table.
+ *
+ * @package AI_Post_Scheduler
+ * @since 3.2.0
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+/**
+ * Class AIPS_Ability_Workflow_Run
+ */
+class AIPS_Ability_Workflow_Run {
+
+	public readonly int $id;
+	public readonly int $workflow_id;
+	public readonly int $workflow_version;
+	public readonly string $status;
+	public readonly array $trigger_context;
+	public readonly int $started_at;
+	public readonly int $finished_at;
+	public readonly ?int $created_by;
+	public readonly ?string $correlation_id;
+
+	private function __construct(
+		int $id,
+		int $workflow_id,
+		int $workflow_version,
+		string $status,
+		array $trigger_context,
+		int $started_at,
+		int $finished_at,
+		?int $created_by,
+		?string $correlation_id
+	) {
+		$this->id               = $id;
+		$this->workflow_id      = $workflow_id;
+		$this->workflow_version = $workflow_version;
+		$this->status           = $status;
+		$this->trigger_context  = $trigger_context;
+		$this->started_at       = $started_at;
+		$this->finished_at      = $finished_at;
+		$this->created_by       = $created_by;
+		$this->correlation_id   = $correlation_id;
+	}
+
+	/**
+	 * Build an instance from a DB row object returned by wpdb.
+	 *
+	 * @param object $row A stdClass row from aips_ability_workflow_runs.
+	 * @return self
+	 */
+	public static function from_row( object $row ): self {
+		return new self(
+			(int) $row->id,
+			(int) $row->workflow_id,
+			isset( $row->workflow_version ) ? (int) $row->workflow_version : 1,
+			(string) ( $row->status ?? 'queued' ),
+			self::decode_json( $row->trigger_context ?? null ),
+			isset( $row->started_at ) ? (int) $row->started_at : 0,
+			isset( $row->finished_at ) ? (int) $row->finished_at : 0,
+			isset( $row->created_by ) && $row->created_by !== null ? (int) $row->created_by : null,
+			isset( $row->correlation_id ) && $row->correlation_id !== '' ? (string) $row->correlation_id : null
+		);
+	}
+
+	/**
+	 * Serialize for AJAX/UI responses.
+	 *
+	 * @return array
+	 */
+	public function to_array(): array {
+		return array(
+			'id'               => $this->id,
+			'workflow_id'      => $this->workflow_id,
+			'workflow_version' => $this->workflow_version,
+			'status'           => $this->status,
+			'trigger_context'  => $this->trigger_context,
+			'started_at'       => $this->started_at,
+			'finished_at'      => $this->finished_at,
+			'created_by'       => $this->created_by,
+			'correlation_id'   => $this->correlation_id,
+		);
+	}
+
+	/**
+	 * Decode a nullable JSON column, defaulting to an empty array.
+	 *
+	 * @param mixed $value Raw column value.
+	 * @return array
+	 */
+	private static function decode_json( $value ): array {
+		if ( ! is_string( $value ) || $value === '' ) {
+			return array();
+		}
+
+		$decoded = json_decode( $value, true );
+
+		return is_array( $decoded ) ? $decoded : array();
+	}
+}

--- a/ai-post-scheduler/includes/class-aips-ability-workflow-runs-controller.php
+++ b/ai-post-scheduler/includes/class-aips-ability-workflow-runs-controller.php
@@ -169,8 +169,8 @@ class AIPS_Ability_Workflow_Runs_Controller {
 
 		$run_id = isset( $_POST['run_id'] ) ? absint( $_POST['run_id'] ) : 0;
 
-		if ( $run_id <= 0 ) {
-			AIPS_Ajax_Response::invalid_request();
+		if ( $run_id <= 0 || ! $this->repository->get_run( $run_id ) ) {
+			AIPS_Ajax_Response::not_found( __( 'Run', 'ai-post-scheduler' ) );
 		}
 
 		$this->repository->update_run_status(

--- a/ai-post-scheduler/includes/class-aips-ability-workflow-runs-controller.php
+++ b/ai-post-scheduler/includes/class-aips-ability-workflow-runs-controller.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Ability Workflow Runs Controller
+ *
+ * AJAX handlers for dispatching and browsing Ability Workflow runs.
+ *
+ * @package AI_Post_Scheduler
+ * @since 3.2.0
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+/**
+ * Class AIPS_Ability_Workflow_Runs_Controller
+ */
+class AIPS_Ability_Workflow_Runs_Controller {
+
+	/**
+	 * @var AIPS_Ability_Workflow_Repository
+	 */
+	private $repository;
+
+	/**
+	 * @var AIPS_Ability_Workflow_Executor
+	 */
+	private $executor;
+
+	/**
+	 * Constructor. Registers all wp_ajax_* hooks owned by this controller.
+	 *
+	 * @param AIPS_Ability_Workflow_Repository|null $repository Repository.
+	 * @param AIPS_Ability_Workflow_Executor|null    $executor   Executor.
+	 */
+	public function __construct( $repository = null, $executor = null ) {
+		$this->repository = $repository ?: AIPS_Ability_Workflow_Repository::instance();
+		$this->executor    = $executor ?: new AIPS_Ability_Workflow_Executor();
+
+		add_action( 'wp_ajax_aips_run_ability_workflow_now', array( $this, 'ajax_run_now' ) );
+		add_action( 'wp_ajax_aips_list_ability_workflow_runs', array( $this, 'ajax_list_runs' ) );
+		add_action( 'wp_ajax_aips_get_ability_workflow_run', array( $this, 'ajax_get_run' ) );
+		add_action( 'wp_ajax_aips_cancel_ability_workflow_run', array( $this, 'ajax_cancel_run' ) );
+	}
+
+	/**
+	 * Dispatch a workflow run immediately. Never blocks — the run executes
+	 * asynchronously via WP-Cron.
+	 */
+	public function ajax_run_now() {
+		if ( ! check_ajax_referer( 'aips_ajax_nonce', 'nonce', false ) ) {
+			AIPS_Ajax_Response::error( __( 'Invalid nonce.', 'ai-post-scheduler' ) );
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			AIPS_Ajax_Response::permission_denied();
+		}
+
+		$workflow_id = isset( $_POST['workflow_id'] ) ? absint( $_POST['workflow_id'] ) : 0;
+
+		if ( $workflow_id <= 0 ) {
+			AIPS_Ajax_Response::invalid_request();
+		}
+
+		$trigger_context = array(
+			'type'    => 'manual',
+			'user_id' => get_current_user_id(),
+		);
+
+		$run_id = $this->executor->dispatch_run( $workflow_id, $trigger_context );
+
+		if ( is_wp_error( $run_id ) ) {
+			AIPS_Ajax_Response::error( $run_id->get_error_message() );
+		}
+
+		do_action( 'aips_ability_workflow_changed', array(
+			'action'      => 'run_dispatched',
+			'workflow_id' => $workflow_id,
+			'run_id'      => absint( $run_id ),
+			'user_id'     => get_current_user_id(),
+		) );
+
+		AIPS_Ajax_Response::success(
+			array( 'run_id' => $run_id ),
+			__( 'Workflow run started.', 'ai-post-scheduler' )
+		);
+	}
+
+	/**
+	 * List runs for a workflow.
+	 */
+	public function ajax_list_runs() {
+		if ( ! check_ajax_referer( 'aips_ajax_nonce', 'nonce', false ) ) {
+			AIPS_Ajax_Response::error( __( 'Invalid nonce.', 'ai-post-scheduler' ) );
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			AIPS_Ajax_Response::permission_denied();
+		}
+
+		$workflow_id = isset( $_POST['workflow_id'] ) ? absint( $_POST['workflow_id'] ) : 0;
+
+		if ( $workflow_id <= 0 ) {
+			AIPS_Ajax_Response::invalid_request();
+		}
+
+		$args = array(
+			'status'   => isset( $_POST['status'] ) ? sanitize_key( wp_unslash( $_POST['status'] ) ) : '',
+			'page'     => isset( $_POST['page'] ) ? absint( $_POST['page'] ) : 1,
+			'per_page' => isset( $_POST['per_page'] ) ? absint( $_POST['per_page'] ) : 20,
+		);
+
+		$result = $this->repository->list_runs( $workflow_id, $args );
+
+		AIPS_Ajax_Response::success(
+			array(
+				'runs'  => array_map( function ( AIPS_Ability_Workflow_Run $run ) {
+					return $run->to_array();
+				}, $result['items'] ),
+				'total' => $result['total'],
+			)
+		);
+	}
+
+	/**
+	 * Fetch a run and its per-step results.
+	 */
+	public function ajax_get_run() {
+		if ( ! check_ajax_referer( 'aips_ajax_nonce', 'nonce', false ) ) {
+			AIPS_Ajax_Response::error( __( 'Invalid nonce.', 'ai-post-scheduler' ) );
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			AIPS_Ajax_Response::permission_denied();
+		}
+
+		$run_id = isset( $_POST['run_id'] ) ? absint( $_POST['run_id'] ) : 0;
+		$run    = $run_id > 0 ? $this->repository->get_run( $run_id ) : null;
+
+		if ( ! $run ) {
+			AIPS_Ajax_Response::not_found( __( 'Run', 'ai-post-scheduler' ) );
+		}
+
+		$step_runs = $this->repository->get_step_runs( $run_id );
+
+		AIPS_Ajax_Response::success(
+			array(
+				'run'       => $run->to_array(),
+				'step_runs' => array_map( function ( AIPS_Ability_Workflow_Step_Run $step_run ) {
+					return $step_run->to_array();
+				}, $step_runs ),
+			)
+		);
+	}
+
+	/**
+	 * Cancel a queued/running run. Best-effort — an in-flight cron
+	 * invocation completes its current step before observing the
+	 * cancellation and stopping.
+	 */
+	public function ajax_cancel_run() {
+		if ( ! check_ajax_referer( 'aips_ajax_nonce', 'nonce', false ) ) {
+			AIPS_Ajax_Response::error( __( 'Invalid nonce.', 'ai-post-scheduler' ) );
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			AIPS_Ajax_Response::permission_denied();
+		}
+
+		$run_id = isset( $_POST['run_id'] ) ? absint( $_POST['run_id'] ) : 0;
+
+		if ( $run_id <= 0 ) {
+			AIPS_Ajax_Response::invalid_request();
+		}
+
+		$this->repository->update_run_status(
+			$run_id,
+			AIPS_Ability_Workflow_Repository::RUN_STATUS_CANCELLED,
+			array( 'finished_at' => time() )
+		);
+
+		do_action( 'aips_ability_workflow_changed', array(
+			'action'  => 'run_cancelled',
+			'run_id'  => $run_id,
+			'user_id' => get_current_user_id(),
+		) );
+
+		AIPS_Ajax_Response::success( array(), __( 'Workflow run cancelled.', 'ai-post-scheduler' ) );
+	}
+}

--- a/ai-post-scheduler/includes/class-aips-ability-workflow-step-run.php
+++ b/ai-post-scheduler/includes/class-aips-ability-workflow-step-run.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Ability Workflow Step Run DTO
+ *
+ * Immutable value object that wraps a row from the
+ * `aips_ability_workflow_step_runs` DB table.
+ *
+ * @package AI_Post_Scheduler
+ * @since 3.2.0
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+/**
+ * Class AIPS_Ability_Workflow_Step_Run
+ */
+class AIPS_Ability_Workflow_Step_Run {
+
+	public readonly int $id;
+	public readonly int $run_id;
+	public readonly int $workflow_id;
+	public readonly ?int $step_id;
+	public readonly string $step_key;
+	public readonly string $ability_name;
+	public readonly string $status;
+	public readonly array $input_snapshot;
+	public readonly array $output_snapshot;
+	public readonly array $error;
+	public readonly int $started_at;
+	public readonly int $finished_at;
+
+	private function __construct(
+		int $id,
+		int $run_id,
+		int $workflow_id,
+		?int $step_id,
+		string $step_key,
+		string $ability_name,
+		string $status,
+		array $input_snapshot,
+		array $output_snapshot,
+		array $error,
+		int $started_at,
+		int $finished_at
+	) {
+		$this->id              = $id;
+		$this->run_id          = $run_id;
+		$this->workflow_id     = $workflow_id;
+		$this->step_id         = $step_id;
+		$this->step_key        = $step_key;
+		$this->ability_name    = $ability_name;
+		$this->status          = $status;
+		$this->input_snapshot  = $input_snapshot;
+		$this->output_snapshot = $output_snapshot;
+		$this->error           = $error;
+		$this->started_at      = $started_at;
+		$this->finished_at     = $finished_at;
+	}
+
+	/**
+	 * Build an instance from a DB row object returned by wpdb.
+	 *
+	 * @param object $row A stdClass row from aips_ability_workflow_step_runs.
+	 * @return self
+	 */
+	public static function from_row( object $row ): self {
+		return new self(
+			(int) $row->id,
+			(int) $row->run_id,
+			(int) $row->workflow_id,
+			isset( $row->step_id ) && $row->step_id !== null ? (int) $row->step_id : null,
+			(string) $row->step_key,
+			(string) $row->ability_name,
+			(string) ( $row->status ?? 'pending' ),
+			self::decode_json( $row->input_snapshot ?? null ),
+			self::decode_json( $row->output_snapshot ?? null ),
+			self::decode_json( $row->error ?? null ),
+			isset( $row->started_at ) ? (int) $row->started_at : 0,
+			isset( $row->finished_at ) ? (int) $row->finished_at : 0
+		);
+	}
+
+	/**
+	 * Serialize for AJAX/UI responses.
+	 *
+	 * @return array
+	 */
+	public function to_array(): array {
+		return array(
+			'id'               => $this->id,
+			'run_id'           => $this->run_id,
+			'workflow_id'      => $this->workflow_id,
+			'step_id'          => $this->step_id,
+			'step_key'         => $this->step_key,
+			'ability_name'     => $this->ability_name,
+			'status'           => $this->status,
+			'input_snapshot'   => $this->input_snapshot,
+			'output_snapshot'  => $this->output_snapshot,
+			'error'            => $this->error,
+			'started_at'       => $this->started_at,
+			'finished_at'      => $this->finished_at,
+		);
+	}
+
+	/**
+	 * Decode a nullable JSON column, defaulting to an empty array.
+	 *
+	 * @param mixed $value Raw column value.
+	 * @return array
+	 */
+	private static function decode_json( $value ): array {
+		if ( ! is_string( $value ) || $value === '' ) {
+			return array();
+		}
+
+		$decoded = json_decode( $value, true );
+
+		return is_array( $decoded ) ? $decoded : array();
+	}
+}

--- a/ai-post-scheduler/includes/class-aips-ability-workflow-step.php
+++ b/ai-post-scheduler/includes/class-aips-ability-workflow-step.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Ability Workflow Step DTO
+ *
+ * Immutable value object that wraps a row from the
+ * `aips_ability_workflow_steps` DB table.
+ *
+ * @package AI_Post_Scheduler
+ * @since 3.2.0
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+/**
+ * Class AIPS_Ability_Workflow_Step
+ */
+class AIPS_Ability_Workflow_Step {
+
+	public readonly int $id;
+	public readonly int $workflow_id;
+	public readonly string $step_key;
+	public readonly ?string $name;
+	public readonly string $ability_name;
+	public readonly int $position;
+	public readonly array $depends_on;
+	public readonly array $input_map;
+	public readonly array $condition_tree;
+	public readonly ?string $output_alias;
+	public readonly array $on_success;
+	public readonly array $on_failure;
+	public readonly array $retry_policy;
+	public readonly int $created_at;
+	public readonly int $updated_at;
+
+	private function __construct(
+		int $id,
+		int $workflow_id,
+		string $step_key,
+		?string $name,
+		string $ability_name,
+		int $position,
+		array $depends_on,
+		array $input_map,
+		array $condition_tree,
+		?string $output_alias,
+		array $on_success,
+		array $on_failure,
+		array $retry_policy,
+		int $created_at,
+		int $updated_at
+	) {
+		$this->id             = $id;
+		$this->workflow_id    = $workflow_id;
+		$this->step_key       = $step_key;
+		$this->name           = $name;
+		$this->ability_name   = $ability_name;
+		$this->position       = $position;
+		$this->depends_on     = $depends_on;
+		$this->input_map      = $input_map;
+		$this->condition_tree = $condition_tree;
+		$this->output_alias   = $output_alias;
+		$this->on_success     = $on_success;
+		$this->on_failure     = $on_failure;
+		$this->retry_policy   = $retry_policy;
+		$this->created_at     = $created_at;
+		$this->updated_at     = $updated_at;
+	}
+
+	/**
+	 * Build an instance from a DB row object returned by wpdb.
+	 *
+	 * @param object $row A stdClass row from aips_ability_workflow_steps.
+	 * @return self
+	 */
+	public static function from_row( object $row ): self {
+		return new self(
+			(int) $row->id,
+			(int) $row->workflow_id,
+			(string) $row->step_key,
+			isset( $row->name ) && $row->name !== '' ? (string) $row->name : null,
+			(string) $row->ability_name,
+			isset( $row->position ) ? (int) $row->position : 0,
+			self::decode_json( $row->depends_on ?? null ),
+			self::decode_json( $row->input_map ?? null ),
+			self::decode_json( $row->condition_tree ?? null ),
+			isset( $row->output_alias ) && $row->output_alias !== '' ? (string) $row->output_alias : null,
+			self::decode_json( $row->on_success ?? null ),
+			self::decode_json( $row->on_failure ?? null ),
+			self::decode_json( $row->retry_policy ?? null ),
+			isset( $row->created_at ) ? (int) $row->created_at : 0,
+			isset( $row->updated_at ) ? (int) $row->updated_at : 0
+		);
+	}
+
+	/**
+	 * Serialize for AJAX/UI responses.
+	 *
+	 * @return array
+	 */
+	public function to_array(): array {
+		return array(
+			'id'             => $this->id,
+			'workflow_id'    => $this->workflow_id,
+			'step_key'       => $this->step_key,
+			'name'           => $this->name,
+			'ability_name'   => $this->ability_name,
+			'position'       => $this->position,
+			'depends_on'     => $this->depends_on,
+			'input_map'      => $this->input_map,
+			'condition_tree' => $this->condition_tree,
+			'output_alias'   => $this->output_alias,
+			'on_success'     => $this->on_success,
+			'on_failure'     => $this->on_failure,
+			'retry_policy'   => $this->retry_policy,
+			'created_at'     => $this->created_at,
+			'updated_at'     => $this->updated_at,
+		);
+	}
+
+	/**
+	 * Decode a nullable JSON column, defaulting to an empty array.
+	 *
+	 * @param mixed $value Raw column value.
+	 * @return array
+	 */
+	private static function decode_json( $value ): array {
+		if ( ! is_string( $value ) || $value === '' ) {
+			return array();
+		}
+
+		$decoded = json_decode( $value, true );
+
+		return is_array( $decoded ) ? $decoded : array();
+	}
+}

--- a/ai-post-scheduler/includes/class-aips-ability-workflow-variable-resolver.php
+++ b/ai-post-scheduler/includes/class-aips-ability-workflow-variable-resolver.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Ability Workflow Variable Resolver
+ *
+ * Resolves `{{trigger.x}}` / `{{steps.<alias>.output.field}}` template
+ * tokens against a run-scoped variable bag. Pure logic — no DB, HTTP, or
+ * ability calls — reused by both the executor (runtime input resolution)
+ * and the document validator (save-time token validation).
+ *
+ * Variable bag shape:
+ *   array(
+ *       'trigger' => array( ... ),
+ *       'steps'   => array(
+ *           '<output_alias>' => array( 'output' => array( ... ), 'status' => 'completed' ),
+ *       ),
+ *   )
+ *
+ * @package AI_Post_Scheduler
+ * @since 3.2.0
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+/**
+ * Class AIPS_Ability_Workflow_Variable_Resolver
+ */
+class AIPS_Ability_Workflow_Variable_Resolver {
+
+	/**
+	 * Regex matching a single {{token.path}} reference anywhere in a string.
+	 */
+	const TOKEN_PATTERN = '/\{\{\s*([a-zA-Z0-9_.]+)\s*\}\}/';
+
+	/**
+	 * Regex matching a string that consists of exactly one {{token.path}} reference.
+	 */
+	const WHOLE_TOKEN_PATTERN = '/^\{\{\s*([a-zA-Z0-9_.]+)\s*\}\}$/';
+
+	/**
+	 * Resolve a template string against a variable bag.
+	 *
+	 * When the whole string is a single token, the raw typed value is
+	 * returned (e.g. an int, array, or bool). When tokens are embedded in a
+	 * longer string, each token is interpolated as a string.
+	 *
+	 * @param string $template_value Template string, e.g. "{{steps.outline.output.count}}".
+	 * @param array  $variables      Variable bag.
+	 * @return mixed
+	 */
+	public function resolve( string $template_value, array $variables ) {
+		if ( '' === $template_value || false === strpos( $template_value, '{{' ) ) {
+			return $template_value;
+		}
+
+		if ( preg_match( self::WHOLE_TOKEN_PATTERN, $template_value, $matches ) ) {
+			return $this->resolve_token_path( $matches[1], $variables );
+		}
+
+		return preg_replace_callback(
+			self::TOKEN_PATTERN,
+			function ( $matches ) use ( $variables ) {
+				$value = $this->resolve_token_path( $matches[1], $variables );
+
+				if ( is_array( $value ) ) {
+					return wp_json_encode( $value );
+				}
+
+				return null === $value ? '' : (string) $value;
+			},
+			$template_value
+		);
+	}
+
+	/**
+	 * Recursively resolve every string leaf of an input map.
+	 *
+	 * @param array $input_map Map of destination field => template value (or nested map).
+	 * @param array $variables Variable bag.
+	 * @return array
+	 */
+	public function resolve_map( array $input_map, array $variables ): array {
+		$resolved = array();
+
+		foreach ( $input_map as $key => $value ) {
+			if ( is_array( $value ) ) {
+				$resolved[ $key ] = $this->resolve_map( $value, $variables );
+			} elseif ( is_string( $value ) ) {
+				$resolved[ $key ] = $this->resolve( $value, $variables );
+			} else {
+				$resolved[ $key ] = $value;
+			}
+		}
+
+		return $resolved;
+	}
+
+	/**
+	 * Extract raw token paths (without braces) found in a template string.
+	 *
+	 * @param string $template_value Template string.
+	 * @return string[]
+	 */
+	public function extract_tokens( string $template_value ): array {
+		if ( ! preg_match_all( self::TOKEN_PATTERN, $template_value, $matches ) ) {
+			return array();
+		}
+
+		return $matches[1];
+	}
+
+	/**
+	 * Validate a single raw token path (e.g. "trigger.topic" or
+	 * "steps.outline.output.sections_count").
+	 *
+	 * @param string $token Raw token path, without braces.
+	 * @return true|WP_Error
+	 */
+	public function validate_token( string $token ) {
+		if ( 'trigger' === $token || 0 === strpos( $token, 'trigger.' ) ) {
+			return true;
+		}
+
+		if ( preg_match( '/^steps\.[a-zA-Z0-9_]+\.output(\.[a-zA-Z0-9_]+)*$/', $token ) ) {
+			return true;
+		}
+
+		return new WP_Error(
+			'ability_workflow_token_invalid',
+			/* translators: %s: token path */
+			sprintf( __( 'Invalid variable reference "%s" — must start with trigger or steps.<alias>.output.', 'ai-post-scheduler' ), $token )
+		);
+	}
+
+	/**
+	 * Extract and validate every token found in a template string.
+	 *
+	 * @param string $value Template string, possibly containing multiple tokens.
+	 * @return true|WP_Error
+	 */
+	public function validate_token_string( string $value ) {
+		foreach ( $this->extract_tokens( $value ) as $token ) {
+			$result = $this->validate_token( $token );
+
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Walk a dot-separated token path through the variable bag.
+	 *
+	 * @param string $path      Dot-separated path, e.g. "steps.outline.output.count".
+	 * @param array  $variables Variable bag.
+	 * @return mixed Null when any segment of the path is missing.
+	 */
+	private function resolve_token_path( string $path, array $variables ) {
+		$cursor = $variables;
+
+		foreach ( explode( '.', $path ) as $segment ) {
+			if ( is_array( $cursor ) && array_key_exists( $segment, $cursor ) ) {
+				$cursor = $cursor[ $segment ];
+			} else {
+				return null;
+			}
+		}
+
+		return $cursor;
+	}
+}

--- a/ai-post-scheduler/includes/class-aips-ability-workflow.php
+++ b/ai-post-scheduler/includes/class-aips-ability-workflow.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Ability Workflow DTO
+ *
+ * Immutable value object that wraps a row from the `aips_ability_workflows`
+ * DB table.
+ *
+ * @package AI_Post_Scheduler
+ * @since 3.2.0
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+/**
+ * Class AIPS_Ability_Workflow
+ */
+class AIPS_Ability_Workflow {
+
+	public readonly int $id;
+	public readonly string $uuid;
+	public readonly string $name;
+	public readonly ?string $description;
+	public readonly string $status;
+	public readonly string $trigger_type;
+	public readonly array $trigger_config;
+	public readonly array $settings;
+	public readonly int $version;
+	public readonly ?int $created_by;
+	public readonly ?int $updated_by;
+	public readonly int $created_at;
+	public readonly int $updated_at;
+
+	private function __construct(
+		int $id,
+		string $uuid,
+		string $name,
+		?string $description,
+		string $status,
+		string $trigger_type,
+		array $trigger_config,
+		array $settings,
+		int $version,
+		?int $created_by,
+		?int $updated_by,
+		int $created_at,
+		int $updated_at
+	) {
+		$this->id             = $id;
+		$this->uuid            = $uuid;
+		$this->name            = $name;
+		$this->description     = $description;
+		$this->status          = $status;
+		$this->trigger_type    = $trigger_type;
+		$this->trigger_config  = $trigger_config;
+		$this->settings        = $settings;
+		$this->version         = $version;
+		$this->created_by      = $created_by;
+		$this->updated_by      = $updated_by;
+		$this->created_at      = $created_at;
+		$this->updated_at      = $updated_at;
+	}
+
+	/**
+	 * Build an instance from a DB row object returned by wpdb.
+	 *
+	 * @param object $row A stdClass row from aips_ability_workflows.
+	 * @return self
+	 */
+	public static function from_row( object $row ): self {
+		return new self(
+			(int) $row->id,
+			(string) $row->uuid,
+			(string) $row->name,
+			isset( $row->description ) && $row->description !== '' ? (string) $row->description : null,
+			(string) ( $row->status ?? 'draft' ),
+			(string) ( $row->trigger_type ?? 'manual' ),
+			self::decode_json( $row->trigger_config ?? null ),
+			self::decode_json( $row->settings ?? null ),
+			isset( $row->version ) ? (int) $row->version : 1,
+			isset( $row->created_by ) && $row->created_by !== null ? (int) $row->created_by : null,
+			isset( $row->updated_by ) && $row->updated_by !== null ? (int) $row->updated_by : null,
+			isset( $row->created_at ) ? (int) $row->created_at : 0,
+			isset( $row->updated_at ) ? (int) $row->updated_at : 0
+		);
+	}
+
+	/**
+	 * Serialize for AJAX/UI responses.
+	 *
+	 * @return array
+	 */
+	public function to_array(): array {
+		return array(
+			'id'             => $this->id,
+			'uuid'           => $this->uuid,
+			'name'           => $this->name,
+			'description'    => $this->description,
+			'status'         => $this->status,
+			'trigger_type'   => $this->trigger_type,
+			'trigger_config' => $this->trigger_config,
+			'settings'       => $this->settings,
+			'version'        => $this->version,
+			'created_by'     => $this->created_by,
+			'updated_by'     => $this->updated_by,
+			'created_at'     => $this->created_at,
+			'updated_at'     => $this->updated_at,
+		);
+	}
+
+	/**
+	 * Decode a nullable JSON column, defaulting to an empty array.
+	 *
+	 * @param mixed $value Raw column value.
+	 * @return array
+	 */
+	private static function decode_json( $value ): array {
+		if ( ! is_string( $value ) || $value === '' ) {
+			return array();
+		}
+
+		$decoded = json_decode( $value, true );
+
+		return is_array( $decoded ) ? $decoded : array();
+	}
+}

--- a/ai-post-scheduler/includes/class-aips-ability-workflows-controller.php
+++ b/ai-post-scheduler/includes/class-aips-ability-workflows-controller.php
@@ -1,0 +1,349 @@
+<?php
+/**
+ * Ability Workflows Controller
+ *
+ * AJAX handlers for Ability Workflow header/step CRUD.
+ *
+ * @package AI_Post_Scheduler
+ * @since 3.2.0
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+/**
+ * Class AIPS_Ability_Workflows_Controller
+ */
+class AIPS_Ability_Workflows_Controller {
+
+	/**
+	 * @var AIPS_Ability_Workflow_Repository
+	 */
+	private $repository;
+
+	/**
+	 * @var AIPS_Ability_Workflow_Document_Validator
+	 */
+	private $validator;
+
+	/**
+	 * Constructor. Registers all wp_ajax_* hooks owned by this controller.
+	 *
+	 * @param AIPS_Ability_Workflow_Repository|null          $repository Repository.
+	 * @param AIPS_Ability_Workflow_Document_Validator|null $validator  Document validator.
+	 */
+	public function __construct( $repository = null, $validator = null ) {
+		$this->repository = $repository ?: AIPS_Ability_Workflow_Repository::instance();
+		$this->validator   = $validator ?: new AIPS_Ability_Workflow_Document_Validator();
+
+		add_action( 'wp_ajax_aips_save_ability_workflow', array( $this, 'ajax_save_workflow' ) );
+		add_action( 'wp_ajax_aips_get_ability_workflow', array( $this, 'ajax_get_workflow' ) );
+		add_action( 'wp_ajax_aips_list_ability_workflows', array( $this, 'ajax_list_workflows' ) );
+		add_action( 'wp_ajax_aips_delete_ability_workflow', array( $this, 'ajax_delete_workflow' ) );
+		add_action( 'wp_ajax_aips_duplicate_ability_workflow', array( $this, 'ajax_duplicate_workflow' ) );
+		add_action( 'wp_ajax_aips_archive_ability_workflow', array( $this, 'ajax_archive_workflow' ) );
+		add_action( 'wp_ajax_aips_save_ability_workflow_steps', array( $this, 'ajax_save_workflow_steps' ) );
+	}
+
+	/**
+	 * Create or update a workflow's header fields.
+	 */
+	public function ajax_save_workflow() {
+		if ( ! check_ajax_referer( 'aips_ajax_nonce', 'nonce', false ) ) {
+			AIPS_Ajax_Response::error( __( 'Invalid nonce.', 'ai-post-scheduler' ) );
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			AIPS_Ajax_Response::permission_denied();
+		}
+
+		$workflow_id = isset( $_POST['workflow_id'] ) ? absint( $_POST['workflow_id'] ) : 0;
+		$name        = isset( $_POST['name'] ) ? sanitize_text_field( wp_unslash( $_POST['name'] ) ) : '';
+
+		if ( '' === trim( $name ) ) {
+			AIPS_Ajax_Response::error( __( 'Workflow name is required.', 'ai-post-scheduler' ) );
+		}
+
+		$data = array(
+			'name'           => $name,
+			'description'    => isset( $_POST['description'] ) ? sanitize_textarea_field( wp_unslash( $_POST['description'] ) ) : '',
+			'status'         => isset( $_POST['status'] ) ? sanitize_key( wp_unslash( $_POST['status'] ) ) : 'draft',
+			'trigger_type'   => isset( $_POST['trigger_type'] ) ? sanitize_key( wp_unslash( $_POST['trigger_type'] ) ) : 'manual',
+			'trigger_config' => $this->decode_json_field( $_POST['trigger_config'] ?? '' ),
+			'settings'       => $this->decode_json_field( $_POST['settings'] ?? '' ),
+		);
+
+		if ( $workflow_id > 0 ) {
+			$data['updated_by'] = get_current_user_id();
+			$result = $this->repository->update_workflow( $workflow_id, $data );
+
+			if ( is_wp_error( $result ) ) {
+				AIPS_Ajax_Response::error( $result->get_error_message() );
+			}
+		} else {
+			$data['created_by'] = get_current_user_id();
+			$data['updated_by'] = get_current_user_id();
+			$workflow_id = $this->repository->create_workflow( $data );
+
+			if ( is_wp_error( $workflow_id ) ) {
+				AIPS_Ajax_Response::error( $workflow_id->get_error_message() );
+			}
+		}
+
+		do_action( 'aips_ability_workflow_changed', array(
+			'action'      => $workflow_id ? 'saved' : 'created',
+			'workflow_id' => absint( $workflow_id ),
+			'user_id'     => get_current_user_id(),
+		) );
+
+		$workflow = $this->repository->get_workflow( $workflow_id );
+
+		AIPS_Ajax_Response::success(
+			array( 'workflow' => $workflow ? $workflow->to_array() : null ),
+			__( 'Workflow saved successfully.', 'ai-post-scheduler' )
+		);
+	}
+
+	/**
+	 * Fetch a single workflow with its steps.
+	 */
+	public function ajax_get_workflow() {
+		if ( ! check_ajax_referer( 'aips_ajax_nonce', 'nonce', false ) ) {
+			AIPS_Ajax_Response::error( __( 'Invalid nonce.', 'ai-post-scheduler' ) );
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			AIPS_Ajax_Response::permission_denied();
+		}
+
+		$workflow_id = isset( $_POST['workflow_id'] ) ? absint( $_POST['workflow_id'] ) : 0;
+		$workflow    = $workflow_id > 0 ? $this->repository->get_workflow( $workflow_id ) : null;
+
+		if ( ! $workflow ) {
+			AIPS_Ajax_Response::not_found( __( 'Workflow', 'ai-post-scheduler' ) );
+		}
+
+		$steps = $this->repository->get_steps( $workflow_id );
+
+		AIPS_Ajax_Response::success(
+			array(
+				'workflow' => $workflow->to_array(),
+				'steps'    => array_map( function ( AIPS_Ability_Workflow_Step $step ) {
+					return $step->to_array();
+				}, $steps ),
+			)
+		);
+	}
+
+	/**
+	 * List workflows with optional filters and pagination.
+	 */
+	public function ajax_list_workflows() {
+		if ( ! check_ajax_referer( 'aips_ajax_nonce', 'nonce', false ) ) {
+			AIPS_Ajax_Response::error( __( 'Invalid nonce.', 'ai-post-scheduler' ) );
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			AIPS_Ajax_Response::permission_denied();
+		}
+
+		$args = array(
+			'status'       => isset( $_POST['status'] ) ? sanitize_key( wp_unslash( $_POST['status'] ) ) : '',
+			'trigger_type' => isset( $_POST['trigger_type'] ) ? sanitize_key( wp_unslash( $_POST['trigger_type'] ) ) : '',
+			'search'       => isset( $_POST['search'] ) ? sanitize_text_field( wp_unslash( $_POST['search'] ) ) : '',
+			'page'         => isset( $_POST['page'] ) ? absint( $_POST['page'] ) : 1,
+			'per_page'     => isset( $_POST['per_page'] ) ? absint( $_POST['per_page'] ) : 20,
+		);
+
+		$result = $this->repository->list_workflows( $args );
+
+		AIPS_Ajax_Response::success(
+			array(
+				'workflows' => array_map( function ( AIPS_Ability_Workflow $workflow ) {
+					return $workflow->to_array();
+				}, $result['items'] ),
+				'total'     => $result['total'],
+			)
+		);
+	}
+
+	/**
+	 * Delete a workflow (and its steps). Run history is preserved.
+	 */
+	public function ajax_delete_workflow() {
+		if ( ! check_ajax_referer( 'aips_ajax_nonce', 'nonce', false ) ) {
+			AIPS_Ajax_Response::error( __( 'Invalid nonce.', 'ai-post-scheduler' ) );
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			AIPS_Ajax_Response::permission_denied();
+		}
+
+		$workflow_id = isset( $_POST['workflow_id'] ) ? absint( $_POST['workflow_id'] ) : 0;
+
+		if ( $workflow_id <= 0 ) {
+			AIPS_Ajax_Response::invalid_request();
+		}
+
+		if ( ! $this->repository->delete_workflow( $workflow_id ) ) {
+			AIPS_Ajax_Response::error( __( 'Failed to delete workflow.', 'ai-post-scheduler' ) );
+		}
+
+		do_action( 'aips_ability_workflow_changed', array(
+			'action'      => 'deleted',
+			'workflow_id' => $workflow_id,
+			'user_id'     => get_current_user_id(),
+		) );
+
+		AIPS_Ajax_Response::success( array(), __( 'Workflow deleted successfully.', 'ai-post-scheduler' ) );
+	}
+
+	/**
+	 * Duplicate a workflow and its steps as a new draft.
+	 */
+	public function ajax_duplicate_workflow() {
+		if ( ! check_ajax_referer( 'aips_ajax_nonce', 'nonce', false ) ) {
+			AIPS_Ajax_Response::error( __( 'Invalid nonce.', 'ai-post-scheduler' ) );
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			AIPS_Ajax_Response::permission_denied();
+		}
+
+		$workflow_id = isset( $_POST['workflow_id'] ) ? absint( $_POST['workflow_id'] ) : 0;
+
+		if ( $workflow_id <= 0 ) {
+			AIPS_Ajax_Response::invalid_request();
+		}
+
+		$new_id = $this->repository->duplicate_workflow( $workflow_id );
+
+		if ( is_wp_error( $new_id ) ) {
+			AIPS_Ajax_Response::error( $new_id->get_error_message() );
+		}
+
+		do_action( 'aips_ability_workflow_changed', array(
+			'action'      => 'duplicated',
+			'workflow_id' => absint( $new_id ),
+			'user_id'     => get_current_user_id(),
+		) );
+
+		$workflow = $this->repository->get_workflow( $new_id );
+
+		AIPS_Ajax_Response::success(
+			array( 'workflow' => $workflow ? $workflow->to_array() : null ),
+			__( 'Workflow duplicated successfully.', 'ai-post-scheduler' )
+		);
+	}
+
+	/**
+	 * Archive a workflow.
+	 */
+	public function ajax_archive_workflow() {
+		if ( ! check_ajax_referer( 'aips_ajax_nonce', 'nonce', false ) ) {
+			AIPS_Ajax_Response::error( __( 'Invalid nonce.', 'ai-post-scheduler' ) );
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			AIPS_Ajax_Response::permission_denied();
+		}
+
+		$workflow_id = isset( $_POST['workflow_id'] ) ? absint( $_POST['workflow_id'] ) : 0;
+
+		if ( $workflow_id <= 0 ) {
+			AIPS_Ajax_Response::invalid_request();
+		}
+
+		if ( ! $this->repository->archive_workflow( $workflow_id ) ) {
+			AIPS_Ajax_Response::error( __( 'Failed to archive workflow.', 'ai-post-scheduler' ) );
+		}
+
+		do_action( 'aips_ability_workflow_changed', array(
+			'action'      => 'archived',
+			'workflow_id' => $workflow_id,
+			'user_id'     => get_current_user_id(),
+		) );
+
+		AIPS_Ajax_Response::success( array(), __( 'Workflow archived successfully.', 'ai-post-scheduler' ) );
+	}
+
+	/**
+	 * Validate and replace all steps for a workflow.
+	 */
+	public function ajax_save_workflow_steps() {
+		if ( ! check_ajax_referer( 'aips_ajax_nonce', 'nonce', false ) ) {
+			AIPS_Ajax_Response::error( __( 'Invalid nonce.', 'ai-post-scheduler' ) );
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			AIPS_Ajax_Response::permission_denied();
+		}
+
+		$workflow_id = isset( $_POST['workflow_id'] ) ? absint( $_POST['workflow_id'] ) : 0;
+
+		if ( $workflow_id <= 0 || ! $this->repository->get_workflow( $workflow_id ) ) {
+			AIPS_Ajax_Response::not_found( __( 'Workflow', 'ai-post-scheduler' ) );
+		}
+
+		$steps = $this->decode_json_field( $_POST['steps'] ?? '' );
+
+		if ( ! is_array( $steps ) ) {
+			AIPS_Ajax_Response::invalid_request( __( 'Steps payload must be a JSON array.', 'ai-post-scheduler' ) );
+		}
+
+		$validation = $this->validator->validate( array( 'steps' => $steps ) );
+
+		if ( is_wp_error( $validation ) ) {
+			AIPS_Ajax_Response::error(
+				$validation->get_error_message(),
+				$validation->get_error_code(),
+				200,
+				(array) $validation->get_error_data()
+			);
+		}
+
+		$result = $this->repository->save_steps( $workflow_id, $steps );
+
+		if ( is_wp_error( $result ) ) {
+			AIPS_Ajax_Response::error( $result->get_error_message() );
+		}
+
+		do_action( 'aips_ability_workflow_changed', array(
+			'action'      => 'steps_saved',
+			'workflow_id' => $workflow_id,
+			'user_id'     => get_current_user_id(),
+		) );
+
+		$saved_steps = $this->repository->get_steps( $workflow_id );
+
+		AIPS_Ajax_Response::success(
+			array(
+				'steps' => array_map( function ( AIPS_Ability_Workflow_Step $step ) {
+					return $step->to_array();
+				}, $saved_steps ),
+			),
+			__( 'Workflow steps saved successfully.', 'ai-post-scheduler' )
+		);
+	}
+
+	/**
+	 * Decode a JSON-encoded POST field into an array.
+	 *
+	 * @param mixed $raw Raw POST value.
+	 * @return array
+	 */
+	private function decode_json_field( $raw ): array {
+		if ( is_array( $raw ) ) {
+			return $raw;
+		}
+
+		if ( ! is_string( $raw ) || '' === $raw ) {
+			return array();
+		}
+
+		$decoded = json_decode( wp_unslash( $raw ), true );
+
+		return is_array( $decoded ) ? $decoded : array();
+	}
+}

--- a/ai-post-scheduler/includes/class-aips-ability-workflows-controller.php
+++ b/ai-post-scheduler/includes/class-aips-ability-workflows-controller.php
@@ -302,10 +302,10 @@ class AIPS_Ability_Workflows_Controller {
 			AIPS_Ajax_Response::not_found( __( 'Workflow', 'ai-post-scheduler' ) );
 		}
 
-		$steps = $this->decode_json_field( $_POST['steps'] ?? '' );
+		$steps = $this->decode_steps_field( $_POST['steps'] ?? '' );
 
-		if ( ! is_array( $steps ) ) {
-			AIPS_Ajax_Response::invalid_request( __( 'Steps payload must be a JSON array.', 'ai-post-scheduler' ) );
+		if ( is_wp_error( $steps ) ) {
+			AIPS_Ajax_Response::invalid_request( $steps->get_error_message() );
 		}
 
 		$validation = $this->validator->validate( array( 'steps' => $steps ) );
@@ -361,5 +361,41 @@ class AIPS_Ability_Workflows_Controller {
 		$decoded = json_decode( wp_unslash( $raw ), true );
 
 		return is_array( $decoded ) ? $decoded : array();
+	}
+
+	/**
+	 * Decode the steps payload strictly, distinguishing "explicitly empty"
+	 * from "malformed JSON" — unlike decode_json_field(), a malformed value
+	 * here must NOT silently coerce to an empty array, since an empty steps
+	 * array passes validation trivially and would wipe every existing step
+	 * via AIPS_Ability_Workflow_Repository::save_steps()'s replace-all
+	 * semantics.
+	 *
+	 * @param mixed $raw Raw POST value.
+	 * @return array|WP_Error Decoded steps array, or WP_Error when the raw
+	 *                         value was non-empty but failed to decode.
+	 */
+	private function decode_steps_field( $raw ) {
+		if ( is_array( $raw ) ) {
+			return $raw;
+		}
+
+		if ( ! is_string( $raw ) ) {
+			return array();
+		}
+
+		$raw = trim( wp_unslash( $raw ) );
+
+		if ( '' === $raw ) {
+			return array();
+		}
+
+		$decoded = json_decode( $raw, true );
+
+		if ( JSON_ERROR_NONE !== json_last_error() || ! is_array( $decoded ) ) {
+			return new WP_Error( 'ability_workflow_steps_payload_invalid', __( 'Steps payload is not valid JSON.', 'ai-post-scheduler' ) );
+		}
+
+		return $decoded;
 	}
 }

--- a/ai-post-scheduler/includes/class-aips-ability-workflows-controller.php
+++ b/ai-post-scheduler/includes/class-aips-ability-workflows-controller.php
@@ -35,7 +35,23 @@ class AIPS_Ability_Workflows_Controller {
 	 */
 	public function __construct( $repository = null, $validator = null ) {
 		$this->repository = $repository ?: AIPS_Ability_Workflow_Repository::instance();
-		$this->validator   = $validator ?: new AIPS_Ability_Workflow_Document_Validator();
+
+		// The validator must be given a catalog service so save-time
+		// validation actually checks that each step's ability_name refers to
+		// a real, available ability — without it, AIPS_Ability_Workflow_Document_Validator::validate()
+		// silently skips ability-existence checks regardless of the
+		// $skip_ability_check argument, since that check is gated on
+		// `$this->catalog instanceof AIPS_Ability_Catalog_Service`.
+		if ( $validator ) {
+			$this->validator = $validator;
+		} else {
+			$container = AIPS_Container::get_instance();
+			$catalog   = $container->has( AIPS_Ability_Catalog_Service::class )
+				? $container->make( AIPS_Ability_Catalog_Service::class )
+				: new AIPS_Ability_Catalog_Service();
+
+			$this->validator = new AIPS_Ability_Workflow_Document_Validator( null, null, $catalog );
+		}
 
 		add_action( 'wp_ajax_aips_save_ability_workflow', array( $this, 'ajax_save_workflow' ) );
 		add_action( 'wp_ajax_aips_get_ability_workflow', array( $this, 'ajax_get_workflow' ) );

--- a/ai-post-scheduler/includes/class-aips-admin-assets.php
+++ b/ai-post-scheduler/includes/class-aips-admin-assets.php
@@ -54,6 +54,8 @@ class AIPS_Admin_Assets {
 	private const PAGE_TELEMETRY = 'aips-telemetry';
 	private const PAGE_INTERNAL_LINKS = 'aips-internal-links';
 	private const PAGE_CACHE_MONITOR  = 'aips-cache-monitor';
+	private const PAGE_ABILITY_WORKFLOWS = 'aips-ability-workflows';
+	private const PAGE_ABILITY_WORKFLOW_BUILDER = 'aips-ability-workflow-builder';
 
     /**
      * Initialize the class.
@@ -174,6 +176,14 @@ class AIPS_Admin_Assets {
 
         if (self::PAGE_CACHE_MONITOR === $page || $this->hook_contains($hook, self::PAGE_CACHE_MONITOR) || $this->is_diagnostics_tab($page, 'cache-monitor')) {
 			$this->enqueue_cache_monitor_assets();
+		}
+
+		if ((self::PAGE_ABILITY_WORKFLOWS === $page || $this->hook_contains($hook, self::PAGE_ABILITY_WORKFLOWS)) && AIPS_Config::get_instance()->get_option('aips_enable_ability_workflows')) {
+			$this->enqueue_ability_workflows_assets();
+		}
+
+		if ((self::PAGE_ABILITY_WORKFLOW_BUILDER === $page || $this->hook_contains($hook, self::PAGE_ABILITY_WORKFLOW_BUILDER)) && AIPS_Config::get_instance()->get_option('aips_enable_ability_workflows')) {
+			$this->enqueue_ability_workflow_builder_assets();
 		}
 
 	}
@@ -1469,6 +1479,61 @@ class AIPS_Admin_Assets {
                 'urlRequired'       => __('A URL is required.', 'ai-post-scheduler'),
                 'groupNameRequired' => __('Please enter a group name.', 'ai-post-scheduler'),
                 'deleteGroupConfirm' => __('Delete this Source Group? Sources in this group will not be deleted.', 'ai-post-scheduler'),
+            ));
+    }
+
+    /**
+     * Enqueue assets for the Ability Workflows list page.
+     */
+    private function enqueue_ability_workflows_assets() {
+            wp_enqueue_script(
+                'aips-admin-ability-workflows',
+                AIPS_PLUGIN_URL . 'assets/js/admin-ability-workflows.js',
+                array('jquery', 'aips-utilities-script', 'aips-templates-script'),
+                AIPS_VERSION,
+                true
+            );
+
+            wp_localize_script('aips-admin-ability-workflows', 'aipsAbilityWorkflowsL10n', array(
+                'addNewWorkflow'   => __('Create Workflow', 'ai-post-scheduler'),
+                'editWorkflow'     => __('Edit Workflow', 'ai-post-scheduler'),
+                'saveWorkflow'     => __('Save Workflow', 'ai-post-scheduler'),
+                'saving'           => __('Saving…', 'ai-post-scheduler'),
+                'deleteConfirm'    => __('Are you sure you want to delete this workflow?', 'ai-post-scheduler'),
+                'saveFailed'       => __('Failed to save workflow.', 'ai-post-scheduler'),
+                'deleteFailed'     => __('Failed to delete workflow.', 'ai-post-scheduler'),
+                'duplicateFailed'  => __('Failed to duplicate workflow.', 'ai-post-scheduler'),
+                'archiveFailed'    => __('Failed to archive workflow.', 'ai-post-scheduler'),
+                'runFailed'        => __('Failed to start workflow run.', 'ai-post-scheduler'),
+                'runStarted'       => __('Workflow run started.', 'ai-post-scheduler'),
+                'nameRequired'     => __('Workflow name is required.', 'ai-post-scheduler'),
+            ));
+    }
+
+    /**
+     * Enqueue assets for the Ability Workflow Builder page.
+     */
+    private function enqueue_ability_workflow_builder_assets() {
+            wp_enqueue_script(
+                'aips-admin-ability-workflow-builder',
+                AIPS_PLUGIN_URL . 'assets/js/admin-ability-workflow-builder.js',
+                array('jquery', 'aips-utilities-script', 'aips-templates-script'),
+                AIPS_VERSION,
+                true
+            );
+
+            wp_localize_script('aips-admin-ability-workflow-builder', 'aipsAbilityWorkflowBuilderL10n', array(
+                'addStep'            => __('Add Step', 'ai-post-scheduler'),
+                'editStep'           => __('Edit Step', 'ai-post-scheduler'),
+                'saveStep'           => __('Save Step', 'ai-post-scheduler'),
+                'saveSteps'          => __('Save Steps', 'ai-post-scheduler'),
+                'saving'             => __('Saving…', 'ai-post-scheduler'),
+                'removeStepConfirm'  => __('Remove this step from the workflow?', 'ai-post-scheduler'),
+                'saveFailed'         => __('Failed to save workflow steps.', 'ai-post-scheduler'),
+                'loadAbilitiesFailed' => __('Failed to load available abilities.', 'ai-post-scheduler'),
+                'loadRunsFailed'     => __('Failed to load workflow runs.', 'ai-post-scheduler'),
+                'stepKeyRequired'    => __('Each step needs a unique key.', 'ai-post-scheduler'),
+                'abilityRequired'    => __('Please choose an ability for this step.', 'ai-post-scheduler'),
             ));
     }
 

--- a/ai-post-scheduler/includes/class-aips-admin-menu.php
+++ b/ai-post-scheduler/includes/class-aips-admin-menu.php
@@ -291,6 +291,26 @@ class AIPS_Admin_Menu {
                 array($this, 'render_dev_tools_page')
             );
         }
+
+        if (AIPS_Config::get_instance()->get_option('aips_enable_ability_workflows')) {
+            add_submenu_page(
+                'ai-post-scheduler',
+                __('Ability Workflows', 'ai-post-scheduler'),
+                __('Ability Workflows', 'ai-post-scheduler'),
+                'manage_options',
+                'aips-ability-workflows',
+                array($this, 'render_ability_workflows_page')
+            );
+
+            add_submenu_page(
+                null,
+                __('Ability Workflow Builder', 'ai-post-scheduler'),
+                __('Ability Workflow Builder', 'ai-post-scheduler'),
+                'manage_options',
+                'aips-ability-workflow-builder',
+                array($this, 'render_ability_workflow_builder_page')
+            );
+        }
     }
 
     /**
@@ -304,7 +324,7 @@ class AIPS_Admin_Menu {
      */
     public function fix_author_topics_parent_file($parent_file) {
         $page = isset($_GET['page']) ? sanitize_key(wp_unslash($_GET['page'])) : '';
-        if ($page === 'aips-author-topics' || $page === AIPS_Campaigns_Controller::DETAIL_PAGE_SLUG || $this->is_diagnostics_child_page($page) || $this->is_automations_child_page($page)) {
+        if ($page === 'aips-author-topics' || $page === AIPS_Campaigns_Controller::DETAIL_PAGE_SLUG || $this->is_diagnostics_child_page($page) || $this->is_automations_child_page($page) || $this->is_ability_workflows_child_page($page)) {
             return 'ai-post-scheduler';
         }
         return $parent_file;
@@ -327,6 +347,9 @@ class AIPS_Admin_Menu {
         }
         if ($this->is_automations_child_page($page)) {
             return 'aips-automations';
+        }
+        if ($this->is_ability_workflows_child_page($page)) {
+            return 'aips-ability-workflows';
         }
         return $submenu_file;
     }
@@ -372,6 +395,22 @@ class AIPS_Admin_Menu {
                 'aips-author-topics',
                 AIPS_Campaigns_Controller::PAGE_SLUG,
                 AIPS_Campaigns_Controller::DETAIL_PAGE_SLUG,
+            ),
+            true
+        );
+    }
+
+    /**
+     * Determine whether a hidden page belongs under Ability Workflows.
+     *
+     * @param string $page Current admin page slug.
+     * @return bool
+     */
+    private function is_ability_workflows_child_page($page) {
+        return in_array(
+            $page,
+            array(
+                'aips-ability-workflow-builder',
             ),
             true
         );
@@ -696,6 +735,25 @@ class AIPS_Admin_Menu {
         // It's a lightweight class, mostly for AJAX and rendering.
         $dev_tools = new AIPS_Dev_Tools();
         $dev_tools->render_page();
+    }
+
+    /**
+     * Render the Ability Workflows list page.
+     *
+     * @return void
+     */
+    public function render_ability_workflows_page() {
+        include AIPS_PLUGIN_DIR . 'templates/admin/ability-workflows.php';
+    }
+
+    /**
+     * Render the Ability Workflow Builder page (hidden — consolidated under
+     * the visible Ability Workflows submenu item).
+     *
+     * @return void
+     */
+    public function render_ability_workflow_builder_page() {
+        include AIPS_PLUGIN_DIR . 'templates/admin/ability-workflow-builder.php';
     }
 
     /**

--- a/ai-post-scheduler/includes/class-aips-ajax-registry.php
+++ b/ai-post-scheduler/includes/class-aips-ajax-registry.php
@@ -290,6 +290,24 @@ class AIPS_Ajax_Registry {
 
 		// Dashboard Controller
 		'aips_get_dashboard_data'              => 'AIPS_Dashboard_Controller',
+
+		// Ability Workflows Controller
+		'aips_save_ability_workflow'           => 'AIPS_Ability_Workflows_Controller',
+		'aips_get_ability_workflow'            => 'AIPS_Ability_Workflows_Controller',
+		'aips_list_ability_workflows'          => 'AIPS_Ability_Workflows_Controller',
+		'aips_delete_ability_workflow'         => 'AIPS_Ability_Workflows_Controller',
+		'aips_duplicate_ability_workflow'      => 'AIPS_Ability_Workflows_Controller',
+		'aips_archive_ability_workflow'        => 'AIPS_Ability_Workflows_Controller',
+		'aips_save_ability_workflow_steps'     => 'AIPS_Ability_Workflows_Controller',
+
+		// Ability Workflow Runs Controller
+		'aips_run_ability_workflow_now'        => 'AIPS_Ability_Workflow_Runs_Controller',
+		'aips_list_ability_workflow_runs'      => 'AIPS_Ability_Workflow_Runs_Controller',
+		'aips_get_ability_workflow_run'        => 'AIPS_Ability_Workflow_Runs_Controller',
+		'aips_cancel_ability_workflow_run'     => 'AIPS_Ability_Workflow_Runs_Controller',
+
+		// Ability Catalog Controller
+		'aips_list_abilities'                  => 'AIPS_Ability_Catalog_Controller',
 	);
 
 	/**

--- a/ai-post-scheduler/includes/class-aips-config.php
+++ b/ai-post-scheduler/includes/class-aips-config.php
@@ -187,6 +187,8 @@ class AIPS_Config {
             'aips_research_niches' => array(),
             // Telemetry
             'aips_enable_telemetry' => false,
+            // Ability Workflows
+            'aips_enable_ability_workflows' => false,
             // Cache Monitor
             'aips_cache_monitor_enabled'               => true,
             'aips_cache_monitor_index_enabled'         => true,

--- a/ai-post-scheduler/includes/class-aips-db-manager.php
+++ b/ai-post-scheduler/includes/class-aips-db-manager.php
@@ -33,6 +33,10 @@ class AIPS_DB_Manager {
         'aips_bulk_batch_jobs',
         'aips_cache_index',
         'aips_cache_events',
+        'aips_ability_workflows',
+        'aips_ability_workflow_steps',
+        'aips_ability_workflow_runs',
+        'aips_ability_workflow_step_runs',
     );
 
     public function __construct() {
@@ -94,6 +98,10 @@ class AIPS_DB_Manager {
         $table_bulk_batch_jobs      = $tables['aips_bulk_batch_jobs'];
         $table_cache_index          = $tables['aips_cache_index'];
         $table_cache_events         = $tables['aips_cache_events'];
+        $table_ability_workflows          = $tables['aips_ability_workflows'];
+        $table_ability_workflow_steps     = $tables['aips_ability_workflow_steps'];
+        $table_ability_workflow_runs      = $tables['aips_ability_workflow_runs'];
+        $table_ability_workflow_step_runs = $tables['aips_ability_workflow_step_runs'];
 
         $sql = array();
 
@@ -637,6 +645,88 @@ class AIPS_DB_Manager {
             KEY event_type (event_type),
             KEY created_at (created_at),
             KEY user_id (user_id)
+        ) $charset_collate;";
+
+        $sql[] = "CREATE TABLE $table_ability_workflows (
+            id bigint(20) NOT NULL AUTO_INCREMENT,
+            uuid varchar(36) NOT NULL,
+            name varchar(255) NOT NULL,
+            description text DEFAULT NULL,
+            status varchar(20) NOT NULL DEFAULT 'draft',
+            trigger_type varchar(50) NOT NULL DEFAULT 'manual',
+            trigger_config longtext DEFAULT NULL,
+            settings longtext DEFAULT NULL,
+            version int(11) NOT NULL DEFAULT 1,
+            created_by bigint(20) DEFAULT NULL,
+            updated_by bigint(20) DEFAULT NULL,
+            created_at bigint(20) unsigned NOT NULL DEFAULT 0,
+            updated_at bigint(20) unsigned NOT NULL DEFAULT 0,
+            PRIMARY KEY  (id),
+            UNIQUE KEY uuid (uuid),
+            KEY status (status),
+            KEY trigger_type (trigger_type),
+            KEY created_by (created_by),
+            KEY updated_at (updated_at)
+        ) $charset_collate;";
+
+        $sql[] = "CREATE TABLE $table_ability_workflow_steps (
+            id bigint(20) NOT NULL AUTO_INCREMENT,
+            workflow_id bigint(20) NOT NULL,
+            step_key varchar(100) NOT NULL,
+            name varchar(255) DEFAULT NULL,
+            ability_name varchar(191) NOT NULL,
+            position int(11) NOT NULL DEFAULT 0,
+            depends_on text DEFAULT NULL,
+            input_map longtext DEFAULT NULL,
+            condition_tree longtext DEFAULT NULL,
+            output_alias varchar(100) DEFAULT NULL,
+            on_success longtext DEFAULT NULL,
+            on_failure longtext DEFAULT NULL,
+            retry_policy longtext DEFAULT NULL,
+            created_at bigint(20) unsigned NOT NULL DEFAULT 0,
+            updated_at bigint(20) unsigned NOT NULL DEFAULT 0,
+            PRIMARY KEY  (id),
+            KEY workflow_id (workflow_id),
+            KEY workflow_position (workflow_id, position),
+            KEY ability_name (ability_name),
+            KEY step_key (step_key)
+        ) $charset_collate;";
+
+        $sql[] = "CREATE TABLE $table_ability_workflow_runs (
+            id bigint(20) NOT NULL AUTO_INCREMENT,
+            workflow_id bigint(20) NOT NULL,
+            workflow_version int(11) NOT NULL DEFAULT 1,
+            status varchar(20) NOT NULL DEFAULT 'queued',
+            trigger_context longtext DEFAULT NULL,
+            started_at bigint(20) unsigned NOT NULL DEFAULT 0,
+            finished_at bigint(20) unsigned NOT NULL DEFAULT 0,
+            created_by bigint(20) DEFAULT NULL,
+            correlation_id varchar(36) DEFAULT NULL,
+            PRIMARY KEY  (id),
+            KEY workflow_id (workflow_id),
+            KEY status (status),
+            KEY workflow_status_started (workflow_id, status, started_at),
+            KEY correlation_id (correlation_id)
+        ) $charset_collate;";
+
+        $sql[] = "CREATE TABLE $table_ability_workflow_step_runs (
+            id bigint(20) NOT NULL AUTO_INCREMENT,
+            run_id bigint(20) NOT NULL,
+            workflow_id bigint(20) NOT NULL,
+            step_id bigint(20) DEFAULT NULL,
+            step_key varchar(100) NOT NULL,
+            ability_name varchar(191) NOT NULL,
+            status varchar(20) NOT NULL DEFAULT 'pending',
+            input_snapshot longtext DEFAULT NULL,
+            output_snapshot longtext DEFAULT NULL,
+            error longtext DEFAULT NULL,
+            started_at bigint(20) unsigned NOT NULL DEFAULT 0,
+            finished_at bigint(20) unsigned NOT NULL DEFAULT 0,
+            PRIMARY KEY  (id),
+            KEY run_id (run_id),
+            KEY workflow_id (workflow_id),
+            KEY run_step_status (run_id, step_key, status),
+            KEY ability_name (ability_name)
         ) $charset_collate;";
 
         return $sql;

--- a/ai-post-scheduler/includes/class-aips-settings-ui.php
+++ b/ai-post-scheduler/includes/class-aips-settings-ui.php
@@ -369,6 +369,26 @@ class AIPS_Settings_UI {
     }
 
     /**
+     * Render the enable Ability Workflows setting field.
+     *
+     * Displays a checkbox to enable or disable the Ability Workflows admin
+     * pages and AJAX endpoints.
+     *
+     * @return void
+     */
+    public function enable_ability_workflows_field_callback() {
+        $value = AIPS_Config::get_instance()->get_option('aips_enable_ability_workflows');
+        ?>
+        <input type="hidden" name="aips_enable_ability_workflows" value="0">
+        <label>
+            <input type="checkbox" name="aips_enable_ability_workflows" value="1" <?php checked($value, 1); ?>>
+            <?php esc_html_e('Enable Ability Workflows', 'ai-post-scheduler'); ?>
+        </label>
+        <p class="description"><?php esc_html_e('Adds an admin page for building multi-step automation workflows out of installed WordPress Abilities.', 'ai-post-scheduler'); ?></p>
+        <?php
+    }
+
+    /**
      * Render the review notifications email setting field.
      *
      * Displays an email input field for the notifications recipient.

--- a/ai-post-scheduler/includes/class-aips-settings.php
+++ b/ai-post-scheduler/includes/class-aips-settings.php
@@ -87,6 +87,10 @@ class AIPS_Settings {
 				'sanitize_callback' => 'absint',
 				'default'           => $defaults['aips_enable_telemetry'],
 			),
+			'aips_enable_ability_workflows' => array(
+				'sanitize_callback' => 'absint',
+				'default'           => $defaults['aips_enable_ability_workflows'],
+			),
 			'aips_enable_retry' => array(
 				'sanitize_callback' => 'absint',
 				'default'           => $defaults['aips_enable_retry'],
@@ -398,6 +402,14 @@ class AIPS_Settings {
             'aips_enable_telemetry',
             __('Enable Telemetry', 'ai-post-scheduler'),
             array($this->ui, 'enable_telemetry_field_callback'),
+            'aips-settings',
+            'aips_developers_section'
+        );
+
+        add_settings_field(
+            'aips_enable_ability_workflows',
+            __('Enable Ability Workflows', 'ai-post-scheduler'),
+            array($this->ui, 'enable_ability_workflows_field_callback'),
             'aips-settings',
             'aips_developers_section'
         );

--- a/ai-post-scheduler/templates/admin/ability-workflow-builder.php
+++ b/ai-post-scheduler/templates/admin/ability-workflow-builder.php
@@ -1,0 +1,342 @@
+<?php
+/**
+ * Ability Workflow Builder admin page template.
+ *
+ * Hidden page (consolidated under the visible "Ability Workflows" submenu
+ * item) for editing a single workflow's steps and viewing its run history.
+ * All data is loaded via AJAX; this template only renders the page shell,
+ * modals, and the AIPS.Templates row templates used by the companion JS.
+ *
+ * @package AI_Post_Scheduler
+ * @since 3.2.0
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+$aips_workflow_id   = isset($_GET['workflow_id']) ? absint($_GET['workflow_id']) : 0;
+$aips_workflows_url = admin_url('admin.php?page=aips-ability-workflows');
+
+if ($aips_workflow_id <= 0) {
+	?>
+	<div class="wrap aips-wrap">
+		<div class="aips-page-container">
+			<div class="aips-empty-state">
+				<h3 class="aips-empty-state-title"><?php esc_html_e('No workflow selected', 'ai-post-scheduler'); ?></h3>
+				<div class="aips-empty-state-actions">
+					<a class="aips-btn aips-btn-primary" href="<?php echo esc_url($aips_workflows_url); ?>">
+						<?php esc_html_e('Back to Ability Workflows', 'ai-post-scheduler'); ?>
+					</a>
+				</div>
+			</div>
+		</div>
+	</div>
+	<?php
+	return;
+}
+?>
+<div class="wrap aips-wrap">
+	<div class="aips-page-container">
+
+		<div class="aips-page-header">
+			<div class="aips-page-header-top">
+				<div>
+					<h1 class="aips-page-title" id="aips-builder-workflow-name"><?php esc_html_e('Loading…', 'ai-post-scheduler'); ?></h1>
+					<p class="aips-page-description">
+						<a href="<?php echo esc_url($aips_workflows_url); ?>">&larr; <?php esc_html_e('Back to Ability Workflows', 'ai-post-scheduler'); ?></a>
+					</p>
+				</div>
+				<div class="aips-page-actions">
+					<button type="button" class="aips-btn aips-btn-secondary" id="aips-builder-run-now-btn">
+						<span class="dashicons dashicons-controls-play"></span>
+						<?php esc_html_e('Run Now', 'ai-post-scheduler'); ?>
+					</button>
+					<button type="button" class="aips-btn aips-btn-primary" id="aips-save-steps-btn">
+						<?php esc_html_e('Save Steps', 'ai-post-scheduler'); ?>
+					</button>
+				</div>
+			</div>
+		</div>
+
+		<div class="aips-tab-nav">
+			<a href="#" class="aips-tab-link active" data-tab="steps"><?php esc_html_e('Steps', 'ai-post-scheduler'); ?></a>
+			<a href="#" class="aips-tab-link" data-tab="runs"><?php esc_html_e('Runs', 'ai-post-scheduler'); ?></a>
+		</div>
+
+		<div class="aips-content-panel" id="aips-builder-tab-steps">
+			<div class="aips-page-actions" style="padding:12px 16px;">
+				<button type="button" class="aips-btn aips-btn-secondary aips-btn-sm" id="aips-add-step-btn">
+					<span class="dashicons dashicons-plus-alt2"></span>
+					<?php esc_html_e('Add Step', 'ai-post-scheduler'); ?>
+				</button>
+			</div>
+			<div class="aips-panel-body no-padding">
+				<table class="aips-table" id="aips-steps-table">
+					<thead>
+						<tr>
+							<th style="width:60px;"><?php esc_html_e('Order', 'ai-post-scheduler'); ?></th>
+							<th><?php esc_html_e('Step', 'ai-post-scheduler'); ?></th>
+							<th><?php esc_html_e('Ability', 'ai-post-scheduler'); ?></th>
+							<th><?php esc_html_e('Output Alias', 'ai-post-scheduler'); ?></th>
+							<th class="column-actions"><?php esc_html_e('Actions', 'ai-post-scheduler'); ?></th>
+						</tr>
+					</thead>
+					<tbody id="aips-steps-table-body"></tbody>
+				</table>
+			</div>
+			<div id="aips-steps-empty" class="aips-empty-state" style="display:none;">
+				<h3 class="aips-empty-state-title"><?php esc_html_e('No steps yet', 'ai-post-scheduler'); ?></h3>
+				<p class="aips-empty-state-description"><?php esc_html_e('Add a step to choose an Ability and map its inputs.', 'ai-post-scheduler'); ?></p>
+			</div>
+		</div>
+
+		<div class="aips-content-panel" id="aips-builder-tab-runs" style="display:none;">
+			<div class="aips-panel-body no-padding">
+				<table class="aips-table" id="aips-runs-table">
+					<thead>
+						<tr>
+							<th><?php esc_html_e('Run', 'ai-post-scheduler'); ?></th>
+							<th><?php esc_html_e('Status', 'ai-post-scheduler'); ?></th>
+							<th><?php esc_html_e('Started', 'ai-post-scheduler'); ?></th>
+							<th><?php esc_html_e('Finished', 'ai-post-scheduler'); ?></th>
+							<th class="column-actions"><?php esc_html_e('Actions', 'ai-post-scheduler'); ?></th>
+						</tr>
+					</thead>
+					<tbody id="aips-runs-table-body"></tbody>
+				</table>
+			</div>
+			<div id="aips-runs-empty" class="aips-empty-state" style="display:none;">
+				<h3 class="aips-empty-state-title"><?php esc_html_e('No runs yet', 'ai-post-scheduler'); ?></h3>
+			</div>
+		</div>
+
+	</div>
+</div>
+
+<!-- Step Edit Modal -->
+<div id="aips-step-modal" class="aips-modal" style="display:none;" role="dialog" aria-modal="true">
+	<div class="aips-modal-content aips-modal-large">
+		<div class="aips-modal-header">
+			<h2 class="aips-modal-title" id="aips-step-modal-title"><?php esc_html_e('Add Step', 'ai-post-scheduler'); ?></h2>
+			<button type="button" class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
+		</div>
+		<div class="aips-modal-body">
+			<form id="aips-step-form" novalidate>
+				<input type="hidden" id="aips-step-index" value="-1">
+
+				<div class="aips-form-row">
+					<label for="aips-step-key">
+						<?php esc_html_e('Step Key', 'ai-post-scheduler'); ?>
+						<span class="required" aria-hidden="true">*</span>
+					</label>
+					<input type="text" id="aips-step-key" class="regular-text" placeholder="<?php esc_attr_e('e.g. generate_outline', 'ai-post-scheduler'); ?>">
+					<p class="description"><?php esc_html_e('Unique identifier for this step (letters, numbers, underscores).', 'ai-post-scheduler'); ?></p>
+				</div>
+
+				<div class="aips-form-row">
+					<label for="aips-step-name"><?php esc_html_e('Name', 'ai-post-scheduler'); ?></label>
+					<input type="text" id="aips-step-name" class="regular-text">
+				</div>
+
+				<div class="aips-form-row">
+					<label for="aips-step-ability">
+						<?php esc_html_e('Ability', 'ai-post-scheduler'); ?>
+						<span class="required" aria-hidden="true">*</span>
+					</label>
+					<select id="aips-step-ability" class="aips-form-select"></select>
+				</div>
+
+				<div class="aips-form-row">
+					<label for="aips-step-depends-on"><?php esc_html_e('Depends On', 'ai-post-scheduler'); ?></label>
+					<select id="aips-step-depends-on" class="aips-form-select" multiple size="4"></select>
+					<p class="description"><?php esc_html_e('This step only runs after all selected steps complete successfully.', 'ai-post-scheduler'); ?></p>
+				</div>
+
+				<div class="aips-form-row">
+					<label for="aips-step-output-alias"><?php esc_html_e('Output Alias', 'ai-post-scheduler'); ?></label>
+					<input type="text" id="aips-step-output-alias" class="regular-text" placeholder="<?php esc_attr_e('e.g. outline', 'ai-post-scheduler'); ?>">
+					<p class="description"><?php esc_html_e('Later steps reference this step\'s output as {{steps.<alias>.output.<field>}}.', 'ai-post-scheduler'); ?></p>
+				</div>
+
+				<div class="aips-form-row">
+					<label><?php esc_html_e('Input Mapping', 'ai-post-scheduler'); ?></label>
+					<table class="aips-table" id="aips-input-map-table">
+						<thead><tr>
+							<th><?php esc_html_e('Field', 'ai-post-scheduler'); ?></th>
+							<th><?php esc_html_e('Value / Template', 'ai-post-scheduler'); ?></th>
+							<th style="width:40px;"></th>
+						</tr></thead>
+						<tbody id="aips-input-map-table-body"></tbody>
+					</table>
+					<button type="button" class="aips-btn aips-btn-sm aips-btn-ghost" id="aips-add-input-map-row-btn">
+						<span class="dashicons dashicons-plus-alt2"></span> <?php esc_html_e('Add Field', 'ai-post-scheduler'); ?>
+					</button>
+					<p class="description"><?php esc_html_e('Use {{trigger.field}} or {{steps.<alias>.output.field}} to reference earlier data.', 'ai-post-scheduler'); ?></p>
+				</div>
+
+				<div class="aips-form-row">
+					<label><?php esc_html_e('Conditions', 'ai-post-scheduler'); ?></label>
+					<select id="aips-condition-operator" class="aips-form-select" style="max-width:120px;">
+						<option value="AND"><?php esc_html_e('AND', 'ai-post-scheduler'); ?></option>
+						<option value="OR"><?php esc_html_e('OR', 'ai-post-scheduler'); ?></option>
+					</select>
+					<table class="aips-table" id="aips-condition-rules-table">
+						<thead><tr>
+							<th><?php esc_html_e('Left (value or {{token}})', 'ai-post-scheduler'); ?></th>
+							<th><?php esc_html_e('Operator', 'ai-post-scheduler'); ?></th>
+							<th><?php esc_html_e('Right', 'ai-post-scheduler'); ?></th>
+							<th style="width:40px;"></th>
+						</tr></thead>
+						<tbody id="aips-condition-rules-table-body"></tbody>
+					</table>
+					<button type="button" class="aips-btn aips-btn-sm aips-btn-ghost" id="aips-add-condition-rule-btn">
+						<span class="dashicons dashicons-plus-alt2"></span> <?php esc_html_e('Add Rule', 'ai-post-scheduler'); ?>
+					</button>
+					<p class="description"><?php esc_html_e('Leave empty to always run this step (subject to Depends On).', 'ai-post-scheduler'); ?></p>
+				</div>
+
+				<div class="aips-form-row">
+					<label for="aips-step-on-success"><?php esc_html_e('On Success', 'ai-post-scheduler'); ?></label>
+					<select id="aips-step-on-success" class="aips-form-select">
+						<option value="continue"><?php esc_html_e('Continue', 'ai-post-scheduler'); ?></option>
+						<option value="stop"><?php esc_html_e('Stop workflow (success)', 'ai-post-scheduler'); ?></option>
+						<option value="skip"><?php esc_html_e('Skip dependent steps', 'ai-post-scheduler'); ?></option>
+					</select>
+				</div>
+
+				<div class="aips-form-row">
+					<label for="aips-step-on-failure"><?php esc_html_e('On Failure', 'ai-post-scheduler'); ?></label>
+					<select id="aips-step-on-failure" class="aips-form-select">
+						<option value="stop"><?php esc_html_e('Stop workflow (failed)', 'ai-post-scheduler'); ?></option>
+						<option value="continue"><?php esc_html_e('Continue', 'ai-post-scheduler'); ?></option>
+						<option value="skip"><?php esc_html_e('Skip dependent steps', 'ai-post-scheduler'); ?></option>
+					</select>
+				</div>
+
+				<div class="aips-form-row">
+					<label for="aips-step-retry-attempts"><?php esc_html_e('Retry Attempts', 'ai-post-scheduler'); ?></label>
+					<input type="number" id="aips-step-retry-attempts" min="0" max="10" value="0" class="small-text">
+				</div>
+
+				<div class="aips-form-row">
+					<label for="aips-step-retry-backoff"><?php esc_html_e('Retry Backoff (seconds)', 'ai-post-scheduler'); ?></label>
+					<input type="number" id="aips-step-retry-backoff" min="1" max="3600" value="5" class="small-text">
+				</div>
+			</form>
+		</div>
+		<div class="aips-modal-footer">
+			<button type="button" class="aips-btn aips-btn-secondary aips-modal-close"><?php esc_html_e('Cancel', 'ai-post-scheduler'); ?></button>
+			<button type="button" class="aips-btn aips-btn-primary" id="aips-save-step-btn">
+				<?php esc_html_e('Save Step', 'ai-post-scheduler'); ?>
+			</button>
+		</div>
+	</div>
+</div>
+
+<!-- Run Detail Modal -->
+<div id="aips-run-detail-modal" class="aips-modal" style="display:none;" role="dialog" aria-modal="true">
+	<div class="aips-modal-content aips-modal-large">
+		<div class="aips-modal-header">
+			<h2 class="aips-modal-title"><?php esc_html_e('Run Details', 'ai-post-scheduler'); ?></h2>
+			<button type="button" class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
+		</div>
+		<div class="aips-modal-body">
+			<table class="aips-table" id="aips-run-detail-table">
+				<thead><tr>
+					<th><?php esc_html_e('Step', 'ai-post-scheduler'); ?></th>
+					<th><?php esc_html_e('Ability', 'ai-post-scheduler'); ?></th>
+					<th><?php esc_html_e('Status', 'ai-post-scheduler'); ?></th>
+					<th><?php esc_html_e('Output / Error', 'ai-post-scheduler'); ?></th>
+				</tr></thead>
+				<tbody id="aips-run-detail-table-body"></tbody>
+			</table>
+		</div>
+		<div class="aips-modal-footer">
+			<button type="button" class="aips-btn aips-btn-secondary aips-modal-close"><?php esc_html_e('Close', 'ai-post-scheduler'); ?></button>
+		</div>
+	</div>
+</div>
+
+<script type="text/html" id="aips-tmpl-step-row">
+	<tr data-index="{{index}}">
+		<td>
+			<button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-move-step-up" data-index="{{index}}" title="<?php esc_attr_e('Move up', 'ai-post-scheduler'); ?>">
+				<span class="dashicons dashicons-arrow-up-alt2"></span>
+			</button>
+			<button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-move-step-down" data-index="{{index}}" title="<?php esc_attr_e('Move down', 'ai-post-scheduler'); ?>">
+				<span class="dashicons dashicons-arrow-down-alt2"></span>
+			</button>
+		</td>
+		<td class="cell-primary">{{step_key}}<div class="cell-meta">{{name}}</div></td>
+		<td>{{ability_name}}</td>
+		<td>{{output_alias}}</td>
+		<td class="column-actions">
+			<div class="aips-action-buttons">
+				<button type="button" class="aips-btn aips-btn-sm aips-edit-step" data-index="{{index}}" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
+					<span class="dashicons dashicons-edit"></span>
+				</button>
+				<button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-remove-step" data-index="{{index}}" title="<?php esc_attr_e('Remove', 'ai-post-scheduler'); ?>">
+					<span class="dashicons dashicons-trash"></span>
+				</button>
+			</div>
+		</td>
+	</tr>
+</script>
+
+<script type="text/html" id="aips-tmpl-input-map-row">
+	<tr data-row-index="{{row_index}}">
+		<td><input type="text" class="regular-text aips-input-map-field" value="{{field}}"></td>
+		<td><input type="text" class="regular-text aips-input-map-value" value="{{value}}"></td>
+		<td><button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-remove-input-map-row" data-row-index="{{row_index}}">&times;</button></td>
+	</tr>
+</script>
+
+<script type="text/html" id="aips-tmpl-condition-rule-row">
+	<tr data-row-index="{{row_index}}">
+		<td><input type="text" class="regular-text aips-rule-left" value="{{left}}"></td>
+		<td>
+			<select class="aips-form-select aips-rule-operator">
+				<option value="equals">equals</option>
+				<option value="not_equals">not_equals</option>
+				<option value="contains">contains</option>
+				<option value="not_contains">not_contains</option>
+				<option value="greater_than">greater_than</option>
+				<option value="less_than">less_than</option>
+				<option value="is_empty">is_empty</option>
+				<option value="is_not_empty">is_not_empty</option>
+				<option value="in">in</option>
+				<option value="not_in">not_in</option>
+			</select>
+		</td>
+		<td><input type="text" class="regular-text aips-rule-right" value="{{right}}"></td>
+		<td><button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-remove-condition-rule" data-row-index="{{row_index}}">&times;</button></td>
+	</tr>
+</script>
+
+<script type="text/html" id="aips-tmpl-run-row">
+	<tr data-run-id="{{id}}">
+		<td class="cell-primary">#{{id}}</td>
+		<td><span class="aips-badge {{status_badge_class}}">{{status}}</span></td>
+		<td>{{started_display}}</td>
+		<td>{{finished_display}}</td>
+		<td class="column-actions">
+			<button type="button" class="aips-btn aips-btn-sm aips-view-run" data-id="{{id}}" title="<?php esc_attr_e('View details', 'ai-post-scheduler'); ?>">
+				<span class="dashicons dashicons-visibility"></span>
+			</button>
+		</td>
+	</tr>
+</script>
+
+<script type="text/html" id="aips-tmpl-step-run-row">
+	<tr>
+		<td class="cell-primary">{{step_key}}</td>
+		<td>{{ability_name}}</td>
+		<td><span class="aips-badge {{status_badge_class}}">{{status}}</span></td>
+		<td><pre style="white-space:pre-wrap; margin:0;">{{payload}}</pre></td>
+	</tr>
+</script>
+
+<script>
+	window.aipsAbilityWorkflowId = <?php echo (int) $aips_workflow_id; ?>;
+</script>

--- a/ai-post-scheduler/templates/admin/ability-workflows.php
+++ b/ai-post-scheduler/templates/admin/ability-workflows.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * Ability Workflows admin page template.
+ *
+ * Lists existing Ability Workflows. Data is loaded and rendered entirely
+ * via AJAX (AIPS.Templates) so search/filter/create/duplicate/archive/
+ * delete/run actions never require a full page reload.
+ *
+ * @package AI_Post_Scheduler
+ * @since 3.2.0
+ */
+
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+$aips_builder_base_url = admin_url('admin.php?page=aips-ability-workflow-builder');
+?>
+<div class="wrap aips-wrap">
+	<div class="aips-page-container">
+
+		<div class="aips-page-header">
+			<div class="aips-page-header-top">
+				<div>
+					<h1 class="aips-page-title"><?php esc_html_e('Ability Workflows', 'ai-post-scheduler'); ?></h1>
+					<p class="aips-page-description"><?php esc_html_e('Build multi-step automations out of installed WordPress Abilities, AI Engine abilities, and this plugin\'s own capabilities.', 'ai-post-scheduler'); ?></p>
+				</div>
+				<div class="aips-page-actions">
+					<button type="button" class="aips-btn aips-btn-primary" id="aips-add-workflow-btn">
+						<span class="dashicons dashicons-plus-alt2"></span>
+						<?php esc_html_e('Create Workflow', 'ai-post-scheduler'); ?>
+					</button>
+				</div>
+			</div>
+		</div>
+
+		<div class="aips-content-panel">
+			<div class="aips-filter-bar">
+				<div class="aips-filter-right">
+					<label class="screen-reader-text" for="aips-workflow-search"><?php esc_html_e('Search Workflows:', 'ai-post-scheduler'); ?></label>
+					<input type="search" id="aips-workflow-search" class="aips-form-input" placeholder="<?php esc_attr_e('Search workflows…', 'ai-post-scheduler'); ?>">
+					<select id="aips-workflow-status-filter" class="aips-form-select">
+						<option value=""><?php esc_html_e('All statuses', 'ai-post-scheduler'); ?></option>
+						<option value="draft"><?php esc_html_e('Draft', 'ai-post-scheduler'); ?></option>
+						<option value="active"><?php esc_html_e('Active', 'ai-post-scheduler'); ?></option>
+						<option value="paused"><?php esc_html_e('Paused', 'ai-post-scheduler'); ?></option>
+						<option value="archived"><?php esc_html_e('Archived', 'ai-post-scheduler'); ?></option>
+					</select>
+				</div>
+			</div>
+
+			<div class="aips-panel-body no-padding">
+				<table class="aips-table aips-ability-workflows-table" id="aips-ability-workflows-table">
+					<thead>
+						<tr>
+							<th class="column-name"><?php esc_html_e('Name', 'ai-post-scheduler'); ?></th>
+							<th class="column-trigger"><?php esc_html_e('Trigger', 'ai-post-scheduler'); ?></th>
+							<th class="column-status"><?php esc_html_e('Status', 'ai-post-scheduler'); ?></th>
+							<th class="column-updated"><?php esc_html_e('Updated', 'ai-post-scheduler'); ?></th>
+							<th class="column-actions"><?php esc_html_e('Actions', 'ai-post-scheduler'); ?></th>
+						</tr>
+					</thead>
+					<tbody id="aips-ability-workflows-table-body">
+					</tbody>
+				</table>
+			</div>
+
+			<div class="tablenav">
+				<span class="aips-table-footer-count" id="aips-ability-workflows-count"></span>
+			</div>
+
+			<div id="aips-ability-workflows-empty" class="aips-empty-state" style="display:none;">
+				<div class="dashicons dashicons-networking aips-empty-state-icon" aria-hidden="true"></div>
+				<h3 class="aips-empty-state-title"><?php esc_html_e('No Ability Workflows Yet', 'ai-post-scheduler'); ?></h3>
+				<p class="aips-empty-state-description"><?php esc_html_e('Create a workflow to chain Abilities together with input mapping and conditional logic.', 'ai-post-scheduler'); ?></p>
+				<div class="aips-empty-state-actions">
+					<button type="button" class="aips-btn aips-btn-primary" id="aips-add-workflow-empty-btn">
+						<?php esc_html_e('Create Your First Workflow', 'ai-post-scheduler'); ?>
+					</button>
+				</div>
+			</div>
+		</div>
+
+	</div>
+</div>
+
+<!-- Add / Edit Workflow Modal -->
+<div id="aips-workflow-modal" class="aips-modal" style="display:none;" role="dialog" aria-modal="true">
+	<div class="aips-modal-content">
+		<div class="aips-modal-header">
+			<h2 class="aips-modal-title" id="aips-workflow-modal-title"><?php esc_html_e('Create Workflow', 'ai-post-scheduler'); ?></h2>
+			<button type="button" class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
+		</div>
+		<div class="aips-modal-body">
+			<form id="aips-workflow-form" novalidate>
+				<input type="hidden" name="workflow_id" id="aips-workflow-id" value="0">
+
+				<div class="aips-form-row">
+					<label for="aips-workflow-name">
+						<?php esc_html_e('Name', 'ai-post-scheduler'); ?>
+						<span class="required" aria-hidden="true">*</span>
+					</label>
+					<input type="text" id="aips-workflow-name" name="name" required class="regular-text">
+				</div>
+
+				<div class="aips-form-row">
+					<label for="aips-workflow-description"><?php esc_html_e('Description', 'ai-post-scheduler'); ?></label>
+					<textarea id="aips-workflow-description" name="description" rows="3" class="large-text"></textarea>
+				</div>
+
+				<div class="aips-form-row">
+					<label for="aips-workflow-status"><?php esc_html_e('Status', 'ai-post-scheduler'); ?></label>
+					<select id="aips-workflow-status" name="status" class="aips-form-select">
+						<option value="draft"><?php esc_html_e('Draft', 'ai-post-scheduler'); ?></option>
+						<option value="active"><?php esc_html_e('Active', 'ai-post-scheduler'); ?></option>
+						<option value="paused"><?php esc_html_e('Paused', 'ai-post-scheduler'); ?></option>
+						<option value="archived"><?php esc_html_e('Archived', 'ai-post-scheduler'); ?></option>
+					</select>
+				</div>
+
+				<div class="aips-form-row">
+					<label for="aips-workflow-trigger-type"><?php esc_html_e('Trigger', 'ai-post-scheduler'); ?></label>
+					<select id="aips-workflow-trigger-type" name="trigger_type" class="aips-form-select">
+						<option value="manual"><?php esc_html_e('Manual (Run Now)', 'ai-post-scheduler'); ?></option>
+						<option value="scheduled"><?php esc_html_e('Scheduled (coming soon)', 'ai-post-scheduler'); ?></option>
+					</select>
+				</div>
+
+				<div class="aips-form-row">
+					<label for="aips-workflow-max-steps"><?php esc_html_e('Max Steps', 'ai-post-scheduler'); ?></label>
+					<input type="number" id="aips-workflow-max-steps" name="max_steps" min="1" max="100" value="20" class="small-text">
+				</div>
+
+				<div class="aips-form-row">
+					<label for="aips-workflow-max-runtime"><?php esc_html_e('Max Runtime (seconds)', 'ai-post-scheduler'); ?></label>
+					<input type="number" id="aips-workflow-max-runtime" name="max_runtime_seconds" min="1" max="3600" value="120" class="small-text">
+				</div>
+
+				<div class="aips-form-row">
+					<label class="aips-checkbox-label">
+						<input type="checkbox" id="aips-workflow-allow-destructive" name="allow_destructive_abilities" value="1">
+						<?php esc_html_e('Allow destructive abilities', 'ai-post-scheduler'); ?>
+					</label>
+					<p class="description"><?php esc_html_e('When unchecked, steps using an ability flagged as destructive will fail instead of running.', 'ai-post-scheduler'); ?></p>
+				</div>
+
+				<div class="aips-form-row">
+					<label class="aips-checkbox-label">
+						<input type="checkbox" id="aips-workflow-log-payloads" name="log_payloads" value="1" checked>
+						<?php esc_html_e('Log step inputs/outputs for audit history', 'ai-post-scheduler'); ?>
+					</label>
+				</div>
+			</form>
+		</div>
+		<div class="aips-modal-footer">
+			<button type="button" class="aips-btn aips-btn-secondary aips-modal-close"><?php esc_html_e('Cancel', 'ai-post-scheduler'); ?></button>
+			<button type="button" class="aips-btn aips-btn-primary" id="aips-save-workflow-btn">
+				<?php esc_html_e('Save Workflow', 'ai-post-scheduler'); ?>
+			</button>
+		</div>
+	</div>
+</div>
+
+<script type="text/html" id="aips-tmpl-workflow-row">
+	<tr data-workflow-id="{{id}}" data-status="{{status}}">
+		<td class="column-name cell-primary">
+			<a href="{{builder_url}}">{{name}}</a>
+			<div class="cell-meta">{{description}}</div>
+		</td>
+		<td class="column-trigger">{{trigger_type}}</td>
+		<td class="column-status">
+			<span class="aips-badge {{status_badge_class}}">{{status_label}}</span>
+		</td>
+		<td class="column-updated">{{updated_display}}</td>
+		<td class="column-actions">
+			<div class="aips-action-buttons">
+				<a class="aips-btn aips-btn-sm" href="{{builder_url}}" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
+					<span class="dashicons dashicons-edit"></span>
+				</a>
+				<button class="aips-btn aips-btn-sm aips-btn-secondary aips-run-workflow-now" data-id="{{id}}" title="<?php esc_attr_e('Run now', 'ai-post-scheduler'); ?>">
+					<span class="dashicons dashicons-controls-play"></span>
+				</button>
+				<button class="aips-btn aips-btn-sm aips-btn-ghost aips-duplicate-workflow" data-id="{{id}}" title="<?php esc_attr_e('Duplicate', 'ai-post-scheduler'); ?>">
+					<span class="dashicons dashicons-admin-page"></span>
+				</button>
+				<button class="aips-btn aips-btn-sm aips-btn-ghost aips-archive-workflow" data-id="{{id}}" title="<?php esc_attr_e('Archive', 'ai-post-scheduler'); ?>">
+					<span class="dashicons dashicons-archive"></span>
+				</button>
+				<button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-workflow" data-id="{{id}}" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
+					<span class="dashicons dashicons-trash"></span>
+				</button>
+			</div>
+		</td>
+	</tr>
+</script>
+
+<script>
+	window.aipsAbilityWorkflowBuilderBaseUrl = <?php echo wp_json_encode($aips_builder_base_url); ?>;
+</script>

--- a/ai-post-scheduler/tests/Test_AIPS_AI_Service.php
+++ b/ai-post-scheduler/tests/Test_AIPS_AI_Service.php
@@ -19,6 +19,7 @@ class Test_AIPS_AI_Service extends WP_UnitTestCase {
     }
 
     public function tearDown(): void {
+        remove_all_filters('aips_ability_provider');
         parent::tearDown();
     }
 
@@ -748,5 +749,248 @@ class Test_AIPS_AI_Service extends WP_UnitTestCase {
             $mwai = $original_mwai;
             $mwai_core = $original_core;
         }
+    }
+
+    // -------------------------------------------------------------------
+    // Ability-fallback path (generate_with_ability())
+    //
+    // These tests deliberately construct their own AIPS_AI_Service with a
+    // *fresh* AIPS_Ability_Service passed as the 4th constructor arg rather
+    // than relying on $this->service or the DI container:
+    //
+    //  - AIPS_AI_Service::get_ability_service() only accepts an object that
+    //    is `instanceof AIPS_Ability_Service` for its constructor-injected
+    //    4th arg; a duck-typed double would be silently discarded.
+    //  - AIPS_Container's bound AIPS_Ability_Service is a process-wide
+    //    singleton, and AIPS_Ability_Service::get_provider() caches its
+    //    resolved provider on first success and never re-checks the
+    //    aips_ability_provider filter afterward — reusing the container
+    //    singleton across tests would leak one test's fake provider into
+    //    every later test in the same run.
+    //
+    // A fresh, explicitly-passed AIPS_Ability_Service instance per test
+    // avoids both hazards. The aips_ability_provider filter registered by
+    // register_fake_ability_provider() is removed in tearDown() above.
+    // -------------------------------------------------------------------
+
+    /**
+     * Force AIPS_AI_Service::get_ai_engine() to report unavailable without
+     * depending on the implicit absence of global $mwai in the test
+     * bootstrap. Setting the private $ai_engine property to `false` (not
+     * `null`) permanently pins it, since get_ai_engine() only re-fetches
+     * from the global when the cached value is strictly null.
+     *
+     * @param AIPS_AI_Service $service Service instance to pin.
+     * @return void
+     */
+    private function force_ai_engine_unavailable(AIPS_AI_Service $service) {
+        $reflection = new ReflectionClass($service);
+        $prop = $reflection->getProperty('ai_engine');
+        $prop->setAccessible(true);
+        $prop->setValue($service, false);
+    }
+
+    /**
+     * Register a fake ability provider via the aips_ability_provider filter.
+     *
+     * @param callable $list   Callable returning the raw ability list.
+     * @param callable $invoke Callable(slug, payload, options) returning the raw invoke response.
+     * @return void
+     */
+    private function register_fake_ability_provider($list, $invoke) {
+        add_filter('aips_ability_provider', function () use ($list, $invoke) {
+            return array(
+                'name'   => 'test-provider',
+                'list'   => $list,
+                'invoke' => $invoke,
+            );
+        });
+    }
+
+    public function test_generate_text_falls_back_to_ability_when_ai_engine_unavailable() {
+        $this->register_fake_ability_provider(
+            function () {
+                return array('aips_generate_text' => array('slug' => 'aips_generate_text'));
+            },
+            function ($slug, $payload, $options) {
+                return array('content' => 'Generated text');
+            }
+        );
+
+        $service = new AIPS_AI_Service(null, null, null, new AIPS_Ability_Service());
+        $this->force_ai_engine_unavailable($service);
+
+        $result = $service->generate_text('Test prompt');
+
+        $this->assertSame('Generated text', $result);
+    }
+
+    public function test_generate_json_falls_back_to_ability_when_ai_engine_unavailable() {
+        $this->register_fake_ability_provider(
+            function () {
+                return array('aips_generate_json' => array('slug' => 'aips_generate_json'));
+            },
+            function ($slug, $payload, $options) {
+                return array('data' => array('title' => 'Generated title'));
+            }
+        );
+
+        $service = new AIPS_AI_Service(null, null, null, new AIPS_Ability_Service());
+        $this->force_ai_engine_unavailable($service);
+
+        $result = $service->generate_json('Test prompt');
+
+        $this->assertIsArray($result);
+        $this->assertSame('Generated title', $result['title']);
+    }
+
+    public function test_generate_image_falls_back_to_ability_when_ai_engine_unavailable() {
+        $this->register_fake_ability_provider(
+            function () {
+                return array('aips_generate_image' => array('slug' => 'aips_generate_image'));
+            },
+            function ($slug, $payload, $options) {
+                return array('url' => 'https://example.com/image.png');
+            }
+        );
+
+        $service = new AIPS_AI_Service(null, null, null, new AIPS_Ability_Service());
+        $this->force_ai_engine_unavailable($service);
+
+        $result = $service->generate_image('Test image prompt');
+
+        $this->assertSame('https://example.com/image.png', $result);
+    }
+
+    public function test_generate_json_from_text_falls_back_to_ability_when_unavailable() {
+        $this->register_fake_ability_provider(
+            function () {
+                return array('aips_generate_json' => array('slug' => 'aips_generate_json'));
+            },
+            function ($slug, $payload, $options) {
+                return array('data' => array('title' => 'From text fallback'));
+            }
+        );
+
+        $service = new AIPS_AI_Service(null, null, null, new AIPS_Ability_Service());
+        $this->force_ai_engine_unavailable($service);
+
+        $result = $service->generate_json_from_text('Test prompt');
+
+        $this->assertIsArray($result);
+        $this->assertSame('From text fallback', $result['title']);
+    }
+
+    public function test_ai_unavailable_error_includes_ability_error_data() {
+        $this->register_fake_ability_provider(
+            function () {
+                return array('aips_generate_text' => array('slug' => 'aips_generate_text'));
+            },
+            function ($slug, $payload, $options) {
+                return new WP_Error('ability_invocation_failed', 'Ability blew up');
+            }
+        );
+
+        $service = new AIPS_AI_Service(null, null, null, new AIPS_Ability_Service());
+        $this->force_ai_engine_unavailable($service);
+
+        $result = $service->generate_text('Test prompt');
+
+        $this->assertInstanceOf('WP_Error', $result);
+        $this->assertEquals('ai_unavailable', $result->get_error_code());
+
+        $data = $result->get_error_data();
+        $this->assertArrayHasKey('ability_error', $data);
+        $this->assertInstanceOf('WP_Error', $data['ability_error']);
+        $this->assertEquals('ability_invocation_failed', $data['ability_error']->get_error_code());
+    }
+
+    public function test_generate_with_ability_respects_ability_slug_option_override() {
+        $this->register_fake_ability_provider(
+            function () {
+                return array('my_custom_slug' => array('slug' => 'my_custom_slug'));
+            },
+            function ($slug, $payload, $options) {
+                if ('my_custom_slug' !== $slug) {
+                    return new WP_Error('unexpected_slug', 'Wrong slug invoked: ' . $slug);
+                }
+                return array('content' => 'Custom slug content');
+            }
+        );
+
+        $service = new AIPS_AI_Service(null, null, null, new AIPS_Ability_Service());
+        $this->force_ai_engine_unavailable($service);
+
+        $result = $service->generate_text('Test prompt', array('ability_slug' => 'my_custom_slug'));
+
+        $this->assertSame('Custom slug content', $result);
+    }
+
+    public function test_generate_with_ability_skips_unavailable_slug_and_tries_next() {
+        // Only the second candidate slug for 'text' ('generate_text') is advertised;
+        // the first ('aips_generate_text') is absent from the list, so is_available()
+        // should be false for it and generate_with_ability() should move on.
+        $this->register_fake_ability_provider(
+            function () {
+                return array('generate_text' => array('slug' => 'generate_text'));
+            },
+            function ($slug, $payload, $options) {
+                return array('content' => 'Second candidate content');
+            }
+        );
+
+        $service = new AIPS_AI_Service(null, null, null, new AIPS_Ability_Service());
+        $this->force_ai_engine_unavailable($service);
+
+        $result = $service->generate_text('Test prompt');
+
+        $this->assertSame('Second candidate content', $result);
+    }
+
+    /**
+     * Documents current behavior (not a bug fix): generate_with_ability()
+     * stops at the first candidate slug whose is_available() is true and
+     * returns whatever invoke() gives back, even a WP_Error — it does not
+     * fall through to try a later candidate slug for the same type just
+     * because invoke() itself failed. If this should instead try every
+     * available candidate before giving up, that is a behavior change that
+     * belongs on the codex/create-ability-service-adapter branch, not here.
+     */
+    public function test_generate_with_ability_stops_on_first_invoke_error() {
+        $this->register_fake_ability_provider(
+            function () {
+                return array(
+                    'aips_generate_text' => array('slug' => 'aips_generate_text'),
+                    'generate_text'      => array('slug' => 'generate_text'),
+                );
+            },
+            function ($slug, $payload, $options) {
+                // Both candidates are "available", but the first one invoked fails.
+                return new WP_Error('ability_invocation_failed', 'First candidate failed: ' . $slug);
+            }
+        );
+
+        $service = new AIPS_AI_Service(null, null, null, new AIPS_Ability_Service());
+        $this->force_ai_engine_unavailable($service);
+
+        $result = $service->generate_text('Test prompt');
+
+        $this->assertInstanceOf('WP_Error', $result);
+        $data = $result->get_error_data();
+        $this->assertArrayHasKey('ability_error', $data);
+        $this->assertEquals('ability_invocation_failed', $data['ability_error']->get_error_code());
+    }
+
+    public function test_ai_unavailable_when_no_ability_provider_registered() {
+        // No aips_ability_provider filter registered — the existing implicit
+        // "no provider available at all" scenario, now asserted explicitly
+        // rather than incidentally.
+        $service = new AIPS_AI_Service(null, null, null, new AIPS_Ability_Service());
+        $this->force_ai_engine_unavailable($service);
+
+        $result = $service->generate_text('Test prompt');
+
+        $this->assertInstanceOf('WP_Error', $result);
+        $this->assertEquals('ai_unavailable', $result->get_error_code());
     }
 }

--- a/ai-post-scheduler/tests/Test_AIPS_Ability_Workflow_Condition_Evaluator.php
+++ b/ai-post-scheduler/tests/Test_AIPS_Ability_Workflow_Condition_Evaluator.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Tests for AIPS_Ability_Workflow_Condition_Evaluator
+ *
+ * @package AI_Post_Scheduler
+ */
+
+class Test_AIPS_Ability_Workflow_Condition_Evaluator extends WP_UnitTestCase {
+
+	private $evaluator;
+	private $variables;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->evaluator = new AIPS_Ability_Workflow_Condition_Evaluator( new AIPS_Ability_Workflow_Variable_Resolver() );
+
+		$this->variables = array(
+			'trigger' => array( 'topic' => 'AI in gardening' ),
+			'steps'   => array(
+				'outline' => array( 'output' => array( 'sections_count' => 5, 'title' => 'My Outline' ) ),
+			),
+		);
+	}
+
+	public function test_empty_tree_is_always_true() {
+		$this->assertTrue( $this->evaluator->evaluate( array(), $this->variables ) );
+		$this->assertTrue( $this->evaluator->evaluate( array( 'operator' => 'AND', 'rules' => array() ), $this->variables ) );
+	}
+
+	public function test_and_group_requires_all_rules_true() {
+		$tree = array(
+			'operator' => 'AND',
+			'rules'    => array(
+				array( 'left' => '{{steps.outline.output.sections_count}}', 'operator' => 'greater_than', 'right' => 0 ),
+				array( 'left' => '{{trigger.topic}}', 'operator' => 'contains', 'right' => 'gardening' ),
+			),
+		);
+
+		$this->assertTrue( $this->evaluator->evaluate( $tree, $this->variables ) );
+
+		$tree['rules'][0]['right'] = 100;
+		$this->assertFalse( $this->evaluator->evaluate( $tree, $this->variables ) );
+	}
+
+	public function test_or_group_requires_any_rule_true() {
+		$tree = array(
+			'operator' => 'OR',
+			'rules'    => array(
+				array( 'left' => '{{steps.outline.output.sections_count}}', 'operator' => 'greater_than', 'right' => 100 ),
+				array( 'left' => '{{trigger.topic}}', 'operator' => 'contains', 'right' => 'gardening' ),
+			),
+		);
+
+		$this->assertTrue( $this->evaluator->evaluate( $tree, $this->variables ) );
+	}
+
+	public function test_nested_groups_are_evaluated_recursively() {
+		$tree = array(
+			'operator' => 'AND',
+			'rules'    => array(
+				array( 'left' => '{{trigger.topic}}', 'operator' => 'is_not_empty' ),
+				array(
+					'operator' => 'OR',
+					'rules'    => array(
+						array( 'left' => '{{steps.outline.output.sections_count}}', 'operator' => 'equals', 'right' => 999 ),
+						array( 'left' => '{{steps.outline.output.sections_count}}', 'operator' => 'equals', 'right' => 5 ),
+					),
+				),
+			),
+		);
+
+		$this->assertTrue( $this->evaluator->evaluate( $tree, $this->variables ) );
+	}
+
+	public function test_is_empty_and_is_not_empty() {
+		$this->assertTrue( $this->evaluator->evaluate_rule( array( 'left' => '{{missing.token}}', 'operator' => 'is_empty' ), $this->variables ) );
+		$this->assertFalse( $this->evaluator->evaluate_rule( array( 'left' => '{{trigger.topic}}', 'operator' => 'is_empty' ), $this->variables ) );
+		$this->assertTrue( $this->evaluator->evaluate_rule( array( 'left' => '{{trigger.topic}}', 'operator' => 'is_not_empty' ), $this->variables ) );
+	}
+
+	public function test_in_and_not_in_operators() {
+		$rule = array( 'left' => '{{trigger.topic}}', 'operator' => 'in', 'right' => 'AI in gardening,Other Topic' );
+		$this->assertTrue( $this->evaluator->evaluate_rule( $rule, $this->variables ) );
+
+		$rule['operator'] = 'not_in';
+		$this->assertFalse( $this->evaluator->evaluate_rule( $rule, $this->variables ) );
+	}
+
+	public function test_validate_condition_tree_accepts_valid_tree() {
+		$tree = array(
+			'operator' => 'AND',
+			'rules'    => array(
+				array( 'left' => '{{trigger.topic}}', 'operator' => 'is_not_empty' ),
+			),
+		);
+
+		$this->assertTrue( $this->evaluator->validate_condition_tree( $tree ) );
+	}
+
+	public function test_validate_condition_tree_rejects_bad_operator() {
+		$result = $this->evaluator->validate_condition_tree( array( 'operator' => 'XOR', 'rules' => array() ) );
+		$this->assertWPError( $result );
+	}
+
+	public function test_validate_condition_tree_rejects_missing_rule_fields() {
+		$tree = array(
+			'operator' => 'AND',
+			'rules'    => array(
+				array( 'operator' => 'equals' ), // missing 'left'
+			),
+		);
+
+		$this->assertWPError( $this->evaluator->validate_condition_tree( $tree ) );
+	}
+
+	public function test_validate_condition_tree_rejects_invalid_token_reference() {
+		$tree = array(
+			'operator' => 'AND',
+			'rules'    => array(
+				array( 'left' => '{{bogus.path}}', 'operator' => 'is_not_empty' ),
+			),
+		);
+
+		$this->assertWPError( $this->evaluator->validate_condition_tree( $tree ) );
+	}
+}

--- a/ai-post-scheduler/tests/Test_AIPS_Ability_Workflow_Document_Validator.php
+++ b/ai-post-scheduler/tests/Test_AIPS_Ability_Workflow_Document_Validator.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Tests for AIPS_Ability_Workflow_Document_Validator
+ *
+ * @package AI_Post_Scheduler
+ */
+
+class Test_AIPS_Ability_Workflow_Document_Validator extends WP_UnitTestCase {
+
+	private $validator;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$resolver  = new AIPS_Ability_Workflow_Variable_Resolver();
+		$evaluator = new AIPS_Ability_Workflow_Condition_Evaluator( $resolver );
+
+		// No catalog service injected -> ability-availability checks are skipped
+		// unless $skip_ability_check is explicitly false and a catalog is present.
+		$this->validator = new AIPS_Ability_Workflow_Document_Validator( $evaluator, $resolver, null );
+	}
+
+	private function valid_document() {
+		return array(
+			'steps' => array(
+				array(
+					'step_key'     => 'generate_outline',
+					'ability_name' => 'vendor/create-outline',
+					'input_map'    => array( 'topic' => '{{trigger.topic}}' ),
+					'output_alias' => 'outline',
+					'on_success'   => array( 'strategy' => 'continue' ),
+					'on_failure'   => array( 'strategy' => 'stop' ),
+					'retry_policy' => array( 'attempts' => 2, 'backoff_seconds' => 5 ),
+				),
+				array(
+					'step_key'       => 'write_post',
+					'ability_name'   => 'vendor/write-post',
+					'depends_on'     => array( 'generate_outline' ),
+					'input_map'      => array( 'outline' => '{{steps.outline.output}}' ),
+					'condition_tree' => array(
+						'operator' => 'AND',
+						'rules'    => array(
+							array( 'left' => '{{steps.outline.output.sections_count}}', 'operator' => 'greater_than', 'right' => 0 ),
+						),
+					),
+					'output_alias'   => 'post',
+				),
+			),
+		);
+	}
+
+	public function test_valid_document_passes() {
+		$result = $this->validator->validate( $this->valid_document(), true );
+		$this->assertTrue( $result );
+	}
+
+	public function test_duplicate_step_keys_rejected() {
+		$doc = $this->valid_document();
+		$doc['steps'][1]['step_key'] = 'generate_outline';
+
+		$this->assertWPError( $this->validator->validate( $doc, true ) );
+	}
+
+	public function test_missing_ability_name_rejected() {
+		$doc = $this->valid_document();
+		unset( $doc['steps'][0]['ability_name'] );
+
+		$this->assertWPError( $this->validator->validate( $doc, true ) );
+	}
+
+	public function test_forward_reference_in_depends_on_rejected() {
+		$doc = array(
+			'steps' => array(
+				array(
+					'step_key'     => 'write_post',
+					'ability_name' => 'vendor/write-post',
+					'depends_on'   => array( 'generate_outline' ), // does not exist yet
+				),
+			),
+		);
+
+		$this->assertWPError( $this->validator->validate( $doc, true ) );
+	}
+
+	public function test_forward_reference_in_input_map_rejected() {
+		$doc = array(
+			'steps' => array(
+				array(
+					'step_key'     => 'write_post',
+					'ability_name' => 'vendor/write-post',
+					'input_map'    => array( 'outline' => '{{steps.outline.output}}' ), // 'outline' alias not produced yet
+				),
+			),
+		);
+
+		$this->assertWPError( $this->validator->validate( $doc, true ) );
+	}
+
+	public function test_invalid_strategy_rejected() {
+		$doc = $this->valid_document();
+		$doc['steps'][0]['on_success']['strategy'] = 'explode';
+
+		$this->assertWPError( $this->validator->validate( $doc, true ) );
+	}
+
+	public function test_negative_retry_attempts_rejected() {
+		$doc = $this->valid_document();
+		$doc['steps'][0]['retry_policy']['attempts'] = -1;
+
+		$this->assertWPError( $this->validator->validate( $doc, true ) );
+	}
+
+	public function test_invalid_condition_tree_rejected() {
+		$doc = $this->valid_document();
+		$doc['steps'][1]['condition_tree']['operator'] = 'XOR';
+
+		$this->assertWPError( $this->validator->validate( $doc, true ) );
+	}
+}

--- a/ai-post-scheduler/tests/Test_AIPS_Ability_Workflow_Executor.php
+++ b/ai-post-scheduler/tests/Test_AIPS_Ability_Workflow_Executor.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Tests for AIPS_Ability_Workflow_Executor
+ *
+ * Focused regression coverage for a review finding: a workflow run can
+ * span multiple cron invocations (time-budget continuations, retry
+ * backoff), and the 'skip' on_success/on_failure strategy's cascade to
+ * dependent steps must be reconstructible from persisted step statuses on
+ * every invocation — not just accumulated within a single pass — or a
+ * cascade interrupted partway through would be lost, letting a step that
+ * should stay permanently skipped execute on a later invocation.
+ *
+ * @package AI_Post_Scheduler
+ */
+
+class Test_AIPS_Ability_Workflow_Executor extends WP_UnitTestCase {
+
+	private $executor;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->executor = new AIPS_Ability_Workflow_Executor();
+	}
+
+	/**
+	 * Build an AIPS_Ability_Workflow_Step via from_row(), matching the
+	 * JSON-string-per-column shape a real DB row would have.
+	 *
+	 * @param array $overrides Fields to override on top of sane defaults.
+	 * @return AIPS_Ability_Workflow_Step
+	 */
+	private function make_step( array $overrides = array() ): AIPS_Ability_Workflow_Step {
+		$defaults = array(
+			'id'             => 1,
+			'workflow_id'    => 1,
+			'step_key'       => 'step',
+			'name'           => null,
+			'ability_name'   => 'vendor/ability',
+			'position'       => 0,
+			'depends_on'     => '[]',
+			'input_map'      => '{}',
+			'condition_tree' => '{}',
+			'output_alias'   => null,
+			'on_success'     => wp_json_encode( array( 'strategy' => 'continue' ) ),
+			'on_failure'     => wp_json_encode( array( 'strategy' => 'stop' ) ),
+			'retry_policy'   => wp_json_encode( array( 'attempts' => 0, 'backoff_seconds' => 5 ) ),
+			'created_at'     => 0,
+			'updated_at'     => 0,
+		);
+
+		$row = (object) array_merge( $defaults, $overrides );
+
+		return AIPS_Ability_Workflow_Step::from_row( $row );
+	}
+
+	/**
+	 * Invoke the private rebuild_skip_cascade() method directly.
+	 *
+	 * @param array $steps
+	 * @param array $resolved_status
+	 * @return array
+	 */
+	private function invoke_rebuild_skip_cascade( array $steps, array $resolved_status ): array {
+		$reflection = new ReflectionClass( $this->executor );
+		$method = $reflection->getMethod( 'rebuild_skip_cascade' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $this->executor, $steps, $resolved_status );
+	}
+
+	public function test_skip_cascade_reconstructed_from_persisted_completed_status() {
+		$ancestor = $this->make_step( array(
+			'step_key'   => 'ancestor',
+			'on_success' => wp_json_encode( array( 'strategy' => 'skip' ) ),
+		) );
+
+		$dependent = $this->make_step( array(
+			'step_key'   => 'dependent',
+			'depends_on' => wp_json_encode( array( 'ancestor' ) ),
+		) );
+
+		$grandchild = $this->make_step( array(
+			'step_key'   => 'grandchild',
+			'depends_on' => wp_json_encode( array( 'dependent' ) ),
+		) );
+
+		$steps = array( $ancestor, $dependent, $grandchild );
+
+		// Simulate a fresh invocation where only the ancestor's outcome has
+		// been persisted so far — e.g. the previous invocation hit its time
+		// budget deadline immediately after completing 'ancestor', before
+		// the in-memory-only $skip_keys accumulator (the pre-fix behavior)
+		// could reach 'dependent'/'grandchild' in the same pass.
+		$resolved_status = array( 'ancestor' => 'completed' );
+
+		$skip_keys = $this->invoke_rebuild_skip_cascade( $steps, $resolved_status );
+
+		$this->assertArrayHasKey( 'dependent', $skip_keys, 'Direct dependent of a skip-strategy ancestor must be reconstructed into the skip set.' );
+		$this->assertArrayHasKey( 'grandchild', $skip_keys, 'Transitive dependent must also be reconstructed into the skip set.' );
+	}
+
+	public function test_skip_cascade_reconstructed_from_persisted_failed_status() {
+		$ancestor = $this->make_step( array(
+			'step_key'   => 'ancestor',
+			'on_failure' => wp_json_encode( array( 'strategy' => 'skip' ) ),
+		) );
+
+		$dependent = $this->make_step( array(
+			'step_key'   => 'dependent',
+			'depends_on' => wp_json_encode( array( 'ancestor' ) ),
+		) );
+
+		$steps = array( $ancestor, $dependent );
+		$resolved_status = array( 'ancestor' => 'failed' );
+
+		$skip_keys = $this->invoke_rebuild_skip_cascade( $steps, $resolved_status );
+
+		$this->assertArrayHasKey( 'dependent', $skip_keys );
+	}
+
+	public function test_no_cascade_when_strategy_is_continue() {
+		$ancestor  = $this->make_step( array( 'step_key' => 'ancestor' ) ); // default on_success.strategy = 'continue'
+		$dependent = $this->make_step( array(
+			'step_key'   => 'dependent',
+			'depends_on' => wp_json_encode( array( 'ancestor' ) ),
+		) );
+
+		$steps = array( $ancestor, $dependent );
+		$resolved_status = array( 'ancestor' => 'completed' );
+
+		$skip_keys = $this->invoke_rebuild_skip_cascade( $steps, $resolved_status );
+
+		$this->assertArrayNotHasKey( 'dependent', $skip_keys );
+	}
+
+	public function test_no_cascade_for_unresolved_ancestor() {
+		$ancestor = $this->make_step( array(
+			'step_key'   => 'ancestor',
+			'on_success' => wp_json_encode( array( 'strategy' => 'skip' ) ),
+		) );
+
+		$dependent = $this->make_step( array(
+			'step_key'   => 'dependent',
+			'depends_on' => wp_json_encode( array( 'ancestor' ) ),
+		) );
+
+		$steps = array( $ancestor, $dependent );
+		$resolved_status = array(); // ancestor not yet resolved this run
+
+		$skip_keys = $this->invoke_rebuild_skip_cascade( $steps, $resolved_status );
+
+		$this->assertSame( array(), $skip_keys );
+	}
+}

--- a/ai-post-scheduler/tests/Test_AIPS_Ability_Workflow_Executor.php
+++ b/ai-post-scheduler/tests/Test_AIPS_Ability_Workflow_Executor.php
@@ -16,10 +16,23 @@
 class Test_AIPS_Ability_Workflow_Executor extends WP_UnitTestCase {
 
 	private $executor;
+	private $created_workflow_ids = array();
 
 	public function setUp(): void {
 		parent::setUp();
 		$this->executor = new AIPS_Ability_Workflow_Executor();
+	}
+
+	public function tearDown(): void {
+		$repository = AIPS_Ability_Workflow_Repository::instance();
+
+		foreach ( $this->created_workflow_ids as $workflow_id ) {
+			$repository->delete_workflow( $workflow_id );
+		}
+
+		$this->created_workflow_ids = array();
+
+		parent::tearDown();
 	}
 
 	/**
@@ -150,5 +163,33 @@ class Test_AIPS_Ability_Workflow_Executor extends WP_UnitTestCase {
 		$skip_keys = $this->invoke_rebuild_skip_cascade( $steps, $resolved_status );
 
 		$this->assertSame( array(), $skip_keys );
+	}
+
+	/**
+	 * Finding: schedule_continuation()'s underlying schedule_simple() return
+	 * value was previously discarded — a scheduling failure left a run
+	 * stuck at 'running'/'queued' forever. dispatch_run() must now mark the
+	 * just-created run row 'failed' instead of leaving it orphaned.
+	 */
+	public function test_dispatch_run_marks_run_failed_when_scheduling_fails() {
+		$repository = AIPS_Ability_Workflow_Repository::instance();
+		$workflow_id = $repository->create_workflow( array( 'name' => 'Test Scheduling Failure Workflow' ) );
+		$this->created_workflow_ids[] = $workflow_id;
+
+		$failing_scheduler = new class extends AIPS_Job_Scheduler {
+			public function schedule_simple( string $hook, int $fire_at, array $args = array(), array $options = array() ): bool {
+				return false;
+			}
+		};
+
+		$executor = new AIPS_Ability_Workflow_Executor( null, null, null, null, null, $failing_scheduler );
+
+		$result = $executor->dispatch_run( $workflow_id );
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+
+		$runs = $repository->list_runs( $workflow_id );
+		$this->assertCount( 1, $runs['items'] );
+		$this->assertSame( AIPS_Ability_Workflow_Repository::RUN_STATUS_FAILED, $runs['items'][0]->status );
 	}
 }

--- a/ai-post-scheduler/tests/Test_AIPS_Ability_Workflow_Repository.php
+++ b/ai-post-scheduler/tests/Test_AIPS_Ability_Workflow_Repository.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Tests for AIPS_Ability_Workflow_Repository
+ *
+ * Focused regression coverage for a review finding: list_runs() did not
+ * treat per_page <= 0 as "no limit" the way list_workflows() does, so
+ * LIMIT 0 silently returned zero rows instead of every run.
+ *
+ * @package AI_Post_Scheduler
+ */
+
+class Test_AIPS_Ability_Workflow_Repository extends WP_UnitTestCase {
+
+	private $repository;
+	private $created_workflow_ids = array();
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->repository = AIPS_Ability_Workflow_Repository::instance();
+	}
+
+	public function tearDown(): void {
+		foreach ( $this->created_workflow_ids as $workflow_id ) {
+			$this->repository->delete_workflow( $workflow_id );
+		}
+
+		$this->created_workflow_ids = array();
+
+		parent::tearDown();
+	}
+
+	public function test_list_runs_with_per_page_zero_returns_all_runs() {
+		$workflow_id = $this->repository->create_workflow( array( 'name' => 'Test List Runs Workflow' ) );
+		$this->created_workflow_ids[] = $workflow_id;
+
+		for ( $i = 0; $i < 3; $i++ ) {
+			$this->repository->create_run( $workflow_id, 1, array() );
+		}
+
+		$result = $this->repository->list_runs( $workflow_id, array( 'per_page' => 0 ) );
+
+		$this->assertSame( 3, $result['total'] );
+		$this->assertCount( 3, $result['items'], 'per_page=0 must mean "no limit", not zero rows.' );
+	}
+
+	public function test_list_runs_respects_positive_per_page() {
+		$workflow_id = $this->repository->create_workflow( array( 'name' => 'Test List Runs Paginated Workflow' ) );
+		$this->created_workflow_ids[] = $workflow_id;
+
+		for ( $i = 0; $i < 3; $i++ ) {
+			$this->repository->create_run( $workflow_id, 1, array() );
+		}
+
+		$result = $this->repository->list_runs( $workflow_id, array( 'per_page' => 2, 'page' => 1 ) );
+
+		$this->assertSame( 3, $result['total'] );
+		$this->assertCount( 2, $result['items'] );
+	}
+}

--- a/ai-post-scheduler/tests/Test_AIPS_Ability_Workflow_Runs_Controller.php
+++ b/ai-post-scheduler/tests/Test_AIPS_Ability_Workflow_Runs_Controller.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Tests for AIPS_Ability_Workflow_Runs_Controller
+ *
+ * Focused regression coverage for a review finding: ajax_cancel_run()
+ * reported success even for a nonexistent run_id, since
+ * AIPS_Ability_Workflow_Repository::update_run_status() returns true
+ * whenever $wpdb->update() doesn't return false — including when it
+ * matched zero rows.
+ *
+ * @package AI_Post_Scheduler
+ */
+
+class Test_AIPS_Ability_Workflow_Runs_Controller extends WP_UnitTestCase {
+
+	private $admin_user_id;
+	private $repository;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->admin_user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $this->admin_user_id );
+
+		$_REQUEST['nonce'] = wp_create_nonce( 'aips_ajax_nonce' );
+
+		$this->repository = AIPS_Ability_Workflow_Repository::instance();
+	}
+
+	public function tearDown(): void {
+		$_POST    = array();
+		$_REQUEST = array();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Capture JSON output produced by a controller AJAX method.
+	 *
+	 * @param callable $callable Controller method to invoke.
+	 * @return array Decoded response array.
+	 */
+	private function capture_ajax( callable $callable ) {
+		if ( isset( $_POST['nonce'] ) ) {
+			$_REQUEST['nonce'] = $_POST['nonce'];
+		}
+
+		ob_start();
+
+		try {
+			$callable();
+		} catch ( WPAjaxDieContinueException $e ) {
+			// Expected after wp_send_json_*.
+		} catch ( WPAjaxDieStopException $e ) {
+			// Expected in full WordPress mode when no buffered output exists yet.
+		}
+
+		return json_decode( strtok( trim( ob_get_clean() ), "\r\n" ), true );
+	}
+
+	public function test_cancel_run_returns_not_found_for_nonexistent_run() {
+		$controller = new AIPS_Ability_Workflow_Runs_Controller();
+
+		$_POST = array(
+			'nonce'  => wp_create_nonce( 'aips_ajax_nonce' ),
+			'run_id' => 999999,
+		);
+
+		$response = $this->capture_ajax( array( $controller, 'ajax_cancel_run' ) );
+
+		$this->assertFalse( $response['success'], 'Canceling a nonexistent run_id must not report success.' );
+	}
+
+	public function test_cancel_run_succeeds_for_existing_run() {
+		$workflow_id = $this->repository->create_workflow( array( 'name' => 'Test Cancel Run Workflow' ) );
+		$run_id      = $this->repository->create_run( $workflow_id, 1, array() );
+
+		$controller = new AIPS_Ability_Workflow_Runs_Controller();
+
+		$_POST = array(
+			'nonce'  => wp_create_nonce( 'aips_ajax_nonce' ),
+			'run_id' => $run_id,
+		);
+
+		$response = $this->capture_ajax( array( $controller, 'ajax_cancel_run' ) );
+
+		$this->assertTrue( $response['success'] );
+
+		$run = $this->repository->get_run( $run_id );
+		$this->assertSame( AIPS_Ability_Workflow_Repository::RUN_STATUS_CANCELLED, $run->status );
+
+		$this->repository->delete_workflow( $workflow_id );
+	}
+}

--- a/ai-post-scheduler/tests/Test_AIPS_Ability_Workflow_Variable_Resolver.php
+++ b/ai-post-scheduler/tests/Test_AIPS_Ability_Workflow_Variable_Resolver.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Tests for AIPS_Ability_Workflow_Variable_Resolver
+ *
+ * @package AI_Post_Scheduler
+ */
+
+class Test_AIPS_Ability_Workflow_Variable_Resolver extends WP_UnitTestCase {
+
+	private $resolver;
+	private $variables;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->resolver = new AIPS_Ability_Workflow_Variable_Resolver();
+
+		$this->variables = array(
+			'trigger' => array( 'topic' => 'AI in gardening' ),
+			'steps'   => array(
+				'outline' => array( 'output' => array( 'sections_count' => 5, 'title' => 'My Outline' ) ),
+			),
+		);
+	}
+
+	public function test_resolve_whole_token_returns_typed_value() {
+		$this->assertSame( 'AI in gardening', $this->resolver->resolve( '{{trigger.topic}}', $this->variables ) );
+		$this->assertSame( 5, $this->resolver->resolve( '{{steps.outline.output.sections_count}}', $this->variables ) );
+	}
+
+	public function test_resolve_embedded_token_interpolates_as_string() {
+		$this->assertSame( 'Topic: AI in gardening', $this->resolver->resolve( 'Topic: {{trigger.topic}}', $this->variables ) );
+	}
+
+	public function test_resolve_missing_token_returns_null_for_whole_match() {
+		$this->assertNull( $this->resolver->resolve( '{{missing.token}}', $this->variables ) );
+	}
+
+	public function test_resolve_missing_token_becomes_empty_string_when_embedded() {
+		$this->assertSame( 'Value: ', $this->resolver->resolve( 'Value: {{missing.token}}', $this->variables ) );
+	}
+
+	public function test_resolve_plain_string_passes_through() {
+		$this->assertSame( 'no tokens here', $this->resolver->resolve( 'no tokens here', $this->variables ) );
+	}
+
+	public function test_resolve_map_recurses_through_nested_arrays() {
+		$map = array(
+			'topic'   => '{{trigger.topic}}',
+			'nested'  => array(
+				'count' => '{{steps.outline.output.sections_count}}',
+			),
+			'literal' => 'static value',
+		);
+
+		$resolved = $this->resolver->resolve_map( $map, $this->variables );
+
+		$this->assertSame( 'AI in gardening', $resolved['topic'] );
+		$this->assertSame( 5, $resolved['nested']['count'] );
+		$this->assertSame( 'static value', $resolved['literal'] );
+	}
+
+	public function test_extract_tokens_finds_all_tokens() {
+		$tokens = $this->resolver->extract_tokens( '{{trigger.topic}} and {{steps.outline.output.title}}' );
+
+		$this->assertSame( array( 'trigger.topic', 'steps.outline.output.title' ), $tokens );
+	}
+
+	public function test_validate_token_accepts_trigger_and_steps_paths() {
+		$this->assertTrue( $this->resolver->validate_token( 'trigger' ) );
+		$this->assertTrue( $this->resolver->validate_token( 'trigger.topic' ) );
+		$this->assertTrue( $this->resolver->validate_token( 'steps.outline.output.sections_count' ) );
+	}
+
+	public function test_validate_token_rejects_unknown_root() {
+		$this->assertWPError( $this->resolver->validate_token( 'bogus.path' ) );
+		$this->assertWPError( $this->resolver->validate_token( 'steps.outline.sections_count' ) ); // missing .output
+	}
+}

--- a/ai-post-scheduler/tests/Test_AIPS_Ability_Workflows_Controller.php
+++ b/ai-post-scheduler/tests/Test_AIPS_Ability_Workflows_Controller.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Tests for AIPS_Ability_Workflows_Controller
+ *
+ * Regression coverage for two review findings on the Ability Workflows
+ * feature: the document validator must actually be wired with a catalog
+ * service (otherwise ability-existence checks silently never run), and
+ * malformed JSON in the steps payload must not silently wipe an existing
+ * workflow's steps.
+ *
+ * @package AI_Post_Scheduler
+ */
+
+class Test_AIPS_Ability_Workflows_Controller extends WP_UnitTestCase {
+
+	private $admin_user_id;
+	private $repository;
+	private $workflow_id;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->admin_user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $this->admin_user_id );
+
+		$_REQUEST['nonce'] = wp_create_nonce( 'aips_ajax_nonce' );
+
+		$this->repository  = AIPS_Ability_Workflow_Repository::instance();
+		$this->workflow_id = $this->repository->create_workflow( array( 'name' => 'Test Workflow' ) );
+	}
+
+	public function tearDown(): void {
+		if ( $this->workflow_id && ! is_wp_error( $this->workflow_id ) ) {
+			$this->repository->delete_workflow( $this->workflow_id );
+		}
+
+		remove_all_filters( 'aips_ability_provider' );
+
+		$_POST    = array();
+		$_REQUEST = array();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Capture JSON output produced by a controller AJAX method.
+	 *
+	 * @param callable $callable Controller method to invoke.
+	 * @return array Decoded response array.
+	 */
+	private function capture_ajax( callable $callable ) {
+		if ( isset( $_POST['nonce'] ) ) {
+			$_REQUEST['nonce'] = $_POST['nonce'];
+		}
+
+		ob_start();
+
+		try {
+			$callable();
+		} catch ( WPAjaxDieContinueException $e ) {
+			// Expected after wp_send_json_*.
+		} catch ( WPAjaxDieStopException $e ) {
+			// Expected in full WordPress mode when no buffered output exists yet.
+		}
+
+		return json_decode( strtok( trim( ob_get_clean() ), "\r\n" ), true );
+	}
+
+	/**
+	 * Finding: the controller previously constructed
+	 * AIPS_Ability_Workflow_Document_Validator with no catalog service, so
+	 * ability-existence validation silently never ran. With no
+	 * aips_ability_provider filter registered, the catalog reports every
+	 * ability name as unavailable — saving a step should now be rejected.
+	 */
+	public function test_save_workflow_steps_rejects_nonexistent_ability() {
+		$controller = new AIPS_Ability_Workflows_Controller();
+
+		$steps = array(
+			array(
+				'step_key'     => 'first_step',
+				'ability_name' => 'vendor/does-not-exist',
+			),
+		);
+
+		$_POST = array(
+			'nonce'       => wp_create_nonce( 'aips_ajax_nonce' ),
+			'workflow_id' => $this->workflow_id,
+			'steps'       => wp_json_encode( $steps ),
+		);
+
+		$response = $this->capture_ajax( array( $controller, 'ajax_save_workflow_steps' ) );
+
+		$this->assertFalse( $response['success'], 'Expected save to be rejected for a nonexistent ability_name.' );
+
+		$saved_steps = $this->repository->get_steps( $this->workflow_id );
+		$this->assertCount( 0, $saved_steps, 'No step should have been persisted.' );
+	}
+
+	/**
+	 * Finding: malformed JSON in the steps payload decoded to an empty
+	 * array and passed validation trivially, silently wiping any existing
+	 * steps via save_steps(). Seed one valid step first, then attempt to
+	 * save with malformed JSON and confirm the existing step survives.
+	 */
+	public function test_save_workflow_steps_rejects_malformed_json_without_wiping_existing_steps() {
+		add_filter( 'aips_ability_provider', function () {
+			return array(
+				'name'   => 'test-provider',
+				'list'   => function () {
+					return array( 'vendor/real-ability' => array( 'slug' => 'vendor/real-ability' ) );
+				},
+				'invoke' => function () {
+					return array( 'content' => 'ok' );
+				},
+			);
+		} );
+
+		$controller = new AIPS_Ability_Workflows_Controller();
+
+		// Seed one valid, persisted step.
+		$_POST = array(
+			'nonce'       => wp_create_nonce( 'aips_ajax_nonce' ),
+			'workflow_id' => $this->workflow_id,
+			'steps'       => wp_json_encode( array(
+				array( 'step_key' => 'seed_step', 'ability_name' => 'vendor/real-ability' ),
+			) ),
+		);
+		$seed_response = $this->capture_ajax( array( $controller, 'ajax_save_workflow_steps' ) );
+		$this->assertTrue( $seed_response['success'], 'Seed save should succeed.' );
+		$this->assertCount( 1, $this->repository->get_steps( $this->workflow_id ) );
+
+		// Now attempt to save with a malformed (non-empty, invalid) JSON payload.
+		$_POST = array(
+			'nonce'       => wp_create_nonce( 'aips_ajax_nonce' ),
+			'workflow_id' => $this->workflow_id,
+			'steps'       => '{not valid json',
+		);
+		$bad_response = $this->capture_ajax( array( $controller, 'ajax_save_workflow_steps' ) );
+
+		$this->assertFalse( $bad_response['success'], 'Malformed JSON payload should be rejected.' );
+
+		$steps_after = $this->repository->get_steps( $this->workflow_id );
+		$this->assertCount( 1, $steps_after, 'The previously-saved step must survive a malformed-JSON save attempt.' );
+		$this->assertSame( 'seed_step', $steps_after[0]->step_key );
+	}
+}

--- a/docs/AI_AGENT_REFERENCE.md
+++ b/docs/AI_AGENT_REFERENCE.md
@@ -32,7 +32,7 @@ Detailed context for AI agents working on AI Post Scheduler. [AGENTS.md](../AGEN
 - Settings are split across `AIPS_Settings`, `AIPS_Settings_UI`, and `AIPS_Settings_Ajax`.
 - Dashboard is rendered by `AIPS_Dashboard_Controller`.
 - System status uses `AIPS_System_Status_Controller`, `AIPS_System_Diagnostics_Service`, and providers in `includes/diagnostics/`.
-- Hidden pages include `aips-author-topics`, `aips-campaign-wizard`, and `aips-campaign-detail`.
+- Hidden pages include `aips-author-topics`, `aips-campaign-wizard`, `aips-campaign-detail`, and `aips-ability-workflow-builder` (feature-flagged behind `aips_enable_ability_workflows`).
 
 ## Data and schema
 

--- a/docs/AI_AGENT_REFERENCE.md
+++ b/docs/AI_AGENT_REFERENCE.md
@@ -24,6 +24,7 @@ Detailed context for AI agents working on AI Post Scheduler. [AGENTS.md](../AGEN
 - Internal links: `AIPS_Internal_Links_Controller`, services/repository, and the `aips_index_posts_batch` cron.
 - Notifications: registry, senders, templates, event handler, plus `AIPS_Notifications_Repository`.
 - Campaigns, post slices, AI assistance, operations insights, telemetry, taxonomy, onboarding, and diagnostics each have dedicated controllers, repositories, and services.
+- Ability Workflows: `AIPS_Ability_Service` (runtime provider adapter), `AIPS_Ability_Catalog_Service`, `AIPS_Ability_Workflow_Repository`, `AIPS_Ability_Workflow_Executor`, `AIPS_Ability_Workflow_Condition_Evaluator`, `AIPS_Ability_Workflow_Variable_Resolver`, `AIPS_Ability_Workflow_Document_Validator`, `AIPS_Ability_Workflows_Controller`, `AIPS_Ability_Workflow_Runs_Controller`, `AIPS_Ability_Catalog_Controller`.
 
 ## Admin/UI reference
 
@@ -38,7 +39,7 @@ Detailed context for AI agents working on AI Post Scheduler. [AGENTS.md](../AGEN
 - Schema changes go through `AIPS_DB_Manager::get_schema()` and `AIPS_DB_Manager::install_tables()` using `dbDelta`.
 - `AIPS_DB_Migrations::check_and_run()` is the migration entry point; `class-aips-upgrades.php` is a compatibility alias.
 - There is no standalone migrations directory.
-- Plugin tables include history/logs, templates, schedules, voices, structures, prompt sections, trending topics, authors/topics/logs/feedback, campaigns, post slices, notifications, sources/data/groups, taxonomy, embeddings, internal links, cache, telemetry, AI assistance, and bulk batch jobs.
+- Plugin tables include history/logs, templates, schedules, voices, structures, prompt sections, trending topics, authors/topics/logs/feedback, campaigns, post slices, notifications, sources/data/groups, taxonomy, embeddings, internal links, cache, telemetry, AI assistance, bulk batch jobs, and Ability Workflows (workflows/steps/runs/step runs).
 
 ## Cron hooks
 
@@ -53,6 +54,7 @@ Recurring hooks:
 - `aips_fetch_sources`
 - `aips_cleanup_bulk_batch_jobs`
 - `aips_cache_monitor_maintenance`
+- `aips_dispatch_scheduled_ability_workflows`
 
 Single-event hooks:
 
@@ -64,3 +66,4 @@ Single-event hooks:
 - `aips_process_bulk_batch`
 - `aips_process_author_embeddings`
 - `aips_index_posts_batch`
+- `aips_run_ability_workflow`

--- a/docs/MIGRATIONS.md
+++ b/docs/MIGRATIONS.md
@@ -67,6 +67,10 @@ Current tables managed by the plugin:
 - `aips_article_structures` - Article structure definitions
 - `aips_prompt_sections` - Reusable prompt sections
 - `aips_trending_topics` - Trending topic research
+- `aips_ability_workflows` - Ability Workflow definitions
+- `aips_ability_workflow_steps` - Ability Workflow step definitions
+- `aips_ability_workflow_runs` - Ability Workflow execution runs
+- `aips_ability_workflow_step_runs` - Per-step results for an Ability Workflow run
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- Implements the **Ability Workflows** feature: admins can build multi-step automations out of installed WordPress Abilities, Meow AI Engine abilities, and this plugin's own capabilities — browsing available Abilities, chaining them as workflow steps, mapping outputs from earlier steps into later inputs, defining AND/OR conditional logic, running workflows manually (with a scheduled-trigger follow-up left as future work), and viewing per-step run history/errors.
- Builds entirely on top of `AIPS_Ability_Service` from this branch's parent (`codex/create-ability-service-adapter`) — no provider-discovery logic is duplicated.
- Delivered as 10 sequential, independently-reviewable commits (DB → models → repository → catalog service → pure logic → execution engine → AJAX → admin menu/settings → builder UI → tests/docs), matching this repo's DB → service → AJAX → UI → tests slicing convention.

### What's included
1. **Schema** — 4 new tables (`aips_ability_workflows`, `_steps`, `_runs`, `_step_runs`) via `AIPS_DB_Manager::get_schema()`, `AIPS_VERSION` bumped to 3.2.0.
2. **Models** — `AIPS_Ability_Workflow(_Step/_Run/_Step_Run)` immutable DTOs.
3. **Repository** — `AIPS_Ability_Workflow_Repository`: workflow CRUD, step replace-all/reorder, run/step-run create + terminal-status-guarded transitions.
4. **Catalog service** — `AIPS_Ability_Catalog_Service` wraps `AIPS_Ability_Service` and normalizes ability metadata (label, category, schemas, `is_destructive`, `is_available`) for the UI/executor.
5. **Pure logic** — `AIPS_Ability_Workflow_Condition_Evaluator` (nested AND/OR trees), `AIPS_Ability_Workflow_Variable_Resolver` (`{{trigger.x}}` / `{{steps.alias.output.field}}` tokens), `AIPS_Ability_Workflow_Document_Validator` (pre-save structural validation).
6. **Execution engine** — `AIPS_Ability_Workflow_Executor` runs steps in dependency order, evaluates conditions, enforces `max_steps`/`max_runtime_seconds`/`allow_destructive_abilities`, retries failed steps with backoff, and self-reschedules via a dedicated `aips_run_ability_workflow` single-event cron hook (deliberately **not** modeled as an `AIPS_Bulk_Batch_Processor` job type, since steps run in dependency order rather than as a flat, order-independent item list — see commit message on Slice 6 for the reasoning). `on_success`/`on_failure` support `continue`/`stop`/`skip` strategies.
7. **AJAX** — `AIPS_Ability_Workflows_Controller`, `AIPS_Ability_Workflow_Runs_Controller`, `AIPS_Ability_Catalog_Controller`, all actions registered in `AIPS_Ajax_Registry`.
8. **Settings/menu** — `aips_enable_ability_workflows` flag (3-step settings pattern), gated top-level "Ability Workflows" menu item + hidden builder page.
9. **Builder UI** — workflow list (search/filter/CRUD/run-now) and a per-workflow Steps/Runs builder (step editor with ability picker, input mapping, condition-rule builder, retry policy; run history with per-step input/output/error detail).
10. **Tests** — PHPUnit coverage for the three DB-free pure-logic classes.

### Deferred / follow-up
- **Scheduled triggers** (`trigger_type = 'scheduled'`) — the document format and DB columns already support it; the dispatcher (`AIPS_Ability_Workflow_Scheduler` + recurring cron hook) is intentionally left for a follow-up since manual "Run Now" is the MVP-critical path.
- **Repository/executor/controller integration tests** — need the WP PHPUnit test harness (DB + WP-Cron), which isn't provisioned in this environment; only the DB/cron-free pure-logic classes have coverage here.
- The step-modal's condition-rule builder only edits flat (non-nested) rule lists; nested AND/OR groups are supported by the data model and executor but not yet by the UI.

## Verification
- [x] `php -l` across every changed/added PHP file
- [x] `composer lint:repository-boundary` passes (no direct `$wpdb` access outside repositories)
- [x] Manual smoke test of the condition evaluator / variable resolver / document validator against representative workflow documents (AND/OR, nested groups, forward-reference rejection, duplicate-key rejection)
- [x] `node --check` on both new JS files
- [ ] `composer test` — not run; this environment has no WP PHPUnit test harness provisioned (no DB, no `wordpress-tests-lib`). Flagging per the project's testing policy rather than fabricating a result.
- [ ] Manual browser verification of the admin UI — not performed in this environment (no running WP install). The Steps/Runs builder pages should be exercised end-to-end (create workflow → add 2 steps with input mapping/conditions → save → Run Now → confirm Runs tab shows per-step results) before merge.
- [ ] Documentation updated — `docs/MIGRATIONS.md` and `docs/AI_AGENT_REFERENCE.md` updated for the new tables/subsystem/cron hooks.

## Risk Checklist
- [x] Label `schema-change` — 4 new tables added.
- [x] Label `admin-ui` + `needs-browser-test` — new admin menu pages/JS.
- [x] Label `ajax-registry` — 12 new actions registered.
- [x] Label `cron` — new `aips_run_ability_workflow` single-event hook with self-rescheduling continuation/retry logic.
- [ ] Label `generation-pipeline` — not applicable; this feature invokes abilities via `AIPS_Ability_Service`, not the existing generation pipeline.
- [x] Label `security-sensitive` — every new AJAX handler follows the nonce → `manage_options` capability → sanitize pattern; flagging for review since it's a new capability-invocation surface (destructive-ability gating via `allow_destructive_abilities`).
- [ ] Duplicate-risk — none known; this is the only Ability Workflows implementation in the codebase.

---
Note: this PR targets `codex/create-ability-service-adapter` (not `main`) since it depends on `AIPS_Ability_Service`, which lives there and hasn't merged yet.


---
_Generated by [Claude Code](https://claude.ai/code/session_016fNpZ2BAcvR73pBn7pdwRo)_