### PR TITLE
Gate Cache Monitor, Seeder, and MCP Bridge dev tools behind flags, disabled by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Security
+- **Dev Tools Gating**: Cache Monitor and the Seeder are now disabled by default and properly enforce their feature flags (`aips_cache_monitor_enabled`, `aips_developer_mode`) at every layer — menu, Diagnostics tab, page render, and AJAX handlers — closing gaps where the flag was only checked for UI visibility. The AI scaffold generator ("Dev Tools") AJAX handler now also re-checks `aips_developer_mode`.
+- **MCP Bridge**: `mcp-bridge.php` is now disabled by default and can only be enabled by defining `AIPS_MCP_BRIDGE_ENABLED` and a shared-secret `AIPS_MCP_BRIDGE_TOKEN` in `wp-config.php` — it can no longer be turned on from the WordPress admin UI. All HTTP requests must now present a matching `token` field, closing a CSRF gap on this previously cookie-auth-only endpoint. See `docs/MCP_BRIDGE.md`.
+
 ## [3.0.1] - 2026-07-07
 
 ### Added

--- a/ai-post-scheduler/includes/class-aips-admin-menu.php
+++ b/ai-post-scheduler/includes/class-aips-admin-menu.php
@@ -244,14 +244,16 @@ class AIPS_Admin_Menu {
             array($this, 'render_status_page')
         );
 
-        add_submenu_page(
-            null,
-            __('Seeder', 'ai-post-scheduler'),
-            __('Seeder', 'ai-post-scheduler'),
-            'manage_options',
-            'aips-seeder',
-            array($this, 'render_seeder_page')
-        );
+        if (AIPS_Config::get_instance()->get_option('aips_developer_mode')) {
+            add_submenu_page(
+                null,
+                __('Seeder', 'ai-post-scheduler'),
+                __('Seeder', 'ai-post-scheduler'),
+                'manage_options',
+                'aips-seeder',
+                array($this, 'render_seeder_page')
+            );
+        }
 
         add_submenu_page(
             null,
@@ -273,14 +275,16 @@ class AIPS_Admin_Menu {
             );
         }
 
