### PR TITLE
Fixed bug causing DIagnostics page to erroneously show DB tables were missing when they existed

### DIFF
--- a/ai-post-scheduler/includes/diagnostics/class-aips-system-diagnostics-environment-provider.php
+++ b/ai-post-scheduler/includes/diagnostics/class-aips-system-diagnostics-environment-provider.php
@@ -107,12 +107,14 @@ class AIPS_System_Diagnostics_Environment_Provider implements AIPS_System_Diagno
 	private function check_database() {
 		global $wpdb;
 
-		$tables  = AIPS_DB_Manager::get_expected_columns();
-		$results = array();
+		$tables          = AIPS_DB_Manager::get_expected_columns();
+		$database_tables = $wpdb->get_col( 'SHOW TABLES' );
+		$table_lookup    = array_fill_keys( array_map( 'strtolower', $database_tables ), true );
+		$results         = array();
 
 		foreach ( $tables as $table_name => $columns ) {
 			$full_table_name = $wpdb->prefix . $table_name;
-			$table_exists    = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $full_table_name ) ) === $full_table_name;
+			$table_exists    = isset( $table_lookup[ strtolower( $full_table_name ) ] );
 
 			if ( ! $table_exists ) {
 				$results[ $table_name ] = array(
@@ -124,7 +126,8 @@ class AIPS_System_Diagnostics_Environment_Provider implements AIPS_System_Diagno
 			}
 
 			$missing_columns = array();
-			$db_columns      = $wpdb->get_results( "SHOW COLUMNS FROM $full_table_name", ARRAY_A );
+			$escaped_table   = str_replace( '`', '``', $full_table_name );
+			$db_columns      = $wpdb->get_results( "SHOW COLUMNS FROM `{$escaped_table}`", ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$db_column_names = array_column( $db_columns, 'Field' );
 
 			foreach ( $columns as $col ) {


### PR DESCRIPTION

## Summary
- What changed?
- Why now?

## Verification
- [ ] `composer test` (or targeted tests) run for changed behavior
- [ ] Manual verification completed for changed admin/runtime paths
- [ ] Documentation updated (if behavior or workflow changed)

## Risk Checklist
- [ ] Label `schema-change` applied when DB schema/version is touched
- [ ] Label `admin-ui` + `needs-browser-test` applied when admin UI is touched
- [ ] Label `ajax-registry` applied when AJAX handlers/registry are touched
- [ ] Label `cron` applied when cron/queue/retry paths are touched
- [ ] Label `generation-pipeline` applied when prompt/generation flow is touched
- [ ] Label `security-sensitive` applied when auth/nonce/capability/data-safety paths are touched
- [ ] Label duplicate-risk applied and addressed before merge
