### PR TITLE
Refactor main plugin file into thin bootstrap + extracted helpers

### DIFF
--- a/ai-post-scheduler/ai-post-scheduler.php
+++ b/ai-post-scheduler/ai-post-scheduler.php
@@ -24,24 +24,6 @@ if (!defined('AIPS_REQUEST_START')) {
     define('AIPS_REQUEST_START', microtime(true));
 }
 
-// Enable SAVEQUERIES as early as possible for telemetry-enabled requests so
-// slow/duplicate query analysis can inspect the collected query log.
-if (!defined('SAVEQUERIES') && function_exists('get_option') && get_option('aips_enable_telemetry', false)) {
-    define('SAVEQUERIES', true);
-}
-
-if (!defined('AIPS_TELEMETRY_SLOW_QUERY_MS')) {
-    define('AIPS_TELEMETRY_SLOW_QUERY_MS', 100);
-}
-
-if (!defined('AIPS_TELEMETRY_SLOW_REQUEST_MS')) {
-    define('AIPS_TELEMETRY_SLOW_REQUEST_MS', 1500);
-}
-
-if (!defined('AIPS_TELEMETRY_QUERY_SAMPLE_LIMIT')) {
-    define('AIPS_TELEMETRY_QUERY_SAMPLE_LIMIT', 10);
-}
-
 // Define plugin constants
 if (!defined('AIPS_VERSION')) {
     define('AIPS_VERSION', '3.1.0');
@@ -59,20 +41,10 @@ if (!defined('AIPS_PLUGIN_BASENAME')) {
     define('AIPS_PLUGIN_BASENAME', plugin_basename(__FILE__));
 }
 
-// Prompt-preview logging can expose generated content in logs. Off by default;
-// opt-in by defining the constant to true earlier (e.g. in wp-config.php), or
-// it will automatically enable when WP_DEBUG is true.
-if (!defined('AIPS_AI_DEBUG_LOG_PROMPTS')) {
-    define('AIPS_AI_DEBUG_LOG_PROMPTS', defined('WP_DEBUG') && WP_DEBUG);
-}
-
-if (!defined('AIPS_DEBUG')) {
-    define('AIPS_DEBUG', defined('WP_DEBUG') && WP_DEBUG);
-}
-
-if (!defined('AIPS_DEBUG_LEVEL')) {
-    define('AIPS_DEBUG_LEVEL', defined('WP_DEBUG') && WP_DEBUG ? 1 : 0);
-}
+// Configurable debug/telemetry constants (SAVEQUERIES, telemetry thresholds,
+// debug flags) live in their own file so this bootstrap stays focused on
+// WordPress-identity constants and request wiring.
+require_once AIPS_PLUGIN_DIR . 'includes/config.php';
 
 final class AI_Post_Scheduler {
     
@@ -349,79 +321,13 @@ final class AI_Post_Scheduler {
     /**
      * Register initial container bindings for core singletons.
      *
-     * Phase 1 registration as described in the container architecture plan:
-     * Registers the most-duplicated singletons to validate the container works
-     * correctly before more complex refactors.
+     * Delegates to AIPS_Container_Bindings; see that class for the actual
+     * binding registrations.
      *
      * @return void
      */
     private function register_container_bindings() {
-        $container = AIPS_Container::get_instance();
-
-        // Register AIPS_Config (uses get_instance() instead of instance())
-        $container->singleton(AIPS_Config::class, function( $container ) {
-            return AIPS_Config::get_instance();
-        });
-
-        // Register AIPS_History_Repository
-        $container->singleton(AIPS_History_Repository::class, function( $container ) {
-            return AIPS_History_Repository::instance();
-        });
-
-		$container->singleton(AIPS_History_Repository_Interface::class, function( $container ) {
-			return $container->make(AIPS_History_Repository::class);
-		});
-
-        // Register AIPS_History_Service
-        $container->singleton(AIPS_History_Service::class, function( $container ) {
-            return AIPS_History_Service::instance();
-        });
-
-		$container->singleton(AIPS_History_Service_Interface::class, function( $container ) {
-			return $container->make(AIPS_History_Service::class);
-		});
-
-        // Register AIPS_Notifications_Repository
-        $container->singleton(AIPS_Notifications_Repository::class, function( $container ) {
-            return AIPS_Notifications_Repository::instance();
-        });
-
-        $container->singleton(AIPS_Notifications_Repository_Interface::class, function( $container ) {
-            return $container->make(AIPS_Notifications_Repository::class);
-        });
-
-        $container->singleton(AIPS_Logger::class, function( $container ) {
-            return AIPS_Logger::instance();
-        });
-
-        $container->singleton(AIPS_Logger_Interface::class, function( $container ) {
-            return $container->make(AIPS_Logger::class);
-        });
-
-        $container->singleton(AIPS_AI_Service::class, function( $container ) {
-            return AIPS_AI_Service::instance();
-        });
-
-        $container->singleton(AIPS_AI_Service_Interface::class, function( $container ) {
-            return $container->make(AIPS_AI_Service::class);
-        });
-
-        $container->singleton(AIPS_Schedule_Repository::class, function( $container ) {
-            return AIPS_Schedule_Repository::instance();
-        });
-
-        $container->singleton(AIPS_Schedule_Repository_Interface::class, function( $container ) {
-            return $container->make(AIPS_Schedule_Repository::class);
-        });
-
-        $container->singleton(AIPS_Telemetry_Repository::class, function( $container ) {
-            return AIPS_Telemetry_Repository::instance();
-        });
-
-        // Register AIPS_Template_Repository
-        $container->singleton(AIPS_Template_Repository::class, function( $container ) {
-            return AIPS_Template_Repository::instance();
-        });
+        AIPS_Container_Bindings::register( AIPS_Container::get_instance() );
     }
 
     /**
@@ -534,254 +440,13 @@ final class AI_Post_Scheduler {
     /**
      * Boot subsystems required only during WP-Cron execution.
      *
-     * Registers cron hook callbacks as closures that resolve the singleton
-     * instance at runtime (when WordPress fires the event). This means that
-     * a cron request dispatched for, say, aips_generate_author_topics will only
-     * ever instantiate AIPS_Author_Topics_Scheduler — the other scheduler
-     * objects are never constructed unless their own hooks fire in the same run.
-     *
-     * Also boots the notification event handler (for generation-failure and quota
-     * alerts fired from cron) and the partial-generation reconciler
-     * (save_post fires when cron creates posts).
+     * Delegates to AIPS_Cron_Bootstrap; see that class for the actual hook
+     * registrations and bulk-batch strategies.
      *
      * @return void
      */
     private function boot_cron() {
-        // Lazy-resolve the main template scheduler only when its hook fires.
-        add_action('aips_generate_scheduled_posts', function() {
-            AIPS_Scheduler::instance()->process();
-        });
-        add_filter('cron_schedules', function($schedules) {
-            return AIPS_Scheduler::instance()->add_cron_intervals($schedules);
-        });
-
-        // Batch-queue single events: each call processes one slice of a large schedule.
-        // Args: schedule_id, start_index, batch_size, total_quantity, correlation_id.
-        add_action('aips_process_schedule_batch', function(
-            $schedule_id,
-            $start_index,
-            $batch_size,
-            $total_quantity,
-            $correlation_id = ''
-        ) {
-            AIPS_Scheduler::instance()->process_batch(
-                (int) $schedule_id,
-                (int) $start_index,
-                (int) $batch_size,
-                (int) $total_quantity,
-                (string) $correlation_id
-            );
-        }, 10, 5);
-
-        // Lazy-resolve the author-topics scheduler only when its hook fires.
-        add_action('aips_generate_author_topics', function() {
-            AIPS_Author_Topics_Scheduler::instance()->process_topic_generation();
-        });
-
-        // Per-author topic-generation slice: process one author's topics in a dedicated cron event.
-        // Args: author_id, correlation_id.
-        add_action('aips_process_author_topics_slice', function( $author_id, $correlation_id = '' ) {
-            AIPS_Author_Topics_Scheduler::instance()->process_author_slice(
-                (int) $author_id,
-                (string) $correlation_id
-            );
-        }, 10, 2);
-
-        // Retry failed topic-generation slices: re-dispatch authors that failed to schedule.
-        // Args: author_ids_json, correlation_id.
-        add_action('aips_retry_failed_author_slices_topics', function( $author_ids_json, $correlation_id = '' ) {
-            AIPS_Author_Topics_Scheduler::instance()->retry_failed_topic_slices(
-                (string) $author_ids_json,
-                (string) $correlation_id
-            );
-        }, 10, 2);
-
-        // Lazy-resolve the author-post generator only when its hook fires.
-        add_action('aips_generate_author_posts', function() {
-            AIPS_Author_Post_Generator::instance()->process();
-        });
-
-        // Per-author post-generation slice: process one author's post in a dedicated cron event.
-        // Args: author_id, correlation_id.
-        add_action('aips_process_author_post_slice', function( $author_id, $correlation_id = '' ) {
-            AIPS_Author_Post_Generator::instance()->process_author_slice(
-                (int) $author_id,
-                (string) $correlation_id
-            );
-        }, 10, 2);
-
-        // Retry failed post-generation slices: re-dispatch authors that failed to schedule.
-        // Args: author_ids_json, correlation_id.
-        add_action('aips_retry_failed_author_slices_posts', function( $author_ids_json, $correlation_id = '' ) {
-            AIPS_Author_Post_Generator::instance()->retry_failed_post_slices(
-                (string) $author_ids_json,
-                (string) $correlation_id
-            );
-        }, 10, 2);
-
-        // Async bulk-batch processing: each single event processes one slice of a stored job.
-        // Args: job_id, start_index, batch_size, total_quantity, correlation_id.
-        add_action('aips_process_bulk_batch', function(
-            $job_id,
-            $start_index,
-            $batch_size,
-            $total_quantity,
-            $correlation_id = ''
-        ) {
-            AIPS_Bulk_Batch_Processor::instance()->process(
-                (string) $job_id,
-                (int)    $start_index,
-                (int)    $batch_size,
-                (int)    $total_quantity,
-                (string) $correlation_id
-            );
-        }, 10, 5);
-
-        // Register bulk-batch strategies for each supported job type.
-        // Strategies are registered directly (not via add_action) so they are
-        // available immediately when boot_cron() runs — before any later cron
-        // hook could fire in the same request.  Closures are safe here because
-        // they are never serialised; only the job_type string goes to the DB.
-        //
-        // Every handler receives ($item, $job_id, $job) so that per-job context
-        // stored in $job->options (e.g. template_id) can be read inside the closure.
-        $processor = AIPS_Bulk_Batch_Processor::instance();
-
-        $processor->register(
-            'author_topic_post',
-            function( $topic_id, $job_id, $job ) {
-                return AIPS_Author_Post_Generator::instance()->generate_now( (int) $topic_id );
-            }
-        );
-
-        $processor->register(
-            'planner_post',
-            function( $item, $job_id, $job ) {
-                $template_id = isset( $job->options['history_meta']['template_id'] )
-                    ? (int) $job->options['history_meta']['template_id']
-                    : 0;
-
-                if ( $template_id <= 0 ) {
-                    return new WP_Error(
-                        'planner_post_missing_template',
-                        __( 'planner_post strategy requires a template_id stored in job options.', 'ai-post-scheduler' )
-                    );
-                }
-
-                $template = ( new AIPS_Template_Repository() )->get_by_id( $template_id );
-
-                if ( ! $template || empty( $template->is_active ) ) {
-                    return new WP_Error(
-                        'planner_post_template_not_found',
-                        /* translators: %d: template ID */
-                        sprintf( __( 'Template %d not found or inactive for planner_post strategy.', 'ai-post-scheduler' ), $template_id )
-                    );
-                }
-
-                $topic     = is_array( $item ) ? ( $item['topic'] ?? (string) $item ) : (string) $item;
-                $generator = new AIPS_Generator();
-
-                return $generator->generate_post( $template, null, $topic );
-            }
-        );
-
-        $processor->register(
-            'trending_topic_post',
-            function( $item, $job_id, $job ) {
-                if ( ! is_array( $item ) || empty( $item['id'] ) || ! isset( $item['topic'] ) ) {
-                    return new WP_Error(
-                        'invalid_trending_topic_item',
-                        __( 'Item must be an array with id and topic keys.', 'ai-post-scheduler' )
-                    );
-                }
-
-                $template_id = isset( $job->options['history_meta']['template_id'] )
-                    ? (int) $job->options['history_meta']['template_id']
-                    : 0;
-
-                if ( $template_id <= 0 ) {
-                    return new WP_Error(
-                        'trending_topic_post_missing_template',
-                        __( 'trending_topic_post strategy requires a template_id stored in job options.', 'ai-post-scheduler' )
-                    );
-                }
-
-                $template = ( new AIPS_Template_Repository() )->get_by_id( $template_id );
-
-                if ( ! $template || empty( $template->is_active ) ) {
-                    return new WP_Error(
-                        'trending_topic_post_template_not_found',
-                        /* translators: %d: template ID */
-                        sprintf( __( 'Template %d not found or inactive for trending_topic_post strategy.', 'ai-post-scheduler' ), $template_id )
-                    );
-                }
-
-                $context   = new AIPS_Template_Context( $template, null, (string) $item['topic'], 'cron' );
-                $generator = new AIPS_Generator();
-                $post_id   = $generator->generate_post( $context );
-
-                if ( is_wp_error( $post_id ) ) {
-                    return $post_id;
-                }
-
-                update_post_meta( $post_id, AIPS_Post_Manager::META_TRENDING_TOPIC_ID,  absint( $item['id'] ) );
-                update_post_meta( $post_id, AIPS_Post_Manager::META_TRENDING_TOPIC_TEXT, sanitize_text_field( (string) $item['topic'] ) );
-
-                return $post_id;
-            }
-        );
-
-        // Daily cleanup of completed/failed bulk-batch job rows.
-        add_action('aips_cleanup_bulk_batch_jobs', function() {
-            $store   = new AIPS_Bulk_Batch_Job_Store();
-            $deleted = $store->cleanup_old_jobs();
-            if ( $deleted > 0 ) {
-                ( new AIPS_Logger() )->log(
-                    sprintf( 'Bulk batch job cleanup: deleted %d old job rows.', $deleted ),
-                    'info'
-                );
-            }
-        });
-
-        // Daily Cache Monitor maintenance (prune expired/orphan index rows + prune old events).
-        add_action('aips_cache_monitor_maintenance', function() {
-            $repository  = new AIPS_Cache_Monitor_Repository();
-            $cache_index = new AIPS_Cache_Index();
-            $service     = new AIPS_Cache_Monitor_Service( $repository, $cache_index );
-            $result      = $service->run_maintenance();
-            ( new AIPS_Logger() )->log(
-                sprintf( 'Cache Monitor maintenance complete: %s', wp_json_encode( $result ) ),
-                'info'
-            );
-        });
-
-        // Lazy-resolve the embeddings worker only when its hook fires.
-        add_action('aips_process_author_embeddings', function($args) {
-            AIPS_Embeddings_Cron::instance()->process_author_embeddings($args);
-        }, 10, 1);
-
-        // Research controller registers the aips_scheduled_research cron hook.
-        new AIPS_Research_Controller();
-
-        // Sources cron: fetch content for sources that have a fetch_interval configured.
-        // AIPS_Sources_Cron::schedule() handles registering the cron event at the
-        // correct recurrence (every_6_hours) during construction.
-        AIPS_Sources_Cron::instance();
-
-        // Notification event handler receives generation-failure/quota alerts from cron.
-        new AIPS_Notifications();
-
-        // Reconciler's save_post hook fires when cron creates or updates posts.
-        new AIPS_Partial_Generation_State_Reconciler();
-
-        // Internal Links indexing cron — construct the controller lazily only
-        // when the cron hook fires to avoid eager instantiation on every cron boot.
-        add_action('aips_index_posts_batch', function($args) {
-            (new AIPS_Internal_Links_Controller())->process_indexing_batch_cron($args);
-        }, 10, 1);
-
-        // Export-file cleanup cron handler.
-        add_action('aips_cleanup_export_files', array('AIPS_Session_To_JSON', 'handle_export_cleanup'));
+        AIPS_Cron_Bootstrap::register();
     }
 
     /**
@@ -879,64 +544,12 @@ function aips_init() {
 
 add_action('plugins_loaded', 'aips_init', 5);
 
-/**
- * Tell Query Monitor that files under the real (symlink-resolved) plugin
- * directory belong to this plugin, not WordPress Core.
- *
- * When the plugin directory is a symlink, PHP's debug_backtrace() returns the
- * real path (e.g. C:/Projects/.../ai-post-scheduler) which does not start with
- * WP_PLUGIN_DIR, so QM falls back to "WordPress Core".
- *
- * The three companion filters together register the resolved path and map the
- * custom key back to TYPE_PLUGIN with the correct plugin-slug context so that
- * QM shows "Plugin: ai-post-scheduler" in the Component column.
- */
-add_filter('qm/component_dirs', function( array $dirs ) {
-    $real = realpath( AIPS_PLUGIN_DIR );
-    if ( false === $real ) {
-        return $dirs;
-    }
-
-    $real = rtrim( str_replace( '\\', '/', $real ), '/' );
-
-    // Compare against the canonical WordPress plugins path, not AIPS_PLUGIN_DIR.
-    // In symlinked installs plugin_dir_path(__FILE__) can already be resolved.
-    $expected = rtrim( str_replace( '\\', '/', WP_PLUGIN_DIR . '/ai-post-scheduler' ), '/' );
-
-    // Only add when the real path differs from the canonical WP plugin path
-    // (i.e. a symlink is in use). Using a namespaced key avoids overwriting
-    // QM's built-in 'plugin' entry which is appended after this filter runs.
-    if ( $real !== $expected ) {
-        $dirs['plugin:ai-post-scheduler'] = $real;
-    }
-
-    return $dirs;
-});
-
-// Map the custom dir-key type back to TYPE_PLUGIN so QM shows the correct
-// component class and name rather than falling into the "unknown" branch.
-add_filter('qm/component_type/plugin:ai-post-scheduler', function() {
-    return 'plugin';
-});
-
-// Supply the plugin slug as the context so the component name becomes
-// "Plugin: ai-post-scheduler" instead of "Plugin: plugin:ai-post-scheduler".
-add_filter('qm/component_context/plugin', function( $context, $file ) {
-    $real = realpath( AIPS_PLUGIN_DIR );
-    
-    if ( false === $real || ! is_string( $file ) ) {
-        return $context;
-    }
-
-    $real = rtrim( str_replace( '\\', '/', $real ), '/' );
-    $file = str_replace( '\\', '/', $file );
-
-    if ( 0 === strpos( $file, $real . '/' ) || $file === $real ) {
-        return 'ai-post-scheduler';
-    }
-
-    return $context;
-}, 10, 2);
+// Query Monitor component-mapping integration (dev-tooling only); see
+// AIPS_Query_Monitor_Integration for the actual filters. Required explicitly
+// (rather than relying on AIPS_Autoloader) because this runs at file-parse
+// time, before the autoloader is registered in AI_Post_Scheduler::includes().
+require_once AIPS_PLUGIN_DIR . 'includes/class-aips-query-monitor-integration.php';
+AIPS_Query_Monitor_Integration::register();
 
 /**
  * Activation hook callback.

--- a/ai-post-scheduler/includes/class-aips-container-bindings.php
+++ b/ai-post-scheduler/includes/class-aips-container-bindings.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Registers core singleton and interface-alias bindings on the DI container.
+ *
+ * Extracted from AI_Post_Scheduler::register_container_bindings() so the
+ * plugin bootstrap file doesn't carry the binding wiring inline.
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class AIPS_Container_Bindings {
+
+    /**
+     * Register initial container bindings for core singletons.
+     *
+     * Phase 1 registration as described in the container architecture plan:
+     * Registers the most-duplicated singletons to validate the container works
+     * correctly before more complex refactors.
+     *
+     * @param AIPS_Container $container
+     * @return void
+     */
+    public static function register( AIPS_Container $container ) {
+        // Register AIPS_Config (uses get_instance() instead of instance())
+        $container->singleton(AIPS_Config::class, function( $container ) {
+            return AIPS_Config::get_instance();
+        });
+
+        // Register AIPS_History_Repository
+        $container->singleton(AIPS_History_Repository::class, function( $container ) {
+            return AIPS_History_Repository::instance();
+        });
+
+        $container->singleton(AIPS_History_Repository_Interface::class, function( $container ) {
+            return $container->make(AIPS_History_Repository::class);
+        });
+
+        // Register AIPS_History_Service
+        $container->singleton(AIPS_History_Service::class, function( $container ) {
+            return AIPS_History_Service::instance();
+        });
+
+        $container->singleton(AIPS_History_Service_Interface::class, function( $container ) {
+            return $container->make(AIPS_History_Service::class);
+        });
+
+        // Register AIPS_Notifications_Repository
+        $container->singleton(AIPS_Notifications_Repository::class, function( $container ) {
+            return AIPS_Notifications_Repository::instance();
+        });
+
+        $container->singleton(AIPS_Notifications_Repository_Interface::class, function( $container ) {
+            return $container->make(AIPS_Notifications_Repository::class);
+        });
+
+        $container->singleton(AIPS_Logger::class, function( $container ) {
+            return AIPS_Logger::instance();
+        });
+
+        $container->singleton(AIPS_Logger_Interface::class, function( $container ) {
+            return $container->make(AIPS_Logger::class);
+        });
+
+        $container->singleton(AIPS_AI_Service::class, function( $container ) {
+            return AIPS_AI_Service::instance();
+        });
+
+        $container->singleton(AIPS_AI_Service_Interface::class, function( $container ) {
+            return $container->make(AIPS_AI_Service::class);
+        });
+
+        $container->singleton(AIPS_Schedule_Repository::class, function( $container ) {
+            return AIPS_Schedule_Repository::instance();
+        });
+
+        $container->singleton(AIPS_Schedule_Repository_Interface::class, function( $container ) {
+            return $container->make(AIPS_Schedule_Repository::class);
+        });
+
+        $container->singleton(AIPS_Telemetry_Repository::class, function( $container ) {
+            return AIPS_Telemetry_Repository::instance();
+        });
+
+        // Register AIPS_Template_Repository
+        $container->singleton(AIPS_Template_Repository::class, function( $container ) {
+            return AIPS_Template_Repository::instance();
+        });
+    }
+}

--- a/ai-post-scheduler/includes/class-aips-cron-bootstrap.php
+++ b/ai-post-scheduler/includes/class-aips-cron-bootstrap.php
@@ -1,0 +1,267 @@
+<?php
+/**
+ * Registers all WP-Cron hook callbacks and bulk-batch strategies.
+ *
+ * Extracted from AI_Post_Scheduler::boot_cron() so the plugin bootstrap file
+ * doesn't carry the full cron wiring inline.
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class AIPS_Cron_Bootstrap {
+
+    /**
+     * Register subsystems required only during WP-Cron execution.
+     *
+     * Registers cron hook callbacks as closures that resolve the singleton
+     * instance at runtime (when WordPress fires the event). This means that
+     * a cron request dispatched for, say, aips_generate_author_topics will only
+     * ever instantiate AIPS_Author_Topics_Scheduler — the other scheduler
+     * objects are never constructed unless their own hooks fire in the same run.
+     *
+     * Also boots the notification event handler (for generation-failure and quota
+     * alerts fired from cron) and the partial-generation reconciler
+     * (save_post fires when cron creates posts).
+     *
+     * @return void
+     */
+    public static function register() {
+        // Lazy-resolve the main template scheduler only when its hook fires.
+        add_action('aips_generate_scheduled_posts', function() {
+            AIPS_Scheduler::instance()->process();
+        });
+        add_filter('cron_schedules', function($schedules) {
+            return AIPS_Scheduler::instance()->add_cron_intervals($schedules);
+        });
+
+        // Batch-queue single events: each call processes one slice of a large schedule.
+        // Args: schedule_id, start_index, batch_size, total_quantity, correlation_id.
+        add_action('aips_process_schedule_batch', function(
+            $schedule_id,
+            $start_index,
+            $batch_size,
+            $total_quantity,
+            $correlation_id = ''
+        ) {
+            AIPS_Scheduler::instance()->process_batch(
+                (int) $schedule_id,
+                (int) $start_index,
+                (int) $batch_size,
+                (int) $total_quantity,
+                (string) $correlation_id
+            );
+        }, 10, 5);
+
+        // Lazy-resolve the author-topics scheduler only when its hook fires.
+        add_action('aips_generate_author_topics', function() {
+            AIPS_Author_Topics_Scheduler::instance()->process_topic_generation();
+        });
+
+        // Per-author topic-generation slice: process one author's topics in a dedicated cron event.
+        // Args: author_id, correlation_id.
+        add_action('aips_process_author_topics_slice', function( $author_id, $correlation_id = '' ) {
+            AIPS_Author_Topics_Scheduler::instance()->process_author_slice(
+                (int) $author_id,
+                (string) $correlation_id
+            );
+        }, 10, 2);
+
+        // Retry failed topic-generation slices: re-dispatch authors that failed to schedule.
+        // Args: author_ids_json, correlation_id.
+        add_action('aips_retry_failed_author_slices_topics', function( $author_ids_json, $correlation_id = '' ) {
+            AIPS_Author_Topics_Scheduler::instance()->retry_failed_topic_slices(
+                (string) $author_ids_json,
+                (string) $correlation_id
+            );
+        }, 10, 2);
+
+        // Lazy-resolve the author-post generator only when its hook fires.
+        add_action('aips_generate_author_posts', function() {
+            AIPS_Author_Post_Generator::instance()->process();
+        });
+
+        // Per-author post-generation slice: process one author's post in a dedicated cron event.
+        // Args: author_id, correlation_id.
+        add_action('aips_process_author_post_slice', function( $author_id, $correlation_id = '' ) {
+            AIPS_Author_Post_Generator::instance()->process_author_slice(
+                (int) $author_id,
+                (string) $correlation_id
+            );
+        }, 10, 2);
+
+        // Retry failed post-generation slices: re-dispatch authors that failed to schedule.
+        // Args: author_ids_json, correlation_id.
+        add_action('aips_retry_failed_author_slices_posts', function( $author_ids_json, $correlation_id = '' ) {
+            AIPS_Author_Post_Generator::instance()->retry_failed_post_slices(
+                (string) $author_ids_json,
+                (string) $correlation_id
+            );
+        }, 10, 2);
+
+        // Async bulk-batch processing: each single event processes one slice of a stored job.
+        // Args: job_id, start_index, batch_size, total_quantity, correlation_id.
+        add_action('aips_process_bulk_batch', function(
+            $job_id,
+            $start_index,
+            $batch_size,
+            $total_quantity,
+            $correlation_id = ''
+        ) {
+            AIPS_Bulk_Batch_Processor::instance()->process(
+                (string) $job_id,
+                (int)    $start_index,
+                (int)    $batch_size,
+                (int)    $total_quantity,
+                (string) $correlation_id
+            );
+        }, 10, 5);
+
+        // Register bulk-batch strategies for each supported job type.
+        // Strategies are registered directly (not via add_action) so they are
+        // available immediately when boot_cron() runs — before any later cron
+        // hook could fire in the same request.  Closures are safe here because
+        // they are never serialised; only the job_type string goes to the DB.
+        //
+        // Every handler receives ($item, $job_id, $job) so that per-job context
+        // stored in $job->options (e.g. template_id) can be read inside the closure.
+        $processor = AIPS_Bulk_Batch_Processor::instance();
+
+        $processor->register(
+            'author_topic_post',
+            function( $topic_id, $job_id, $job ) {
+                return AIPS_Author_Post_Generator::instance()->generate_now( (int) $topic_id );
+            }
+        );
+
+        $processor->register(
+            'planner_post',
+            function( $item, $job_id, $job ) {
+                $template_id = isset( $job->options['history_meta']['template_id'] )
+                    ? (int) $job->options['history_meta']['template_id']
+                    : 0;
+
+                if ( $template_id <= 0 ) {
+                    return new WP_Error(
+                        'planner_post_missing_template',
+                        __( 'planner_post strategy requires a template_id stored in job options.', 'ai-post-scheduler' )
+                    );
+                }
+
+                $template = ( new AIPS_Template_Repository() )->get_by_id( $template_id );
+
+                if ( ! $template || empty( $template->is_active ) ) {
+                    return new WP_Error(
+                        'planner_post_template_not_found',
+                        /* translators: %d: template ID */
+                        sprintf( __( 'Template %d not found or inactive for planner_post strategy.', 'ai-post-scheduler' ), $template_id )
+                    );
+                }
+
+                $topic     = is_array( $item ) ? ( $item['topic'] ?? (string) $item ) : (string) $item;
+                $generator = new AIPS_Generator();
+
+                return $generator->generate_post( $template, null, $topic );
+            }
+        );
+
+        $processor->register(
+            'trending_topic_post',
+            function( $item, $job_id, $job ) {
+                if ( ! is_array( $item ) || empty( $item['id'] ) || ! isset( $item['topic'] ) ) {
+                    return new WP_Error(
+                        'invalid_trending_topic_item',
+                        __( 'Item must be an array with id and topic keys.', 'ai-post-scheduler' )
+                    );
+                }
+
+                $template_id = isset( $job->options['history_meta']['template_id'] )
+                    ? (int) $job->options['history_meta']['template_id']
+                    : 0;
+
+                if ( $template_id <= 0 ) {
+                    return new WP_Error(
+                        'trending_topic_post_missing_template',
+                        __( 'trending_topic_post strategy requires a template_id stored in job options.', 'ai-post-scheduler' )
+                    );
+                }
+
+                $template = ( new AIPS_Template_Repository() )->get_by_id( $template_id );
+
+                if ( ! $template || empty( $template->is_active ) ) {
+                    return new WP_Error(
+                        'trending_topic_post_template_not_found',
+                        /* translators: %d: template ID */
+                        sprintf( __( 'Template %d not found or inactive for trending_topic_post strategy.', 'ai-post-scheduler' ), $template_id )
+                    );
+                }
+
+                $context   = new AIPS_Template_Context( $template, null, (string) $item['topic'], 'cron' );
+                $generator = new AIPS_Generator();
+                $post_id   = $generator->generate_post( $context );
+
+                if ( is_wp_error( $post_id ) ) {
+                    return $post_id;
+                }
+
+                update_post_meta( $post_id, AIPS_Post_Manager::META_TRENDING_TOPIC_ID,  absint( $item['id'] ) );
+                update_post_meta( $post_id, AIPS_Post_Manager::META_TRENDING_TOPIC_TEXT, sanitize_text_field( (string) $item['topic'] ) );
+
+                return $post_id;
+            }
+        );
+
+        // Daily cleanup of completed/failed bulk-batch job rows.
+        add_action('aips_cleanup_bulk_batch_jobs', function() {
+            $store   = new AIPS_Bulk_Batch_Job_Store();
+            $deleted = $store->cleanup_old_jobs();
+            if ( $deleted > 0 ) {
+                ( new AIPS_Logger() )->log(
+                    sprintf( 'Bulk batch job cleanup: deleted %d old job rows.', $deleted ),
+                    'info'
+                );
+            }
+        });
+
+        // Daily Cache Monitor maintenance (prune expired/orphan index rows + prune old events).
+        add_action('aips_cache_monitor_maintenance', function() {
+            $repository  = new AIPS_Cache_Monitor_Repository();
+            $cache_index = new AIPS_Cache_Index();
+            $service     = new AIPS_Cache_Monitor_Service( $repository, $cache_index );
+            $result      = $service->run_maintenance();
+            ( new AIPS_Logger() )->log(
+                sprintf( 'Cache Monitor maintenance complete: %s', wp_json_encode( $result ) ),
+                'info'
+            );
+        });
+
+        // Lazy-resolve the embeddings worker only when its hook fires.
+        add_action('aips_process_author_embeddings', function($args) {
+            AIPS_Embeddings_Cron::instance()->process_author_embeddings($args);
+        }, 10, 1);
+
+        // Research controller registers the aips_scheduled_research cron hook.
+        new AIPS_Research_Controller();
+
+        // Sources cron: fetch content for sources that have a fetch_interval configured.
+        // AIPS_Sources_Cron::schedule() handles registering the cron event at the
+        // correct recurrence (every_6_hours) during construction.
+        AIPS_Sources_Cron::instance();
+
+        // Notification event handler receives generation-failure/quota alerts from cron.
+        new AIPS_Notifications();
+
+        // Reconciler's save_post hook fires when cron creates or updates posts.
+        new AIPS_Partial_Generation_State_Reconciler();
+
+        // Internal Links indexing cron — construct the controller lazily only
+        // when the cron hook fires to avoid eager instantiation on every cron boot.
+        add_action('aips_index_posts_batch', function($args) {
+            (new AIPS_Internal_Links_Controller())->process_indexing_batch_cron($args);
+        }, 10, 1);
+
+        // Export-file cleanup cron handler.
+        add_action('aips_cleanup_export_files', array('AIPS_Session_To_JSON', 'handle_export_cleanup'));
+    }
+}

--- a/ai-post-scheduler/includes/class-aips-query-monitor-integration.php
+++ b/ai-post-scheduler/includes/class-aips-query-monitor-integration.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Query Monitor component-mapping integration.
+ *
+ * Tells Query Monitor that files under the real (symlink-resolved) plugin
+ * directory belong to this plugin, not WordPress Core.
+ *
+ * When the plugin directory is a symlink, PHP's debug_backtrace() returns the
+ * real path (e.g. C:/Projects/.../ai-post-scheduler) which does not start with
+ * WP_PLUGIN_DIR, so QM falls back to "WordPress Core".
+ *
+ * The three companion filters together register the resolved path and map the
+ * custom key back to TYPE_PLUGIN with the correct plugin-slug context so that
+ * QM shows "Plugin: ai-post-scheduler" in the Component column.
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class AIPS_Query_Monitor_Integration {
+
+    /**
+     * Register the Query Monitor component-mapping filters.
+     *
+     * @return void
+     */
+    public static function register() {
+        add_filter('qm/component_dirs', function( array $dirs ) {
+            $real = realpath( AIPS_PLUGIN_DIR );
+            if ( false === $real ) {
+                return $dirs;
+            }
+
+            $real = rtrim( str_replace( '\\', '/', $real ), '/' );
+
+            // Compare against the canonical WordPress plugins path, not AIPS_PLUGIN_DIR.
+            // In symlinked installs plugin_dir_path(__FILE__) can already be resolved.
+            $expected = rtrim( str_replace( '\\', '/', WP_PLUGIN_DIR . '/ai-post-scheduler' ), '/' );
+
+            // Only add when the real path differs from the canonical WP plugin path
+            // (i.e. a symlink is in use). Using a namespaced key avoids overwriting
+            // QM's built-in 'plugin' entry which is appended after this filter runs.
+            if ( $real !== $expected ) {
+                $dirs['plugin:ai-post-scheduler'] = $real;
+            }
+
+            return $dirs;
+        });
+
+        // Map the custom dir-key type back to TYPE_PLUGIN so QM shows the correct
+        // component class and name rather than falling into the "unknown" branch.
+        add_filter('qm/component_type/plugin:ai-post-scheduler', function() {
+            return 'plugin';
+        });
+
+        // Supply the plugin slug as the context so the component name becomes
+        // "Plugin: ai-post-scheduler" instead of "Plugin: plugin:ai-post-scheduler".
+        add_filter('qm/component_context/plugin', function( $context, $file ) {
+            $real = realpath( AIPS_PLUGIN_DIR );
+
+            if ( false === $real || ! is_string( $file ) ) {
+                return $context;
+            }
+
+            $real = rtrim( str_replace( '\\', '/', $real ), '/' );
+            $file = str_replace( '\\', '/', $file );
+
+            if ( 0 === strpos( $file, $real . '/' ) || $file === $real ) {
+                return 'ai-post-scheduler';
+            }
+
+            return $context;
+        }, 10, 2);
+    }
+}

--- a/ai-post-scheduler/includes/config.php
+++ b/ai-post-scheduler/includes/config.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Configurable debug/telemetry constants.
+ *
+ * These are raw PHP constants (not AIPS_Config options) because some of them
+ * intentionally support being pre-defined earlier in wp-config.php, before the
+ * plugin loads — a pattern only possible with define(), not the options API.
+ *
+ * Required from ai-post-scheduler.php after AIPS_PLUGIN_DIR is defined.
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+// Enable SAVEQUERIES as early as possible for telemetry-enabled requests so
+// slow/duplicate query analysis can inspect the collected query log.
+if (!defined('SAVEQUERIES') && function_exists('get_option') && get_option('aips_enable_telemetry', false)) {
+    define('SAVEQUERIES', true);
+}
+
+if (!defined('AIPS_TELEMETRY_SLOW_QUERY_MS')) {
+    define('AIPS_TELEMETRY_SLOW_QUERY_MS', 100);
+}
+
+if (!defined('AIPS_TELEMETRY_SLOW_REQUEST_MS')) {
+    define('AIPS_TELEMETRY_SLOW_REQUEST_MS', 1500);
+}
+
+if (!defined('AIPS_TELEMETRY_QUERY_SAMPLE_LIMIT')) {
+    define('AIPS_TELEMETRY_QUERY_SAMPLE_LIMIT', 10);
+}
+
+// Prompt-preview logging can expose generated content in logs. Off by default;
+// opt-in by defining the constant to true earlier (e.g. in wp-config.php), or
+// it will automatically enable when WP_DEBUG is true.
+if (!defined('AIPS_AI_DEBUG_LOG_PROMPTS')) {
+    define('AIPS_AI_DEBUG_LOG_PROMPTS', defined('WP_DEBUG') && WP_DEBUG);
+}
+
+if (!defined('AIPS_DEBUG')) {
+    define('AIPS_DEBUG', defined('WP_DEBUG') && WP_DEBUG);
+}
+
+if (!defined('AIPS_DEBUG_LEVEL')) {
+    define('AIPS_DEBUG_LEVEL', defined('WP_DEBUG') && WP_DEBUG ? 1 : 0);
+}


### PR DESCRIPTION
## Summary
- `ai-post-scheduler.php` was 961 lines and mixed entry-point wiring with real business logic (a 68-line container-binding block and a 237-line cron-hook-registration block inside `boot_cron()`), plus an unrelated 58-line Query Monitor dev-tooling block. This splits those out so the entry point stays thin and scannable.
- New `includes/config.php`: the configurable debug/telemetry constants (`SAVEQUERIES`, `AIPS_TELEMETRY_SLOW_QUERY_MS`, `AIPS_TELEMETRY_SLOW_REQUEST_MS`, `AIPS_TELEMETRY_QUERY_SAMPLE_LIMIT`, `AIPS_AI_DEBUG_LOG_PROMPTS`, `AIPS_DEBUG`, `AIPS_DEBUG_LEVEL`), required right after the WP-identity constants. `AIPS_VERSION`, `AIPS_PLUGIN_DIR`, `AIPS_PLUGIN_URL`, `AIPS_PLUGIN_BASENAME`, and `AIPS_REQUEST_START` stay in the main file since they depend on `__FILE__` or must be captured before anything else runs.
- New `includes/class-aips-container-bindings.php` (`AIPS_Container_Bindings::register()`): holds the DI container singleton/interface-alias wiring previously inlined in `register_container_bindings()`.
- New `includes/class-aips-cron-bootstrap.php` (`AIPS_Cron_Bootstrap::register()`): holds the full WP-Cron hook + bulk-batch-strategy registration previously inlined in `boot_cron()` (the single largest chunk of the old file).
- New `includes/class-aips-query-monitor-integration.php` (`AIPS_Query_Monitor_Integration::register()`): holds the 3 Query Monitor component-mapping filters, explicitly `require_once`'d and called at top-level since it runs before the autoloader is registered.
- `AI_Post_Scheduler` keeps its private `boot_common`/`boot_cron`/`boot_ajax`/`boot_admin`/`boot_frontend` and `register_container_bindings` methods (now one-line delegations) unchanged in name/visibility, so the existing reflection-based tests (`Test_AIPS_Context_Boot`, `Test_AIPS_Container_Bindings`) continue to pass without modification.
- Net effect: `ai-post-scheduler.php` drops from 961 to 574 lines with no behavior change.

## Verification
- [x] `php -l` on all new/changed files — no syntax errors
- [x] `php tools/check-repository-boundary.php` — passes (new files don't match the `*-controller.php`/`*-service.php` pattern and don't touch `$wpdb`)
- [ ] `composer test` (or targeted tests) run for changed behavior — not run per repo policy (only on explicit request); no test files require changes since the reflected method names/visibility on `AI_Post_Scheduler` are preserved
- [ ] Manual verification completed for changed admin/runtime paths — not performed in this sandboxed environment (no live WP install)
- [ ] Documentation updated (if behavior or workflow changed) — no user-facing behavior changed, so none needed

## Risk Checklist
- [ ] Label `schema-change` — not applicable, no DB/schema changes
- [ ] Label `admin-ui` + `needs-browser-test` — not applicable, no admin UI changes
- [ ] Label `ajax-registry` — not applicable, no AJAX handler changes
- [x] Label `cron` — cron hook registration code moved (not behaviorally changed) to `AIPS_Cron_Bootstrap`
- [ ] Label `generation-pipeline` — not applicable, generation logic itself untouched
- [ ] Label `security-sensitive` — not applicable, no auth/nonce/capability changes
- [ ] Label duplicate-risk — none identified

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHt3wEXzk2zhkY9wkNbxWy)_