-        add_submenu_page(
-            null,
-            __('Cache Monitor', 'ai-post-scheduler'),
-            __('Cache Monitor', 'ai-post-scheduler'),
-            'manage_options',
-            'aips-cache-monitor',
-            array($this, 'render_cache_monitor_page')
-        );
+        if (AIPS_Config::get_instance()->get_option('aips_cache_monitor_enabled')) {
+            add_submenu_page(
+                null,
+                __('Cache Monitor', 'ai-post-scheduler'),
+                __('Cache Monitor', 'ai-post-scheduler'),
+                'manage_options',
+                'aips-cache-monitor',
+                array($this, 'render_cache_monitor_page')
+            );
+        }
         if (AIPS_Config::get_instance()->get_option('aips_developer_mode')) {
             add_submenu_page(
                 null,

--- a/ai-post-scheduler/includes/class-aips-cache-monitor-controller.php
+++ b/ai-post-scheduler/includes/class-aips-cache-monitor-controller.php
@@ -75,6 +75,10 @@ class AIPS_Cache_Monitor_Controller {
 			wp_die(esc_html__('You do not have permission to access this page.', 'ai-post-scheduler'));
 		}
 
+		if (!AIPS_Config::get_instance()->get_option('aips_cache_monitor_enabled')) {
+			wp_die(esc_html__('Cache Monitor is currently disabled.', 'ai-post-scheduler'));
+		}
+
 		$service      = $this->service;
 		$summary      = $service->get_summary();
 		$nonce        = wp_create_nonce('aips_cache_monitor');
@@ -409,6 +413,10 @@ class AIPS_Cache_Monitor_Controller {
 
 		if (!current_user_can('manage_options')) {
 			AIPS_Ajax_Response::permission_denied();
+		}
+
+		if (!AIPS_Config::get_instance()->get_option('aips_cache_monitor_enabled')) {
+			AIPS_Ajax_Response::error(__('Cache Monitor is disabled.', 'ai-post-scheduler'));
 		}
 	}
 

--- a/ai-post-scheduler/includes/class-aips-config.php
+++ b/ai-post-scheduler/includes/class-aips-config.php
@@ -188,7 +188,7 @@ class AIPS_Config {
             // Telemetry
             'aips_enable_telemetry' => false,
             // Cache Monitor
-            'aips_cache_monitor_enabled'               => true,
+            'aips_cache_monitor_enabled'               => false,
             'aips_cache_monitor_index_enabled'         => true,
             'aips_cache_monitor_metrics_enabled'       => true,
             'aips_cache_monitor_event_retention_days'  => 30,

--- a/ai-post-scheduler/includes/class-aips-dev-tools.php
+++ b/ai-post-scheduler/includes/class-aips-dev-tools.php
@@ -25,6 +25,10 @@ class AIPS_Dev_Tools {
      * @return void
      */
     public function render_page($embedded = false) {
+        if (!AIPS_Config::get_instance()->get_option('aips_developer_mode')) {
+            wp_die(esc_html__('Developer Mode is currently disabled.', 'ai-post-scheduler'));
+        }
+
         $embedded = (bool) $embedded;
 
         include AIPS_PLUGIN_DIR . 'templates/admin/dev-tools.php';
@@ -45,6 +49,10 @@ class AIPS_Dev_Tools {
 
         if (!current_user_can('manage_options')) {
             AIPS_Ajax_Response::error(__('Unauthorized access.', 'ai-post-scheduler'));
+        }
+
+        if (!AIPS_Config::get_instance()->get_option('aips_developer_mode')) {
+            AIPS_Ajax_Response::error(__('Developer Mode is disabled.', 'ai-post-scheduler'));
         }
 
         $topic = isset($_POST['topic']) ? sanitize_text_field(wp_unslash($_POST['topic'])) : '';

--- a/ai-post-scheduler/includes/class-aips-diagnostics-controller.php
+++ b/ai-post-scheduler/includes/class-aips-diagnostics-controller.php
@@ -67,9 +67,11 @@ class AIPS_Diagnostics_Controller {
 			'label' => __('Insights', 'ai-post-scheduler'),
 		);
 
-		$tabs['seeder'] = array(
-			'label' => __('Seeder', 'ai-post-scheduler'),
-		);
+		if (self::is_tab_available('seeder')) {
+			$tabs['seeder'] = array(
+				'label' => __('Seeder', 'ai-post-scheduler'),
+			);
+		}
 
 		if (self::is_tab_available('dev-tools')) {
 			$tabs['dev-tools'] = array(
@@ -108,7 +110,7 @@ class AIPS_Diagnostics_Controller {
 	 * @return bool
 	 */
 	public static function is_tab_available($tab) {
-		if (in_array($tab, array('status', 'seeder', 'insights', 'cache-monitor'), true)) {
+		if (in_array($tab, array('status', 'insights'), true)) {
 			return true;
 		}
 
@@ -116,7 +118,11 @@ class AIPS_Diagnostics_Controller {
 			return (bool) AIPS_Config::get_instance()->get_option('aips_enable_telemetry');
 		}
 
-		if ('dev-tools' === $tab) {
+		if ('cache-monitor' === $tab) {
+			return (bool) AIPS_Config::get_instance()->get_option('aips_cache_monitor_enabled');
+		}
+
+		if ('seeder' === $tab || 'dev-tools' === $tab) {
 			return (bool) AIPS_Config::get_instance()->get_option('aips_developer_mode');
 		}
 

--- a/ai-post-scheduler/includes/class-aips-seeder-admin.php
+++ b/ai-post-scheduler/includes/class-aips-seeder-admin.php
@@ -34,6 +34,10 @@ class AIPS_Seeder_Admin {
     }
 
     public function render_page($embedded = false) {
+        if (!AIPS_Config::get_instance()->get_option('aips_developer_mode')) {
+            wp_die(esc_html__('Developer Mode is currently disabled.', 'ai-post-scheduler'));
+        }
+
         $embedded = (bool) $embedded;
 
         include AIPS_PLUGIN_DIR . 'templates/admin/seeder.php';
@@ -46,6 +50,10 @@ class AIPS_Seeder_Admin {
 
         if (!current_user_can('manage_options')) {
             AIPS_Ajax_Response::permission_denied();
+        }
+
+        if (!AIPS_Config::get_instance()->get_option('aips_developer_mode')) {
+            AIPS_Ajax_Response::error(__('Developer Mode is disabled.', 'ai-post-scheduler'));
         }
 
         $type = isset($_POST['type']) ? sanitize_text_field(wp_unslash($_POST['type'])) : '';

--- a/ai-post-scheduler/includes/class-aips-settings-ui.php
+++ b/ai-post-scheduler/includes/class-aips-settings-ui.php
@@ -369,6 +369,26 @@ class AIPS_Settings_UI {
     }
 
     /**
+     * Render the cache monitor setting field.
+     *
+     * Displays a checkbox to enable or disable the Cache Monitor
+     * admin page and its AJAX endpoints (internal cache introspection tool).
+     *
+     * @return void
+     */
+    public function cache_monitor_enabled_field_callback() {
+        $value = AIPS_Config::get_instance()->get_option('aips_cache_monitor_enabled');
+        ?>
+        <input type="hidden" name="aips_cache_monitor_enabled" value="0">
+        <label>
+            <input type="checkbox" name="aips_cache_monitor_enabled" value="1" <?php checked($value, 1); ?>>
+            <?php esc_html_e('Enable Cache Monitor (internal cache introspection tool)', 'ai-post-scheduler'); ?>
+        </label>
+        <p class="description"><?php esc_html_e('Exposes an admin page and AJAX endpoints for inspecting and flushing internal cache entries. Not recommended for production.', 'ai-post-scheduler'); ?></p>
+        <?php
+    }
+
+    /**
      * Render the review notifications email setting field.
      *
      * Displays an email input field for the notifications recipient.

--- a/ai-post-scheduler/includes/class-aips-settings.php
+++ b/ai-post-scheduler/includes/class-aips-settings.php
@@ -87,6 +87,10 @@ class AIPS_Settings {
 				'sanitize_callback' => 'absint',
 				'default'           => $defaults['aips_enable_telemetry'],
 			),
+			'aips_cache_monitor_enabled' => array(
+				'sanitize_callback' => 'absint',
+				'default'           => $defaults['aips_cache_monitor_enabled'],
+			),
 			'aips_enable_retry' => array(
 				'sanitize_callback' => 'absint',
 				'default'           => $defaults['aips_enable_retry'],
@@ -398,6 +402,14 @@ class AIPS_Settings {
             'aips_enable_telemetry',
             __('Enable Telemetry', 'ai-post-scheduler'),
             array($this->ui, 'enable_telemetry_field_callback'),
+            'aips-settings',
+            'aips_developers_section'
+        );
+
+        add_settings_field(
+            'aips_cache_monitor_enabled',
+            __('Enable Cache Monitor', 'ai-post-scheduler'),
+            array($this->ui, 'cache_monitor_enabled_field_callback'),
             'aips-settings',
             'aips_developers_section'
         );

--- a/ai-post-scheduler/mcp-bridge.php
+++ b/ai-post-scheduler/mcp-bridge.php
@@ -428,10 +428,11 @@ class AIPS_MCP_Bridge {
 	 * @return void
 	 */
 	public function handle_request() {
-		// Verify user has admin capabilities
-		if (!current_user_can('manage_options')) {
-			$this->send_error(-32001, 'Insufficient permissions. Admin access required.');
-			return;
+		// Defense in depth: re-check the bridge is enabled even though the
+		// top-level dispatcher already gates on this before instantiating us.
+		if (!defined('AIPS_MCP_BRIDGE_ENABLED') || !AIPS_MCP_BRIDGE_ENABLED) {
+			http_response_code(404);
+			exit;
 		}
 
 		// Get request body
@@ -440,6 +441,22 @@ class AIPS_MCP_Bridge {
 
 		if (json_last_error() !== JSON_ERROR_NONE) {
 			$this->send_error(-32700, 'Parse error: Invalid JSON');
+			return;
+		}
+
+		// Require a shared-secret token before any other processing. This is
+		// the bridge's CSRF protection (the endpoint is otherwise cookie/session
+		// authenticated only) and lets non-browser MCP clients authenticate
+		// without a WordPress nonce tied to a logged-in session.
+		$provided_token = isset($request['token']) ? (string) $request['token'] : '';
+		if (!defined('AIPS_MCP_BRIDGE_TOKEN') || '' === AIPS_MCP_BRIDGE_TOKEN || !hash_equals((string) AIPS_MCP_BRIDGE_TOKEN, $provided_token)) {
+			$this->send_error(-32001, 'Unauthorized: invalid or missing token.');
+			return;
+		}
+
+		// Verify user has admin capabilities
+		if (!current_user_can('manage_options')) {
+			$this->send_error(-32001, 'Insufficient permissions. Admin access required.');
 			return;
 		}
 
@@ -1788,6 +1805,14 @@ $is_cli = php_sapi_name() === 'cli' || php_sapi_name() === 'cli-server';
 $is_http_post = isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'POST';
 
 if ($is_http_post) {
+	// The bridge is disabled by default. It must be explicitly enabled by
+	// defining AIPS_MCP_BRIDGE_ENABLED (and AIPS_MCP_BRIDGE_TOKEN) in wp-config.php
+	// so it cannot be turned on from within the WP admin UI.
+	if (!defined('AIPS_MCP_BRIDGE_ENABLED') || !AIPS_MCP_BRIDGE_ENABLED) {
+		http_response_code(404);
+		exit;
+	}
+
 	// HTTP POST: standard JSON-RPC request/response
 	$bridge = new AIPS_MCP_Bridge();
 	$bridge->handle_request();

--- a/ai-post-scheduler/tests/Test_AIPS_Admin_Menu.php
+++ b/ai-post-scheduler/tests/Test_AIPS_Admin_Menu.php
@@ -135,7 +135,7 @@ class Test_AIPS_Admin_Menu extends WP_UnitTestCase {
 			'Diagnostics should be visible in the primary submenu.'
 		);
 
-		foreach (array('aips-operations-insights', 'aips-status', 'aips-seeder') as $hidden_page) {
+		foreach (array('aips-operations-insights', 'aips-status') as $hidden_page) {
 			$this->assertNotContains(
 				$hidden_page,
 				$submenu_pages,
@@ -155,6 +155,96 @@ class Test_AIPS_Admin_Menu extends WP_UnitTestCase {
 	public function test_diagnostics_controller_and_template_exist() {
 		$this->assertTrue(class_exists('AIPS_Diagnostics_Controller'));
 		$this->assertFileExists(AIPS_PLUGIN_DIR . 'templates/admin/diagnostics.php');
+	}
+
+	/**
+	 * Seeder is a dev/test-data tool and must be disabled (unregistered) by default.
+	 */
+	public function test_seeder_page_is_not_registered_by_default() {
+		global $submenu, $_registered_pages;
+
+		$submenu           = array();
+		$_registered_pages = array();
+
+		update_option('aips_developer_mode', false);
+		AIPS_Config::get_instance()->flush_option_cache();
+
+		$this->admin_menu->add_menu_pages();
+
+		$this->assertArrayNotHasKey(
+			'admin_page_aips-seeder',
+			$_registered_pages,
+			'Seeder should not be registered when Developer Mode is disabled.'
+		);
+	}
+
+	/**
+	 * Seeder becomes reachable once Developer Mode is enabled.
+	 */
+	public function test_seeder_page_is_registered_when_developer_mode_enabled() {
+		global $submenu, $_registered_pages;
+
+		$submenu           = array();
+		$_registered_pages = array();
+
+		update_option('aips_developer_mode', true);
+		AIPS_Config::get_instance()->flush_option_cache();
+
+		$this->admin_menu->add_menu_pages();
+
+		$this->assertArrayHasKey(
+			'admin_page_aips-seeder',
+			$_registered_pages,
+			'Seeder should be registered for direct admin.php?page= access when Developer Mode is enabled.'
+		);
+
+		update_option('aips_developer_mode', false);
+		AIPS_Config::get_instance()->flush_option_cache();
+	}
+
+	/**
+	 * Cache Monitor is an internal introspection tool and must be disabled by default.
+	 */
+	public function test_cache_monitor_page_is_not_registered_by_default() {
+		global $submenu, $_registered_pages;
+
+		$submenu           = array();
+		$_registered_pages = array();
+
+		update_option('aips_cache_monitor_enabled', false);
+		AIPS_Config::get_instance()->flush_option_cache();
+
+		$this->admin_menu->add_menu_pages();
+
+		$this->assertArrayNotHasKey(
+			'admin_page_aips-cache-monitor',
+			$_registered_pages,
+			'Cache Monitor should not be registered when aips_cache_monitor_enabled is disabled.'
+		);
+	}
+
+	/**
+	 * Cache Monitor becomes reachable once explicitly enabled.
+	 */
+	public function test_cache_monitor_page_is_registered_when_enabled() {
+		global $submenu, $_registered_pages;
+
+		$submenu           = array();
+		$_registered_pages = array();
+
+		update_option('aips_cache_monitor_enabled', true);
+		AIPS_Config::get_instance()->flush_option_cache();
+
+		$this->admin_menu->add_menu_pages();
+
+		$this->assertArrayHasKey(
+			'admin_page_aips-cache-monitor',
+			$_registered_pages,
+			'Cache Monitor should be registered for direct admin.php?page= access when enabled.'
+		);
+
+		update_option('aips_cache_monitor_enabled', false);
+		AIPS_Config::get_instance()->flush_option_cache();
 	}
 
 	/**

--- a/docs/MCP_BRIDGE.md
+++ b/docs/MCP_BRIDGE.md
@@ -8,9 +8,22 @@ The JSON schema for all tools is at `ai-post-scheduler/mcp-bridge-schema.json`. 
 
 ---
 
+## Enabling the bridge
+
+The bridge is **disabled by default**. It cannot be turned on from the WordPress admin UI — it must be explicitly enabled by a site operator with filesystem access, by adding both of the following to `wp-config.php`:
+
+```php
+define( 'AIPS_MCP_BRIDGE_ENABLED', true );
+define( 'AIPS_MCP_BRIDGE_TOKEN', 'a long random shared secret, e.g. from `wp_generate_password( 64, false )`' );
+```
+
+Without `AIPS_MCP_BRIDGE_ENABLED`, any HTTP POST to `mcp-bridge.php` returns a 404. `AIPS_MCP_BRIDGE_TOKEN` is a shared secret every request must present (see Protocol below) — this is deliberately not a DB option/settings checkbox, so a compromised `manage_options` admin session cannot self-enable the bridge.
+
+---
+
 ## Authentication
 
-All requests require WordPress admin capabilities (`manage_options`). Supported methods:
+All requests require **both** the shared-secret token above (`token` field in the JSON-RPC request body) **and** WordPress admin capabilities (`manage_options`). Supported methods for the latter:
 
 - **Application Passwords** (recommended): generate at WordPress Dashboard → Users → Profile → Application Passwords. Format: `xxxx xxxx xxxx xxxx xxxx xxxx`.
 - **Session cookies**: send WordPress session cookies with the request.
@@ -25,7 +38,7 @@ All requests require WordPress admin capabilities (`manage_options`). Supported 
 curl -X POST https://your-site.com/wp-content/plugins/ai-post-scheduler/mcp-bridge.php \
   -u "admin:xxxx xxxx xxxx xxxx" \
   -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","method":"list_tools","params":{},"id":1}'
+  -d '{"jsonrpc":"2.0","method":"list_tools","params":{},"id":1,"token":"YOUR_AIPS_MCP_BRIDGE_TOKEN"}'
 
 # Or run the local test suite
 cd ai-post-scheduler && php test-mcp-bridge.php
@@ -127,8 +140,10 @@ Test with: `@mcp list_tools from aips` in Copilot chat. Expected: 25 tools.
 All requests follow JSON-RPC 2.0:
 
 ```json
-{ "jsonrpc": "2.0", "method": "tool_name", "params": {}, "id": 1 }
+{ "jsonrpc": "2.0", "method": "tool_name", "params": {}, "id": 1, "token": "YOUR_AIPS_MCP_BRIDGE_TOKEN" }
 ```
+
+The top-level `token` field must match the `AIPS_MCP_BRIDGE_TOKEN` constant defined in `wp-config.php`; requests without it (or with a wrong value) are rejected before any tool runs, regardless of WordPress authentication.
 
 Error responses:
 
@@ -136,7 +151,7 @@ Error responses:
 { "jsonrpc": "2.0", "error": { "code": -32001, "message": "Insufficient permissions." }, "id": 1 }
 ```
 
-Error codes: `-32700` parse error, `-32600` invalid request, `-32001` insufficient permissions, `-32000` tool execution error.
+Error codes: `-32700` parse error, `-32600` invalid request, `-32001` invalid/missing token or insufficient permissions, `-32000` tool execution error. A disabled bridge (`AIPS_MCP_BRIDGE_ENABLED` not set) returns a plain HTTP 404, not a JSON-RPC error.
 
 ---
 
@@ -150,8 +165,10 @@ Error codes: `-32700` parse error, `-32600` invalid request, `-32001` insufficie
 
 ## Troubleshooting
 
+- **404 on every request**: the bridge is disabled by default — define `AIPS_MCP_BRIDGE_ENABLED` and `AIPS_MCP_BRIDGE_TOKEN` in `wp-config.php` (see "Enabling the bridge" above).
+- **-32001 invalid/missing token**: the request body's `token` field doesn't match `AIPS_MCP_BRIDGE_TOKEN`.
 - **401 / auth failure**: use Application Password (not main password); username must be WordPress login name, not email.
 - **403 / permissions**: user must have administrator role (`manage_options`).
-- **Bridge not accessible**: check file permissions on `mcp-bridge.php` and that the plugin is active.
+- **Bridge not accessible**: check file permissions on `mcp-bridge.php`, that the plugin is active, and that the bridge is enabled per above.
 - **Timeout on `generate_post`**: expected for long-running AI calls; increase `timeout` in MCP client config.
 - **Debug logs**: `wp-content/debug.log` (requires `WP_DEBUG_LOG true`) and plugin logs under `wp-content/uploads/aips-logs/`.

--- a/scripts/mcp-client-example.py
+++ b/scripts/mcp-client-example.py
@@ -21,30 +21,34 @@ from typing import Dict, Any, Optional
 class MCPClient:
     """Simple MCP Bridge client"""
     
-    def __init__(self, url: str, username: str = None, password: str = None):
+    def __init__(self, url: str, username: str = None, password: str = None, token: str = None):
         """
         Initialize MCP client
-        
+
         Args:
             url: URL to the MCP bridge endpoint
             username: WordPress username (optional)
             password: WordPress application password (optional)
+            token: Shared secret matching the AIPS_MCP_BRIDGE_TOKEN constant
+                defined in wp-config.php (required; the bridge rejects
+                requests without it regardless of WordPress auth)
         """
         self.url = url
+        self.token = token
         self.session = requests.Session()
-        
+
         if username and password:
             self.session.auth = (username, password)
-    
+
     def call_tool(self, method: str, params: Optional[Dict[str, Any]] = None, request_id: int = 1) -> Dict[str, Any]:
         """
         Call an MCP tool
-        
+
         Args:
             method: Tool name to call
             params: Tool parameters (optional)
             request_id: JSON-RPC request ID
-            
+
         Returns:
             Tool result or error
         """
@@ -52,7 +56,8 @@ class MCPClient:
             "jsonrpc": "2.0",
             "method": method,
             "params": params or {},
-            "id": request_id
+            "id": request_id,
+            "token": self.token
         }
         
         try:
@@ -93,6 +98,7 @@ def main():
     parser.add_argument("--url", required=True, help="MCP Bridge URL")
     parser.add_argument("--username", help="WordPress username")
     parser.add_argument("--password", help="WordPress application password")
+    parser.add_argument("--token", required=True, help="Shared secret matching AIPS_MCP_BRIDGE_TOKEN in wp-config.php")
     parser.add_argument("--tool", default="list_tools", help="Tool to call (default: list_tools)")
     parser.add_argument("--params", help="Tool parameters as JSON string")
     
@@ -108,7 +114,7 @@ def main():
             return 1
     
     # Create client
-    client = MCPClient(args.url, args.username, args.password)
+    client = MCPClient(args.url, args.username, args.password, args.token)
     
     print(f"🔧 Calling tool: {args.tool}")
     print(f"📝 Parameters: {json.dumps(params)}")

--- a/scripts/mcp-client-example.sh
+++ b/scripts/mcp-client-example.sh
@@ -13,6 +13,8 @@
 MCP_URL="${MCP_URL:-http://localhost/wp-content/plugins/ai-post-scheduler/mcp-bridge.php}"
 WP_USERNAME="${WP_USERNAME:-admin}"
 WP_PASSWORD="${WP_PASSWORD:-}"
+# Must match the AIPS_MCP_BRIDGE_TOKEN constant defined in wp-config.php.
+MCP_BRIDGE_TOKEN="${MCP_BRIDGE_TOKEN:-}"
 
 # Colors for output
 GREEN='\033[0;32m'
@@ -32,7 +34,8 @@ REQUEST=$(cat <<EOF
   "jsonrpc": "2.0",
   "method": "$TOOL",
   "params": $PARAMS,
-  "id": 1
+  "id": 1,
+  "token": "$MCP_BRIDGE_TOKEN"
 }
 EOF
 )


### PR DESCRIPTION
## Summary
- Inventoried every "Dev Tools"-style internal introspection tool in the plugin (Cache Monitor, Telemetry, the AI scaffold "Dev Tools", the Seeder, System Status/Operations Insights/Diagnostics hub, and the standalone MCP Bridge endpoint) and closed the gating gaps found:
  - **Cache Monitor**: `aips_cache_monitor_enabled` now defaults to `false` (was `true`), has a real "Enable Cache Monitor" checkbox in Developer Settings, and is now actually enforced by the menu registration, the Diagnostics tab, `render_page()`, and all 13 AJAX handlers (previously the option was only read for display — the AJAX endpoints were reachable regardless).
  - **Dev Tools** (AI scaffold generator): `ajax_generate_scaffold()` and `render_page()` now re-check `aips_developer_mode` — previously only the menu item/tab were gated, so the AJAX action was reachable directly even with the flag off.
  - **Seeder**: newly gated behind `aips_developer_mode` at the menu, Diagnostics tab, AJAX handler, and page render — previously unconditional (a fake-data generator has no place on a live site).
  - **MCP Bridge** (`mcp-bridge.php`): the highest-risk item found — a standalone, web-reachable JSON-RPC file with no CSRF protection and no disable flag, exposing DB export/repair, cron triggers, and full generation history to any `manage_options` session. It's now disabled by default and requires two constants defined in `wp-config.php` (not a UI checkbox, since a compromised admin session must not be able to self-enable it): `AIPS_MCP_BRIDGE_ENABLED` and a shared-secret `AIPS_MCP_BRIDGE_TOKEN`, checked before any tool executes. Docs and the example CLI clients (`scripts/mcp-client-example.{sh,py}`) updated accordingly.
- Left System Status, Operations Insights, and the Diagnostics hub shell as normal `manage_options`-gated admin pages — they provide real operational/repair value distinct from internals introspection.
- Telemetry was already correctly gated and default-off; used as the reference pattern for the fixes above.

## Verification
- [x] Manual trace of each flag through its full chain (menu → tab → render → AJAX) with `php -l` syntax checks on all touched files
- [ ] `composer test` not run per repo policy (not requested); added/updated `Test_AIPS_Admin_Menu.php` coverage for the new conditional registration of Seeder and Cache Monitor
- [x] Documentation updated (`docs/MCP_BRIDGE.md`, `CHANGELOG.md`)

## Risk Checklist
- [ ] Label `schema-change` — not applicable, no DB schema changes
- [x] Label `admin-ui` + `needs-browser-test` — admin menu/settings UI touched
- [x] Label `ajax-registry` — AJAX handlers touched (Cache Monitor, Dev Tools, Seeder)
- [ ] Label `cron` — not applicable
- [ ] Label `generation-pipeline` — not applicable
- [x] Label `security-sensitive` — feature-flag/capability gating and MCP Bridge auth touched
- [ ] Label duplicate-risk — not applicable

---
_Generated by [Claude Code](https://claude.ai/code/session_011yRUhXbxdfb4kMHT1avb9j)_