### PR TITLE
Fix Edit Schedule timezone bug and simplify weekly day picking

### DIFF
--- a/ai-post-scheduler/assets/js/admin.js
+++ b/ai-post-scheduler/assets/js/admin.js
@@ -270,6 +270,8 @@
             $(document).on('click', '.aips-run-now-schedule', this.runNowSchedule);
             $(document).on('click', '.aips-save-schedule', this.saveSchedule);
             $(document).on('click', '.aips-save-schedule-wizard', this.saveScheduleWizard);
+            $(document).on('change', '#schedule_frequency', this.onScheduleFrequencyChange);
+            $(document).on('click', '.aips-schedule-day-btn', this.onScheduleDayPick);
             $(document).on('click', '.aips-delete-schedule', this.deleteSchedule);
             $(document).on('change', '.aips-toggle-schedule', this.toggleSchedule);
             $(document).on('click', '.aips-view-schedule-history', this.viewScheduleHistory);
@@ -1401,6 +1403,67 @@
         },
 
         /**
+         * Reset the legacy modal's "Repeat on" day picker: hide it, clear the
+         * hidden day value, and un-highlight all day buttons.
+         */
+        resetScheduleDayPicker: function() {
+            $('#schedule_repeat_day').val('');
+            $('.aips-schedule-day-btn').removeClass('aips-btn-primary').addClass('aips-btn-secondary');
+            $('#aips-schedule-repeat-on-row').hide();
+        },
+
+        /**
+         * Apply a `frequency` value (as stored on a schedule row) to the legacy
+         * modal's Frequency select and "Repeat on" day picker.
+         *
+         * The Frequency dropdown no longer lists the 7 day-specific values
+         * (`every_monday` ... `every_sunday`) directly, so a day-specific
+         * frequency is presented as "Weekly" with the matching day pre-selected.
+         *
+         * @param {string} frequency
+         */
+        applyScheduleFrequencyToForm: function(frequency) {
+            var dayMatch = /^every_(monday|tuesday|wednesday|thursday|friday|saturday|sunday)$/.exec(frequency || '');
+            AIPS.resetScheduleDayPicker();
+            if (dayMatch) {
+                var day = dayMatch[1];
+                $('#schedule_frequency').val('weekly');
+                $('#schedule_repeat_day').val(day);
+                $('.aips-schedule-day-btn[data-day="' + day + '"]').removeClass('aips-btn-secondary').addClass('aips-btn-primary');
+                $('#aips-schedule-repeat-on-row').show();
+            } else {
+                $('#schedule_frequency').val(frequency);
+                $('#aips-schedule-repeat-on-row').toggle(frequency === 'weekly');
+            }
+        },
+
+        /**
+         * Show/hide the "Repeat on" day picker when the Frequency select changes.
+         *
+         * @param {Event} e - Change event from `#schedule_frequency`.
+         */
+        onScheduleFrequencyChange: function(e) {
+            if ($(this).val() === 'weekly') {
+                $('#aips-schedule-repeat-on-row').show();
+            } else {
+                AIPS.resetScheduleDayPicker();
+            }
+        },
+
+        /**
+         * Single-select a day-of-week button in the "Repeat on" picker.
+         *
+         * @param {Event} e - Click event from an `.aips-schedule-day-btn` element.
+         */
+        onScheduleDayPick: function(e) {
+            e.preventDefault();
+            var $btn = $(this);
+            $('.aips-schedule-day-btn').removeClass('aips-btn-primary').addClass('aips-btn-secondary');
+            $btn.removeClass('aips-btn-secondary').addClass('aips-btn-primary');
+            $('#schedule_repeat_day').val($btn.data('day'));
+        },
+
+        /**
          * Open the schedule wizard in "Add New" mode.
          *
          * Resets the wizard form, initialises the wizard to step 1, and shows
@@ -1416,6 +1479,7 @@
                 // Fallback to legacy modal if wizard not present
                 $('#aips-schedule-form')[0].reset();
                 $('#schedule_id').val('');
+                AIPS.resetScheduleDayPicker();
                 $('#aips-schedule-modal').find('.aips-modal-title').text('Add New Schedule');
                 $('#aips-schedule-modal').show();
                 return;
@@ -1454,18 +1518,14 @@
                 $('#schedule_id').val(scheduleId);
                 $('#schedule_title').val(scheduleTitle || '');
                 $('#schedule_template').val(templateId);
-                $('#schedule_frequency').val(frequency);
+                AIPS.applyScheduleFrequencyToForm(frequency);
                 $('#schedule_topic').val(topic || '');
                 $('#article_structure_id').val(articleStructureId || '');
                 $('#rotation_pattern').val(rotationPattern || '');
                 $('#schedule_is_active').prop('checked', isActive == 1);
                 if (nextRun) {
-                    var dt0 = AIPS.DateTime.parse(nextRun);
-                    if (dt0) {
-                        var pad0 = function(n) { return n < 10 ? '0' + n : n; };
-                        $('#schedule_start_time').val(dt0.getFullYear() + '-' + pad0(dt0.getMonth() + 1) + '-' + pad0(dt0.getDate()) +
-                            'T' + pad0(dt0.getHours()) + ':' + pad0(dt0.getMinutes()));
-                    }
+                    var offsetSeconds = (typeof aipsScheduleL10n !== 'undefined') ? aipsScheduleL10n.gmtOffsetSeconds : 0;
+                    $('#schedule_start_time').val(AIPS.DateTime.toLocalInputValue(nextRun, offsetSeconds));
                 }
                 $('#aips-schedule-modal').find('.aips-modal-title').text('Edit Schedule');
                 $('#aips-schedule-modal').show();
@@ -1525,7 +1585,7 @@
                 $('#schedule_id').val('');
                 $('#schedule_title').val(scheduleTitle || '');
                 $('#schedule_template').val(templateId);
-                $('#schedule_frequency').val(frequency);
+                AIPS.applyScheduleFrequencyToForm(frequency);
                 $('#schedule_topic').val(topic);
                 $('#article_structure_id').val(articleStructureId);
                 $('#rotation_pattern').val(rotationPattern);
@@ -1575,6 +1635,13 @@
 
             AIPS.Utilities.setButtonLoading($btn, aipsAdminL10n.saving);
 
+            // "Weekly" + a selected day maps to the day-specific backend frequency
+            // (e.g. 'every_monday') so the existing recurrence math is reused unchanged.
+            var repeatDay = $('#schedule_repeat_day').val();
+            var frequency = ($('#schedule_frequency').val() === 'weekly' && repeatDay)
+                ? 'every_' + repeatDay
+                : $('#schedule_frequency').val();
+
             $.ajax({
                 url: aipsAjax.ajaxUrl,
                 type: 'POST',
@@ -1584,7 +1651,7 @@
                     schedule_id: $('#schedule_id').val(),
                     schedule_title: $('#schedule_title').val(),
                     template_id: $('#schedule_template').val(),
-                    frequency: $('#schedule_frequency').val(),
+                    frequency: frequency,
                     start_time: $('#schedule_start_time').val(),
                     topic: $('#schedule_topic').val(),
                     article_structure_id: $('#article_structure_id').val(),

--- a/ai-post-scheduler/assets/js/datetime.js
+++ b/ai-post-scheduler/assets/js/datetime.js
@@ -76,6 +76,28 @@
 		},
 
 		/**
+		 * Format a UTC instant as a 'YYYY-MM-DDTHH:MM' string for a `datetime-local`
+		 * input, shifted by an explicit UTC offset rather than the browser's own
+		 * timezone. Use this to seed a datetime-local field with the WordPress site's
+		 * local time (e.g. from `aipsScheduleL10n.gmtOffsetSeconds`), so the value is
+		 * correct regardless of what timezone the admin's browser happens to be in.
+		 *
+		 * @param {*} value Anything accepted by parse() (Unix seconds, MySQL/ISO string, Date).
+		 * @param {number} offsetSeconds UTC offset in seconds (may be negative).
+		 * @return {string} 'YYYY-MM-DDTHH:MM', or '' when value cannot be parsed.
+		 */
+		toLocalInputValue: function(value, offsetSeconds) {
+			var d = this.parse(value);
+			if (!d) {
+				return '';
+			}
+			var shifted = new Date(d.getTime() + (offsetSeconds || 0) * 1000);
+			var pad = function(n) { return n < 10 ? '0' + n : n; };
+			return shifted.getUTCFullYear() + '-' + pad(shifted.getUTCMonth() + 1) + '-' + pad(shifted.getUTCDate()) +
+				'T' + pad(shifted.getUTCHours()) + ':' + pad(shifted.getUTCMinutes());
+		},
+
+		/**
 		 * Return the Intl locale string for date/time formatting.
 		 *
 		 * Reads `locale` from the provided l10n object, then from the global

--- a/ai-post-scheduler/includes/class-aips-admin-assets.php
+++ b/ai-post-scheduler/includes/class-aips-admin-assets.php
@@ -862,6 +862,10 @@ class AIPS_Admin_Assets {
      */
     private function enqueue_schedule_assets($hook) {
             wp_localize_script('aips-admin-script', 'aipsScheduleL10n', array(
+                // Current WordPress site UTC offset in seconds, used to render/parse the
+                // "Start Time" datetime-local field in site-local time regardless of the
+                // admin's own browser timezone.
+                'gmtOffsetSeconds'                => (int) wp_timezone()->getOffset(new DateTime('now', wp_timezone())),
                 // Run schedule
                 'runScheduleConfirm'             => __('Are you sure you want to run this schedule now? This will immediately generate posts.', 'ai-post-scheduler'),
                 'scheduleRunning'                => __('Running...', 'ai-post-scheduler'),

--- a/ai-post-scheduler/includes/class-aips-date-time.php
+++ b/ai-post-scheduler/includes/class-aips-date-time.php
@@ -137,6 +137,35 @@ class AIPS_DateTime extends DateTimeImmutable {
 	}
 
 	/**
+	 * Parse a naive "wall clock" string as the WordPress site timezone.
+	 *
+	 * Use this for user-entered local date/time input (e.g. a `datetime-local`
+	 * form field) where the string has no timezone information of its own but
+	 * is understood to represent the site's local time — matching how
+	 * {@see toDisplay()} renders timestamps back out. Accepts both the
+	 * `datetime-local` format ('Y-m-d\TH:i') and MySQL-style ('Y-m-d H:i:s').
+	 *
+	 * @param string $datetime Naive local datetime string.
+	 * @return static
+	 * @throws \InvalidArgumentException If the string cannot be parsed.
+	 */
+	public static function fromSiteLocal( string $datetime ): static {
+		$normalized = str_replace( 'T', ' ', trim( $datetime ) );
+		$tz         = self::site_timezone_static();
+
+		foreach ( array( 'Y-m-d H:i:s', 'Y-m-d H:i' ) as $format ) {
+			$dt = parent::createFromFormat( $format, $normalized, $tz );
+			if ( $dt !== false ) {
+				return new static( $dt->format( 'Y-m-d H:i:s' ), $tz );
+			}
+		}
+
+		throw new \InvalidArgumentException(
+			sprintf( 'Cannot parse local datetime: %s', $datetime )
+		);
+	}
+
+	/**
 	 * Format a mixed date input as relative (if within 24h) or absolute time.
 	 *
 	 * Accepts numeric timestamps, MySQL datetime strings, or null. Converts to
@@ -478,6 +507,15 @@ class AIPS_DateTime extends DateTimeImmutable {
 	 * @return DateTimeZone
 	 */
 	private function site_timezone(): DateTimeZone {
+		return self::site_timezone_static();
+	}
+
+	/**
+	 * Get the WordPress site timezone (static form, usable from factory methods).
+	 *
+	 * @return DateTimeZone
+	 */
+	private static function site_timezone_static(): DateTimeZone {
 		if ( function_exists( 'wp_timezone' ) ) {
 			return wp_timezone();
 		}

--- a/ai-post-scheduler/includes/class-aips-scheduler.php
+++ b/ai-post-scheduler/includes/class-aips-scheduler.php
@@ -175,9 +175,13 @@ class AIPS_Scheduler implements AIPS_Cron_Generation_Handler {
 					: '';
 
 				// Parse start_time from datetime-local input (YYYY-MM-DDTHH:MM) or fallback to now.
+				// The input has no timezone of its own; treat it as the WordPress site
+				// timezone (matching how it is displayed elsewhere) rather than PHP's
+				// ambient runtime timezone, which may not match the site's configured one.
 				if (!empty($start_time_raw)) {
-					$start_timestamp = (int) strtotime($start_time_raw);
-					if ($start_timestamp <= 0) {
+					try {
+						$start_timestamp = AIPS_DateTime::fromSiteLocal($start_time_raw)->toUtc()->timestamp();
+					} catch (\InvalidArgumentException $e) {
 						$start_timestamp = AIPS_DateTime::now()->timestamp();
 					}
 				} else {

--- a/ai-post-scheduler/templates/admin/schedule.php
+++ b/ai-post-scheduler/templates/admin/schedule.php
@@ -547,11 +547,73 @@ if (!function_exists('aips_datetime_from_db_value')) {
 						uasort($cron_schedules_list, function ($a, $b) {
 							return $a['interval'] - $b['interval'];
 						});
+
+						// The 7 single-day frequencies (every_monday ... every_sunday) are chosen
+						// via the "Repeat On" day picker below instead of being listed here
+						// individually — that used to mean scanning past 7 near-duplicate entries
+						// to find e.g. "Every Monday".
+						$day_specific_keys = array_map(function ($day) {
+							return 'every_' . strtolower($day);
+						}, array('Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'));
+
+						$frequency_groups = array(
+							'hourly'  => array('label' => __('Hourly', 'ai-post-scheduler'), 'options' => array()),
+							'daily'   => array('label' => __('Daily', 'ai-post-scheduler'), 'options' => array()),
+							'weekly'  => array('label' => __('Weekly', 'ai-post-scheduler'), 'options' => array()),
+							'monthly' => array('label' => __('Monthly', 'ai-post-scheduler'), 'options' => array()),
+							'once'    => array('label' => __('One-Time', 'ai-post-scheduler'), 'options' => array()),
+						);
+
 						foreach ($cron_schedules_list as $key => $schedule) {
-							echo '<option value="' . esc_attr($key) . '" ' . selected('daily', $key, false) . '>' . esc_html($schedule['display']) . '</option>';
+							if (in_array($key, $day_specific_keys, true)) {
+								continue;
+							}
+							if ('once' === $key) {
+								$group_key = 'once';
+							} elseif ($schedule['interval'] < DAY_IN_SECONDS) {
+								$group_key = 'hourly';
+							} elseif ($schedule['interval'] === DAY_IN_SECONDS) {
+								$group_key = 'daily';
+							} elseif ($schedule['interval'] <= 2 * WEEK_IN_SECONDS) {
+								$group_key = 'weekly';
+							} else {
+								$group_key = 'monthly';
+							}
+							$frequency_groups[$group_key]['options'][$key] = $schedule['display'];
+						}
+
+						foreach ($frequency_groups as $group) {
+							if (empty($group['options'])) {
+								continue;
+							}
+							echo '<optgroup label="' . esc_attr($group['label']) . '">';
+							foreach ($group['options'] as $key => $display) {
+								echo '<option value="' . esc_attr($key) . '" ' . selected('daily', $key, false) . '>' . esc_html($display) . '</option>';
+							}
+							echo '</optgroup>';
 						}
 						?>
 					</select>
+				</div>
+				<div class="aips-form-row" id="aips-schedule-repeat-on-row" style="display:none;">
+					<label><?php esc_html_e('Repeat On', 'ai-post-scheduler'); ?></label>
+					<input type="hidden" id="schedule_repeat_day" name="repeat_day" value="">
+					<div class="aips-btn-group" role="group" aria-label="<?php esc_attr_e('Day of week', 'ai-post-scheduler'); ?>">
+						<?php
+						$day_picker_labels = array(
+							'monday'    => __('Mon', 'ai-post-scheduler'),
+							'tuesday'   => __('Tue', 'ai-post-scheduler'),
+							'wednesday' => __('Wed', 'ai-post-scheduler'),
+							'thursday'  => __('Thu', 'ai-post-scheduler'),
+							'friday'    => __('Fri', 'ai-post-scheduler'),
+							'saturday'  => __('Sat', 'ai-post-scheduler'),
+							'sunday'    => __('Sun', 'ai-post-scheduler'),
+						);
+						foreach ($day_picker_labels as $day_key => $day_label): ?>
+						<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-schedule-day-btn" data-day="<?php echo esc_attr($day_key); ?>"><?php echo esc_html($day_label); ?></button>
+						<?php endforeach; ?>
+					</div>
+					<p class="description"><?php esc_html_e('Choose which day of the week this schedule should run on.', 'ai-post-scheduler'); ?></p>
 				</div>
 				<div class="aips-form-row">
 					<label for="schedule_start_time"><?php esc_html_e('Start Time', 'ai-post-scheduler'); ?></label>

--- a/ai-post-scheduler/tests/Test_AIPS_Date_Time.php
+++ b/ai-post-scheduler/tests/Test_AIPS_Date_Time.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Tests for AIPS_DateTime::fromSiteLocal().
+ *
+ * @package AI_Post_Scheduler
+ */
+
+class Test_AIPS_Date_Time extends WP_UnitTestCase {
+
+	private $original_timezone_string;
+	private $original_gmt_offset;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->original_timezone_string = get_option( 'timezone_string' );
+		$this->original_gmt_offset      = get_option( 'gmt_offset' );
+	}
+
+	public function tearDown(): void {
+		update_option( 'timezone_string', $this->original_timezone_string );
+		update_option( 'gmt_offset', $this->original_gmt_offset );
+
+		parent::tearDown();
+	}
+
+	public function test_from_site_local_interprets_naive_datetime_local_string_in_site_timezone() {
+		update_option( 'timezone_string', 'America/New_York' );
+
+		// 2026-03-20 09:00 in America/New_York (EDT, UTC-4 after the March DST change).
+		$dt = AIPS_DateTime::fromSiteLocal( '2026-03-20T09:00' );
+
+		$this->assertSame( '2026-03-20 13:00:00', $dt->toUtc()->toMysql() );
+	}
+
+	public function test_from_site_local_accepts_mysql_style_string_with_seconds() {
+		update_option( 'timezone_string', 'America/New_York' );
+
+		$dt = AIPS_DateTime::fromSiteLocal( '2026-03-20 09:00:00' );
+
+		$this->assertSame( '2026-03-20 13:00:00', $dt->toUtc()->toMysql() );
+	}
+
+	public function test_from_site_local_round_trips_back_to_display_time() {
+		update_option( 'timezone_string', 'America/New_York' );
+
+		$utc_timestamp = AIPS_DateTime::fromSiteLocal( '2026-03-20T09:00' )->toUtc()->timestamp();
+
+		$this->assertSame(
+			'2026-03-20 09:00',
+			AIPS_DateTime::fromTimestamp( $utc_timestamp )->toDisplay( 'Y-m-d H:i' )
+		);
+	}
+
+	public function test_from_site_local_throws_on_unparseable_input() {
+		$this->expectException( \InvalidArgumentException::class );
+
+		AIPS_DateTime::fromSiteLocal( 'not-a-date' );
+	}
+}

--- a/ai-post-scheduler/tests/Test_AIPS_Scheduler_Save.php
+++ b/ai-post-scheduler/tests/Test_AIPS_Scheduler_Save.php
@@ -96,4 +96,34 @@ class Test_AIPS_Scheduler_Save extends WP_UnitTestCase {
 
 		$this->assertSame( 77, $updated_id );
 	}
+
+	public function test_save_schedule_interprets_start_time_in_site_timezone_not_php_default() {
+		$original_timezone_string = get_option( 'timezone_string' );
+		update_option( 'timezone_string', 'America/New_York' );
+
+		$this->repository->expects( $this->once() )
+			->method( 'create' )
+			->with(
+				$this->callback(
+					function ( $data ) {
+						// 2026-03-20T09:00 in America/New_York (EDT, UTC-4) is 13:00 UTC.
+						$expected_utc = AIPS_DateTime::fromMysql( '2026-03-20 13:00:00' )->timestamp();
+						return isset( $data['next_run'] ) && $expected_utc === (int) $data['next_run'];
+					}
+				)
+			)
+			->willReturn( 42 );
+
+		$this->scheduler->save_schedule(
+			array(
+				'template_id' => 15,
+				'frequency'   => 'daily',
+				'start_time'  => '2026-03-20T09:00',
+				'is_active'   => 1,
+				'topic'       => 'Timezone-sensitive schedule',
+			)
+		);
+
+		update_option( 'timezone_string', $original_timezone_string );
+	}
 }


### PR DESCRIPTION
## Summary
- Fixed the "Edit Schedule" modal saving the wrong `next_run` date/time: `AIPS_Scheduler::save_schedule()` parsed the `datetime-local` "Start Time" field with plain `strtotime()`, which resolves in PHP's ambient runtime timezone rather than the WordPress site's configured timezone (used everywhere else the value is displayed, e.g. the "Next Run" column via `date_i18n()`). Added `AIPS_DateTime::fromSiteLocal()` to parse the naive input explicitly in `wp_timezone()` and convert to UTC for storage. Also fixed the companion JS bug where reopening the modal to edit a schedule repopulated Start Time using the *browser's* local timezone instead of the site's — added `AIPS.DateTime.toLocalInputValue()` driven by a new server-localized `aipsScheduleL10n.gmtOffsetSeconds` value.
- Simplified weekly/day-of-week scheduling: the Frequency dropdown used to flatten 7 near-duplicate "Every Monday" … "Every Sunday" entries in with Hourly/Daily/Monthly/etc, all sharing the same interval length and no clear sort order. These are now grouped with `<optgroup>`s (Hourly/Daily/Weekly/Monthly/One-Time) and the 7 day-specific entries are replaced by a "Repeat On" day-of-week button picker that only appears when "Weekly" is selected. The existing `every_<day>` backend frequency values and `AIPS_Interval_Calculator` recurrence math are reused unchanged — this is a presentation-only change with no DB schema or backend logic changes.
- Why now: reported bug where saving a schedule's start date/interval didn't persist the intended date, plus a UX complaint that scheduling "every Monday"-style recurrence was cumbersome to find in the dropdown.

## Verification
- [x] Targeted tests added/updated for changed behavior: `tests/Test_AIPS_Date_Time.php` (new — covers `AIPS_DateTime::fromSiteLocal()` DST-correct parsing/round-trip) and `tests/Test_AIPS_Scheduler_Save.php` (added a test asserting `save_schedule()` interprets `start_time` in the site timezone, not PHP's default). **Not executed** — no WP test environment / Docker daemon available in this sandbox session; `php -l` and `node --check` were run on all touched files instead. Please run `composer test -- --filter Test_AIPS_Date_Time` and `--filter Test_AIPS_Scheduler_Save` before merge.
- [ ] Manual verification completed for changed admin/runtime paths — not yet done in a live WP admin (no browser environment in this session); needs a manual pass on the Schedules page (edit an existing schedule, confirm Start Time round-trips correctly; select Weekly + a day, save, reopen, confirm it re-shows correctly).
- [ ] Documentation updated (if behavior or workflow changed) — no user-facing docs currently describe this modal's fields, so none touched.

## Risk Checklist
- [ ] Label `schema-change` — not applicable, no DB schema changes.
- [x] Label `admin-ui` + `needs-browser-test` applied when admin UI is touched — this PR touches `templates/admin/schedule.php` and `assets/js/admin.js`.
- [ ] Label `ajax-registry` — not applicable, no AJAX registry changes (existing `aips_save_schedule` handler/payload shape unchanged, just the `frequency` value it receives).
- [ ] Label `cron` — not applicable, `AIPS_Interval_Calculator` recurrence math is unchanged.
- [ ] Label `generation-pipeline` — not applicable.
- [ ] Label `security-sensitive` — not applicable, no auth/nonce/capability changes.
- [ ] Label duplicate-risk — not checked against other open PRs.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LHcvyV7VtqDzcbhJgMAf88)_