### PR TITLE
Add Post Generated notification type

### DIFF
--- a/ai-post-scheduler/includes/class-aips-config.php
+++ b/ai-post-scheduler/includes/class-aips-config.php
@@ -154,6 +154,7 @@ class AIPS_Config {
 				'post_ready_for_review' => 'db',
 				'post_rejected' => 'db',
 				'partial_generation_completed' => 'db',
+				'post_generated' => 'both',
             ),
             // Notification digest state (runtime markers, not user-configurable)
             'aips_notif_daily_digest_last_sent' => '',

--- a/ai-post-scheduler/includes/class-aips-notification-registry.php
+++ b/ai-post-scheduler/includes/class-aips-notification-registry.php
@@ -123,6 +123,13 @@ class AIPS_Notification_Registry {
 				'level'         => 'warning',
 				'dedupe_window' => 60,
 			),
+			'post_generated' => array(
+				'label'         => __('Post Generated', 'ai-post-scheduler'),
+				'description'   => __('A new post finished generating (from a template, author topic, planner, or trending-topic run).', 'ai-post-scheduler'),
+				'default_mode'  => self::MODE_BOTH,
+				'level'         => 'info',
+				'dedupe_window' => 60,
+			),
 			'daily_digest' => array(
 				'label'         => __('Daily Digest', 'ai-post-scheduler'),
 				'description'   => __('Daily summary of generation and review activity.', 'ai-post-scheduler'),

--- a/ai-post-scheduler/includes/class-aips-notification-senders.php
+++ b/ai-post-scheduler/includes/class-aips-notification-senders.php
@@ -420,20 +420,29 @@ class AIPS_Notification_Senders {
 		$post_status       = !empty($payload['post_status']) ? $payload['post_status'] : '';
 		$post_status_label = !empty($payload['post_status_label']) ? $payload['post_status_label'] : __('Unknown', 'ai-post-scheduler');
 
-		$title   = sprintf(__('Post generated: %s', 'ai-post-scheduler'), $post_title);
+		$title   = $post_title;
 		$message = sprintf(
-			/* translators: 1: source label (Template/Author) 2: post title 3: post status label */
-			__('%1$s generated post "%2$s" (%3$s).', 'ai-post-scheduler'),
+			/* translators: 1: source label (Template/Author) 2: post status label */
+			__('%1$s — %2$s', 'ai-post-scheduler'),
 			$source_label,
-			$post_title,
 			$post_status_label
 		);
 
 		$edit_url = $post_id ? esc_url_raw(get_edit_post_link($post_id, 'raw')) : '';
-		$view_url = '';
-		if ($post) {
-			$view_url = ('publish' === $post_status) ? get_permalink($post_id) : get_preview_post_link($post);
-			$view_url = $view_url ? esc_url_raw($view_url) : '';
+
+		// Preview links carry a nonce tied to the current user/session at creation
+		// time. Post generation is frequently unauthenticated (cron/scheduled/bulk
+		// jobs), and even when it isn't, this URL is consumed later — by whoever
+		// opens the email — not synchronously by its creator. A baked-in preview
+		// nonce will not validate for that later viewer, so non-published posts
+		// route to the edit screen instead, where a fresh Preview button is
+		// generated for whoever is actually looking at it.
+		$view_url = $edit_url;
+		if ($post && 'publish' === $post_status) {
+			$permalink = get_permalink($post_id);
+			if ($permalink) {
+				$view_url = esc_url_raw($permalink);
+			}
 		}
 
 		$post_excerpt = $post && !empty($post->post_excerpt)

--- a/ai-post-scheduler/includes/class-aips-notification-senders.php
+++ b/ai-post-scheduler/includes/class-aips-notification-senders.php
@@ -403,6 +403,87 @@ class AIPS_Notification_Senders {
 	}
 
 	/**
+	 * Send a post-generated notification.
+	 *
+	 * Fires unconditionally for every successfully generated post, unlike
+	 * manual_generation_completed/post_ready_for_review which are conditional
+	 * on creation method / post status.
+	 *
+	 * @param array $payload Notification payload.
+	 * @return void
+	 */
+	public function post_generated( array $payload ) {
+		$post_id           = !empty($payload['post_id']) ? absint($payload['post_id']) : 0;
+		$post              = $post_id ? get_post($post_id) : null;
+		$post_title        = ($post && !empty($post->post_title)) ? $post->post_title : __('Untitled', 'ai-post-scheduler');
+		$source_label      = !empty($payload['source_label']) ? $payload['source_label'] : __('Unknown', 'ai-post-scheduler');
+		$post_status       = !empty($payload['post_status']) ? $payload['post_status'] : '';
+		$post_status_label = !empty($payload['post_status_label']) ? $payload['post_status_label'] : __('Unknown', 'ai-post-scheduler');
+
+		$title   = sprintf(__('Post generated: %s', 'ai-post-scheduler'), $post_title);
+		$message = sprintf(
+			/* translators: 1: source label (Template/Author) 2: post title 3: post status label */
+			__('%1$s generated post "%2$s" (%3$s).', 'ai-post-scheduler'),
+			$source_label,
+			$post_title,
+			$post_status_label
+		);
+
+		$edit_url = $post_id ? esc_url_raw(get_edit_post_link($post_id, 'raw')) : '';
+		$view_url = '';
+		if ($post) {
+			$view_url = ('publish' === $post_status) ? get_permalink($post_id) : get_preview_post_link($post);
+			$view_url = $view_url ? esc_url_raw($view_url) : '';
+		}
+
+		$post_excerpt = $post && !empty($post->post_excerpt)
+			? $post->post_excerpt
+			: ($post ? wp_trim_words(wp_strip_all_tags($post->post_content), 55) : '');
+
+		$post_content_html = $post ? wp_kses_post($post->post_content) : '';
+
+		$featured_image_row = '';
+		if ($post_id) {
+			$thumbnail_id = get_post_thumbnail_id($post_id);
+			if ($thumbnail_id) {
+				$image_url = get_the_post_thumbnail_url($post_id, 'large');
+				if ($image_url) {
+					$featured_image_row = '<tr><td style="padding:0;">'
+						. '<img src="' . esc_url($image_url) . '" alt="' . esc_attr($post_title) . '" style="width:100%;max-width:640px;height:auto;display:block;" />'
+						. '</td></tr>';
+				}
+			}
+		}
+
+		$vars = array(
+			'{{site_name}}'          => esc_html(get_bloginfo('name')),
+			'{{source_label}}'       => esc_html($source_label),
+			'{{post_status_label}}'  => esc_html($post_status_label),
+			'{{post_title}}'         => esc_html($post_title),
+			'{{post_excerpt}}'       => esc_html($post_excerpt),
+			'{{post_content}}'       => $post_content_html,
+			'{{featured_image_row}}' => $featured_image_row,
+			'{{edit_url}}'           => esc_url($edit_url),
+			'{{view_url}}'           => esc_url($view_url),
+		);
+
+		call_user_func(
+			$this->dispatcher,
+			'post_generated',
+			array(
+				'title'         => $title,
+				'message'       => $message,
+				'url'           => $edit_url,
+				'level'         => 'info',
+				'meta'          => $payload,
+				'dedupe_key'    => !empty($payload['dedupe_key'])    ? $payload['dedupe_key']          : ('post_generated_' . $post_id),
+				'dedupe_window' => !empty($payload['dedupe_window']) ? (int) $payload['dedupe_window'] : 60,
+				'vars'          => $vars,
+			)
+		);
+	}
+
+	/**
 	 * Send a daily digest summary notification.
 	 *
 	 * @param array $payload Summary payload.

--- a/ai-post-scheduler/includes/class-aips-notification-templates.php
+++ b/ai-post-scheduler/includes/class-aips-notification-templates.php
@@ -114,6 +114,7 @@ class AIPS_Notification_Templates {
 		$this->register($this->build_standard_event_template('post_ready_for_review', __('Post Ready For Review', 'ai-post-scheduler'), '#2271b1'));
 		$this->register($this->build_standard_event_template('post_rejected', __('Post Rejected', 'ai-post-scheduler'), '#dba617'));
 		$this->register($this->build_standard_event_template('partial_generation_completed', __('Partial Generation Completed', 'ai-post-scheduler'), '#dba617'));
+		$this->register($this->build_post_generated_template());
 		$this->register($this->build_standard_event_template('daily_digest', __('Daily Digest', 'ai-post-scheduler'), '#2271b1'));
 		$this->register($this->build_standard_event_template('weekly_summary', __('Weekly Summary', 'ai-post-scheduler'), '#2271b1'));
 		$this->register($this->build_standard_event_template('monthly_report', __('Monthly Report', 'ai-post-scheduler'), '#2271b1'));
@@ -178,6 +179,51 @@ class AIPS_Notification_Templates {
 
 		return new AIPS_Notification_Template(
 			$type,
+			$subject,
+			$body,
+			$header_title,
+			$header_color
+		);
+	}
+
+	/**
+	 * Build the "Post Generated" email template.
+	 *
+	 * Uses a bespoke body (not build_standard_event_template()'s generic alert
+	 * box) so it can present the full generated post as an email-safe HTML
+	 * table: title, featured image (if any), excerpt, content, source/status,
+	 * and edit/view links.
+	 *
+	 * @return AIPS_Notification_Template
+	 */
+	private function build_post_generated_template() {
+		$header_title = __('Post Generated', 'ai-post-scheduler');
+		$header_color = '#2271b1';
+		$subject      = '[{{site_name}}] ' . __('Post Generated', 'ai-post-scheduler') . ' — {{source_label}} — {{post_status_label}}';
+
+		$body_content =
+			'<p>' . esc_html__('AI Post Scheduler generated a new post:', 'ai-post-scheduler') . '</p>'
+			. '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border:1px solid #ddd;border-radius:4px;overflow:hidden;margin:20px 0;border-collapse:collapse;">'
+			. '<tr><td style="background:#2271b1;color:#ffffff;padding:14px 18px;font-size:18px;font-weight:bold;">{{post_title}}</td></tr>'
+			. '{{featured_image_row}}'
+			. '<tr><td style="padding:14px 18px;border-top:1px solid #eee;">'
+			. '<strong style="display:block;margin-bottom:6px;color:#1d2327;">' . esc_html__('Excerpt', 'ai-post-scheduler') . '</strong>'
+			. '<div style="color:#3c434a;">{{post_excerpt}}</div></td></tr>'
+			. '<tr><td style="padding:14px 18px;border-top:1px solid #eee;">'
+			. '<strong style="display:block;margin-bottom:6px;color:#1d2327;">' . esc_html__('Content', 'ai-post-scheduler') . '</strong>'
+			. '<div style="color:#3c434a;line-height:1.6;">{{post_content}}</div></td></tr>'
+			. '<tr><td style="padding:12px 18px;border-top:1px solid #eee;background:#f9f9f9;font-size:13px;color:#646970;">'
+			. '<strong>{{source_label}}</strong> &middot; <strong>{{post_status_label}}</strong></td></tr>'
+			. '</table>'
+			. '<p class="button-center">'
+			. '<a href="{{edit_url}}" class="button">' . esc_html__('Edit Post', 'ai-post-scheduler') . '</a>'
+			. '<a href="{{view_url}}" class="button button-secondary">' . esc_html__('View Post', 'ai-post-scheduler') . '</a>'
+			. '</p>';
+
+		$body = $this->render_layout($header_title, $header_color, $body_content);
+
+		return new AIPS_Notification_Template(
+			'post_generated',
 			$subject,
 			$body,
 			$header_title,

--- a/ai-post-scheduler/includes/class-aips-notifications-event-handler.php
+++ b/ai-post-scheduler/includes/class-aips-notifications-event-handler.php
@@ -357,6 +357,16 @@ class AIPS_Notifications_Event_Handler {
 		$post = get_post($post_id);
 		$post_status = ($post && !empty($post->post_status)) ? $post->post_status : '';
 
+		$this->notifications->post_generated(array(
+			'post_id'           => $post_id,
+			'history_id'        => absint($history_id),
+			'source_label'      => $this->get_source_label($context),
+			'post_status'       => $post_status,
+			'post_status_label' => $this->format_post_status_label($post_status),
+			'dedupe_key'        => 'post_generated_' . $post_id,
+			'dedupe_window'     => 60,
+		));
+
 		if ('manual' === $creation_method) {
 			$this->notifications->manual_generation_completed(array(
 				'post_id'       => $post_id,
@@ -666,6 +676,17 @@ class AIPS_Notifications_Event_Handler {
 		}
 
 		return __('Unknown', 'ai-post-scheduler');
+	}
+
+	/**
+	 * Return a human-readable label for a WordPress post status slug.
+	 *
+	 * @param string $post_status Post status slug.
+	 * @return string
+	 */
+	private function format_post_status_label($post_status) {
+		$status_object = get_post_status_object($post_status);
+		return ($status_object && !empty($status_object->label)) ? $status_object->label : ucfirst(str_replace('_', ' ', (string) $post_status));
 	}
 
 	/**

--- a/ai-post-scheduler/includes/class-aips-notifications.php
+++ b/ai-post-scheduler/includes/class-aips-notifications.php
@@ -326,6 +326,16 @@ class AIPS_Notifications {
 	}
 
 	/**
+	 * Send a post-generated notification.
+	 *
+	 * @param array $payload Notification payload.
+	 * @return void
+	 */
+	public function post_generated(array $payload) {
+		$this->senders->post_generated($payload);
+	}
+
+	/**
 	 * Send a daily digest summary notification.
 	 *
 	 * @param array $payload Summary payload.


### PR DESCRIPTION
## Summary
- Add a new `post_generated` notification type that fires unconditionally on every successful post generation (manual, scheduled template, author-topic, planner, and trending-topic runs), configurable as DB / Email / Both like every other notification type via the existing registry-driven Settings → Notifications UI (defaults to DB + Email).
- **DB notification**: short entry with the source (Template or Author), post title, and post status.
- **Email notification**: subject includes the source and post status; body is an email-client-safe HTML table (inline-styled) with the post title, featured image (if one was generated), excerpt, full content, source/status, and Edit Post / View Post links.
- Why now: there was no notification that fired for every generated post regardless of source or status — the closest existing types (`manual_generation_completed`, `post_ready_for_review`) are conditional and only carry short text, not the full generated post. This is additive; it fires alongside those existing types, not instead of them.

Changed files:
- `includes/class-aips-notification-registry.php` — new `post_generated` registry entry.
- `includes/class-aips-config.php` — new default preference (`'both'`).
- `includes/class-aips-notifications-event-handler.php` — unconditional dispatch in `handle_post_generated_notification()` + new `format_post_status_label()` helper.
- `includes/class-aips-notification-senders.php` — new `post_generated()` sender that builds the DB message and the email template vars (excerpt, content, featured image row, edit/view URLs).
- `includes/class-aips-notifications.php` — new `post_generated()` proxy method.
- `includes/class-aips-notification-templates.php` — new bespoke `build_post_generated_template()` email template.

No DB schema change (uses the existing `wp_aips_notifications.meta` column), no admin template changes (the Settings UI is generated automatically from the registry), no JS changes.

## Verification
- [x] `php -l` run on all six changed files — no syntax errors.
- [ ] `composer test` (or targeted tests) run for changed behavior — not run per repo testing policy (not explicitly requested); no existing notification test suite was found to extend.
- [ ] Manual verification completed for changed admin/runtime paths — not run in this session (no live WP/Docker environment available); recommend verifying in `make shell`/Docker: confirm the new "Post Generated" row appears in Settings → Notifications, trigger a manual generation, and confirm both the DB notification row and the email (subject/body/links) render as expected.
- [ ] Documentation updated (if behavior or workflow changed) — no user-facing docs beyond the in-app Settings UI, which is auto-generated.

## Risk Checklist
- [ ] Label `schema-change` applied when DB schema/version is touched — N/A, no schema change.
- [ ] Label `admin-ui` + `needs-browser-test` applied when admin UI is touched — N/A, no template changes (Settings row is auto-generated from the registry).
- [ ] Label `ajax-registry` applied when AJAX handlers/registry are touched — N/A.
- [ ] Label `cron` applied when cron/queue/retry paths are touched — N/A, hooks into the existing `aips_post_generated` action, no new cron/queue logic.
- [ ] Label `generation-pipeline` applied when prompt/generation flow is touched — N/A, only consumes the existing post-generation hook; no changes to generation/prompt logic.
- [ ] Label `security-sensitive` applied when auth/nonce/capability/data-safety paths are touched — N/A, no AJAX/auth paths touched; email/DB content is escaped (`esc_html`/`esc_url`/`wp_kses_post`) consistent with existing notification senders.
- [ ] Label duplicate-risk applied and addressed before merge — please confirm no overlapping in-flight PR adds a similar per-post notification type.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tg99ZoGSeZ9VGcv6hDLLq5)_