### PR TITLE
Fixed missing is_available() cache driver method

### DIFF
--- a/ai-post-scheduler/includes/class-aips-cache-array-driver.php
+++ b/ai-post-scheduler/includes/class-aips-cache-array-driver.php
@@ -32,6 +32,10 @@ class AIPS_Cache_Array_Driver implements AIPS_Cache_Driver, AIPS_Cache_Monitorab
 	 */
 	private $expiries = array();
 
+	public function is_available() {
+		return true;
+	}
+
 	/**
 	 * {@inheritdoc}
 	 */

--- a/ai-post-scheduler/includes/class-aips-cache-db-driver.php
+++ b/ai-post-scheduler/includes/class-aips-cache-db-driver.php
@@ -36,6 +36,10 @@ class AIPS_Cache_Db_Driver implements AIPS_Cache_Driver, AIPS_Cache_Monitorable_
 		$this->prefix = (string) $prefix;
 	}
 
+	public function is_available() {
+		return true;
+	}
+
 	/**
 	 * {@inheritdoc}
 	 */

--- a/ai-post-scheduler/includes/class-aips-cache-wp-object-cache-driver.php
+++ b/ai-post-scheduler/includes/class-aips-cache-wp-object-cache-driver.php
@@ -70,6 +70,10 @@ class AIPS_Cache_Wp_Object_Cache_Driver implements AIPS_Cache_Driver, AIPS_Cache
 		$this->generation = ( false !== $stored && is_int( $stored ) ) ? $stored : 0;
 	}
 
+	public function is_available() {
+		return true;
+	}
+
 	// -----------------------------------------------------------------------
 	// AIPS_Cache_Driver implementation
 	// -----------------------------------------------------------------------

--- a/ai-post-scheduler/includes/class-aips-cache.php
+++ b/ai-post-scheduler/includes/class-aips-cache.php
@@ -540,6 +540,15 @@ class AIPS_Cache {
 	// -----------------------------------------------------------------------
 
 	/**
+	 * Check whether the cache system and underlying driver are available.
+	 *
+	 * @return bool True when caching is enabled and the driver is available.
+	 */
+	public function is_available() {
+		return self::is_system_enabled() && $this->driver->is_available();
+	}
+
+	/**
 	 * Return the underlying driver instance.
 	 *
 	 * @return AIPS_Cache_Driver

--- a/ai-post-scheduler/includes/interface-aips-cache-driver.php
+++ b/ai-post-scheduler/includes/interface-aips-cache-driver.php
@@ -61,4 +61,11 @@ interface AIPS_Cache_Driver {
 	 * @return bool True if the key exists and is valid.
 	 */
 	public function has( $key, $group = 'default' );
+
+	/**
+	 * Check whether the cache driver is available for use.
+	 *
+	 * @return bool True if the cache driver is available, false otherwise.
+	 */
+	public function is_available();
 }


### PR DESCRIPTION
## Summary
- What changed?
- Why now?

## Verification
- [ ] `composer test` (or targeted tests) run for changed behavior
- [ ] Manual verification completed for changed admin/runtime paths
- [ ] Documentation updated (if behavior or workflow changed)

## Risk Checklist
- [ ] Label `schema-change` applied when DB schema/version is touched
- [ ] Label `admin-ui` + `needs-browser-test` applied when admin UI is touched
- [ ] Label `ajax-registry` applied when AJAX handlers/registry are touched
- [ ] Label `cron` applied when cron/queue/retry paths are touched
- [ ] Label `generation-pipeline` applied when prompt/generation flow is touched
- [ ] Label `security-sensitive` applied when auth/nonce/capability/data-safety paths are touched
- [ ] Label duplicate-risk applied and addressed before merge
