### PR TITLE
🎨 Palette: Add explicit type="button" to interactive UI elements

### DIFF
--- a/ai-post-scheduler/.build/palette.md
+++ b/ai-post-scheduler/.build/palette.md
@@ -10,3 +10,9 @@
 **PR:** 🎨 Palette: Add aria-label to remove post button in taxonomy
 **Learning:** Missing aria-labels on icon-only buttons (like `&times;`) degrades screen reader accessibility.
 **Action:** Always ensure icon-only buttons have an `aria-label` attribute describing their function for assistive technologies.
+## 2024-08-08 - Prevent Accidental Form Submissions
+**Area:** Admin Templates (`templates/admin/*.php`)
+**Status:** opened PR
+**PR:** 🎨 Palette: Add explicit type="button" to interactive UI elements
+**Learning:** In WordPress admin contexts, buttons outside explicit forms without a `type` attribute default to `type="submit"`. This can cause unintended page reloads or form submissions if intercepted incorrectly by scripts.
+**Action:** Always include an explicit `type="button"` on interactive button elements outside forms to prevent them from acting as implicit submit buttons.

--- a/ai-post-scheduler/templates/admin/author-topics.php
+++ b/ai-post-scheduler/templates/admin/author-topics.php
@@ -93,7 +93,7 @@ $posts_count        = $logs_repository->count_generated_posts_by_author($author_
 						<span class="dashicons dashicons-edit"></span>
 						<?php esc_html_e('Edit Author', 'ai-post-scheduler'); ?>
 					</a>
-					<button class="aips-btn aips-btn-primary aips-generate-topics-now" data-id="<?php echo esc_attr($author->id); ?>">
+					<button type="button" class="aips-btn aips-btn-primary aips-generate-topics-now" data-id="<?php echo esc_attr($author->id); ?>">
 						<span class="dashicons dashicons-update"></span>
 						<?php esc_html_e('Generate Topics', 'ai-post-scheduler'); ?>
 					</button>
@@ -134,23 +134,23 @@ $posts_count        = $logs_repository->count_generated_posts_by_author($author_
 		<div class="aips-content-panel" id="aips-author-topics-panel">
 			<!-- Tabs -->
 			<div class="aips-topics-tabs aips-page-tabs">
-				<button class="aips-tab-link active" data-tab="pending">
+				<button type="button" class="aips-tab-link active" data-tab="pending">
 					<?php esc_html_e('Pending Review', 'ai-post-scheduler'); ?>
 					<span class="aips-tab-count" id="pending-count"><?php echo esc_html($status_counts['pending']); ?></span>
 				</button>
-				<button class="aips-tab-link" data-tab="approved">
+				<button type="button" class="aips-tab-link" data-tab="approved">
 					<?php esc_html_e('Approved', 'ai-post-scheduler'); ?>
 					<span class="aips-tab-count" id="approved-count"><?php echo esc_html($status_counts['approved']); ?></span>
 				</button>
-				<button class="aips-tab-link" data-tab="rejected">
+				<button type="button" class="aips-tab-link" data-tab="rejected">
 					<?php esc_html_e('Rejected', 'ai-post-scheduler'); ?>
 					<span class="aips-tab-count" id="rejected-count"><?php echo esc_html($status_counts['rejected']); ?></span>
 				</button>
-				<button class="aips-tab-link" data-tab="posts_generated">
+				<button type="button" class="aips-tab-link" data-tab="posts_generated">
 					<?php esc_html_e('Posts Generated', 'ai-post-scheduler'); ?>
 					<span class="aips-tab-count" id="posts-generated-count"><?php echo esc_html($status_counts['posts_generated']); ?></span>
 				</button>
-				<button class="aips-tab-link" data-tab="feedback">
+				<button type="button" class="aips-tab-link" data-tab="feedback">
 					<?php esc_html_e('Feedback', 'ai-post-scheduler'); ?>
 				</button>
 			</div>
@@ -164,7 +164,7 @@ $posts_count        = $logs_repository->count_generated_posts_by_author($author_
 						<option value="reject"><?php esc_html_e('Reject', 'ai-post-scheduler'); ?></option>
 						<option value="delete"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></option>
 					</select>
-					<button class="aips-btn aips-btn-sm aips-btn-secondary aips-bulk-action-execute"><?php esc_html_e('Execute', 'ai-post-scheduler'); ?></button>
+					<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-bulk-action-execute"><?php esc_html_e('Execute', 'ai-post-scheduler'); ?></button>
 				</div>
 				<div class="aips-filter-right">
 					<label class="screen-reader-text" for="aips-topic-search"><?php esc_html_e('Search Topics:', 'ai-post-scheduler'); ?></label>

--- a/ai-post-scheduler/templates/admin/authors.php
+++ b/ai-post-scheduler/templates/admin/authors.php
@@ -46,11 +46,11 @@ $site_ctx = AIPS_Site_Context::get();
                     <p class="aips-page-description"><?php esc_html_e('Manage AI author profiles, generate topics, and create authentic content from different perspectives.', 'ai-post-scheduler'); ?></p>
                 </div>
                 <div class="aips-page-actions">
-                    <button class="aips-btn aips-btn-secondary" id="aips-suggest-authors-btn">
+                    <button type="button" class="aips-btn aips-btn-secondary" id="aips-suggest-authors-btn">
                         <span class="dashicons dashicons-lightbulb"></span>
                         <?php esc_html_e('Suggest Authors', 'ai-post-scheduler'); ?>
                     </button>
-                    <button class="aips-btn aips-btn-primary aips-add-author-btn">
+                    <button type="button" class="aips-btn aips-btn-primary aips-add-author-btn">
                         <span class="dashicons dashicons-plus-alt"></span>
                         <?php esc_html_e('Add Author', 'ai-post-scheduler'); ?>
                     </button>
@@ -240,20 +240,20 @@ $site_ctx = AIPS_Site_Context::get();
                                     <td>
                                         <div class="cell-actions">
                                             <div class="aips-author-generation-actions">
-                                                <button class="aips-btn aips-btn-sm aips-btn-primary aips-generate-topics-now" data-id="<?php echo esc_attr($author->id); ?>" title="<?php esc_attr_e('Generate Topics', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Generate Topics', 'ai-post-scheduler'); ?>">
+                                                <button type="button" class="aips-btn aips-btn-sm aips-btn-primary aips-generate-topics-now" data-id="<?php echo esc_attr($author->id); ?>" title="<?php esc_attr_e('Generate Topics', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Generate Topics', 'ai-post-scheduler'); ?>">
                                                     <span class="dashicons dashicons-update"></span>
                                                     <?php esc_html_e('Generate Topics', 'ai-post-scheduler'); ?>
                                                 </button>
-                                                <button class="aips-btn aips-btn-sm aips-btn-author-posts aips-generate-author-posts-now" data-id="<?php echo esc_attr($author->id); ?>" data-type="<?php echo esc_attr(AIPS_Unified_Schedule_Service::TYPE_AUTHOR_POST); ?>" data-quantity="<?php echo esc_attr(isset($author->manual_post_generation_quantity) ? max(1, (int) $author->manual_post_generation_quantity) : 1); ?>" title="<?php esc_attr_e('Generate Posts', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Generate Posts', 'ai-post-scheduler'); ?>">
+                                                <button type="button" class="aips-btn aips-btn-sm aips-btn-author-posts aips-generate-author-posts-now" data-id="<?php echo esc_attr($author->id); ?>" data-type="<?php echo esc_attr(AIPS_Unified_Schedule_Service::TYPE_AUTHOR_POST); ?>" data-quantity="<?php echo esc_attr(isset($author->manual_post_generation_quantity) ? max(1, (int) $author->manual_post_generation_quantity) : 1); ?>" title="<?php esc_attr_e('Generate Posts', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Generate Posts', 'ai-post-scheduler'); ?>">
                                                     <span class="dashicons dashicons-admin-post"></span>
                                                     <?php esc_html_e('Generate Posts', 'ai-post-scheduler'); ?>
                                                 </button>
                                             </div>
-                                            <button class="aips-btn aips-btn-sm aips-btn-secondary aips-edit-author" data-id="<?php echo esc_attr($author->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
+                                            <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-edit-author" data-id="<?php echo esc_attr($author->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
                                                 <span class="dashicons dashicons-edit"></span>
                                                 <?php esc_html_e('Edit', 'ai-post-scheduler'); ?>
                                             </button>
-                                            <button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-author" data-id="<?php echo esc_attr($author->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
+                                            <button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-author" data-id="<?php echo esc_attr($author->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
                                                 <span class="dashicons dashicons-trash"></span>
                                                 <?php esc_html_e('Delete', 'ai-post-scheduler'); ?>
                                             </button>
@@ -306,7 +306,7 @@ $site_ctx = AIPS_Site_Context::get();
                         <h3 class="aips-empty-state-title"><?php esc_html_e('No Authors Yet', 'ai-post-scheduler'); ?></h3>
                         <p class="aips-empty-state-description"><?php esc_html_e('Create your first author to start generating topically diverse blog posts.', 'ai-post-scheduler'); ?></p>
                         <div class="aips-empty-state-actions">
-                            <button class="aips-btn aips-btn-primary aips-add-author-btn">
+                            <button type="button" class="aips-btn aips-btn-primary aips-add-author-btn">
                                 <span class="dashicons dashicons-plus-alt"></span>
                                 <?php esc_html_e('Add Author', 'ai-post-scheduler'); ?>
                             </button>
@@ -786,24 +786,24 @@ $site_ctx = AIPS_Site_Context::get();
 
 <script type="text/html" id="aips-tmpl-topic-actions-pending">
 <div class="cell-actions">
-    <button class="aips-btn aips-btn-sm aips-btn-secondary aips-edit-topic" data-id="{{id}}">{{editLabel}}</button>
+    <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-edit-topic" data-id="{{id}}">{{editLabel}}</button>
 </div>
 <div class="cell-actions" style="margin-top: 6px;">
-    <button class="aips-btn aips-btn-sm aips-btn-secondary aips-approve-topic" data-id="{{id}}">{{approveLabel}}</button>
-    <button class="aips-btn aips-btn-sm aips-btn-secondary aips-reject-topic" data-id="{{id}}">{{rejectLabel}}</button>
+    <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-approve-topic" data-id="{{id}}">{{approveLabel}}</button>
+    <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-reject-topic" data-id="{{id}}">{{rejectLabel}}</button>
 </div>
 </script>
 
 <script type="text/html" id="aips-tmpl-topic-actions-approved">
 <div class="cell-actions">
-    <button class="aips-btn aips-btn-sm aips-btn-secondary aips-generate-post-now" data-id="{{id}}">{{generateLabel}}</button>
-    <button class="aips-btn aips-btn-sm aips-btn-ghost aips-edit-topic" data-id="{{id}}">{{editLabel}}</button>
+    <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-generate-post-now" data-id="{{id}}">{{generateLabel}}</button>
+    <button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-edit-topic" data-id="{{id}}">{{editLabel}}</button>
 </div>
 </script>
 
 <script type="text/html" id="aips-tmpl-topic-actions-rejected">
 <div class="cell-actions">
-    <button class="aips-btn aips-btn-sm aips-btn-ghost aips-edit-topic" data-id="{{id}}">{{editLabel}}</button>
+    <button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-edit-topic" data-id="{{id}}">{{editLabel}}</button>
 </div>
 </script>
 

--- a/ai-post-scheduler/templates/admin/calendar.php
+++ b/ai-post-scheduler/templates/admin/calendar.php
@@ -33,31 +33,31 @@ if (!defined('ABSPATH')) {
 				<!-- Calendar Header with Navigation -->
 				<div class="aips-calendar-header">
 					<div class="aips-calendar-nav">
-						<button class="aips-btn aips-btn-sm aips-btn-secondary aips-calendar-prev" title="<?php esc_attr_e('Previous Month', 'ai-post-scheduler'); ?>">
+						<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-calendar-prev" title="<?php esc_attr_e('Previous Month', 'ai-post-scheduler'); ?>">
 							<span class="dashicons dashicons-arrow-left-alt2"></span>
 						</button>
 						<h2 class="aips-calendar-title">
 							<span class="aips-calendar-month-year"></span>
 						</h2>
-						<button class="aips-btn aips-btn-sm aips-btn-secondary aips-calendar-next" title="<?php esc_attr_e('Next Month', 'ai-post-scheduler'); ?>">
+						<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-calendar-next" title="<?php esc_attr_e('Next Month', 'ai-post-scheduler'); ?>">
 							<span class="dashicons dashicons-arrow-right-alt2"></span>
 						</button>
 					</div>
 					
 					<div class="aips-calendar-view-switcher">
-						<button class="aips-btn aips-btn-sm aips-calendar-view-btn active" data-view="month">
+						<button type="button" class="aips-btn aips-btn-sm aips-calendar-view-btn active" data-view="month">
 							<?php esc_html_e('Month', 'ai-post-scheduler'); ?>
 						</button>
-						<button class="aips-btn aips-btn-sm aips-calendar-view-btn" data-view="week">
+						<button type="button" class="aips-btn aips-btn-sm aips-calendar-view-btn" data-view="week">
 							<?php esc_html_e('Week', 'ai-post-scheduler'); ?>
 						</button>
-						<button class="aips-btn aips-btn-sm aips-calendar-view-btn" data-view="day">
+						<button type="button" class="aips-btn aips-btn-sm aips-calendar-view-btn" data-view="day">
 							<?php esc_html_e('Day', 'ai-post-scheduler'); ?>
 						</button>
 					</div>
 					
 					<div class="aips-calendar-today">
-						<button class="aips-btn aips-btn-secondary aips-calendar-today-btn">
+						<button type="button" class="aips-btn aips-btn-secondary aips-calendar-today-btn">
 							<?php esc_html_e('Today', 'ai-post-scheduler'); ?>
 						</button>
 					</div>

--- a/ai-post-scheduler/templates/admin/dashboard.php
+++ b/ai-post-scheduler/templates/admin/dashboard.php
@@ -133,19 +133,19 @@ if (!defined('ABSPATH')) {
 			<div class="aips-content-panel detail-tabs-panel glass-morphic">
 				<!-- Tab Headers -->
 				<div class="aips-tab-headers" role="tablist">
-					<button class="aips-tab-btn active" role="tab" aria-selected="true" aria-controls="tab-posts" id="btn-tab-posts">
+					<button type="button" class="aips-tab-btn active" role="tab" aria-selected="true" aria-controls="tab-posts" id="btn-tab-posts">
 						<span class="dashicons dashicons-edit"></span>
 						<?php esc_html_e('Generated Posts', 'ai-post-scheduler'); ?>
 					</button>
-					<button class="aips-tab-btn" role="tab" aria-selected="false" aria-controls="tab-topics" id="btn-tab-topics">
+					<button type="button" class="aips-tab-btn" role="tab" aria-selected="false" aria-controls="tab-topics" id="btn-tab-topics">
 						<span class="dashicons dashicons-welcome-write-blog"></span>
 						<?php esc_html_e('Author Topics', 'ai-post-scheduler'); ?>
 					</button>
-					<button class="aips-tab-btn" role="tab" aria-selected="false" aria-controls="tab-topic-posts" id="btn-tab-topic-posts">
+					<button type="button" class="aips-tab-btn" role="tab" aria-selected="false" aria-controls="tab-topic-posts" id="btn-tab-topic-posts">
 						<span class="dashicons dashicons-admin-links"></span>
 						<?php esc_html_e('Posts by Topic', 'ai-post-scheduler'); ?>
 					</button>
-					<button class="aips-tab-btn" role="tab" aria-selected="false" aria-controls="tab-schedules" id="btn-tab-schedules">
+					<button type="button" class="aips-tab-btn" role="tab" aria-selected="false" aria-controls="tab-schedules" id="btn-tab-schedules">
 						<span class="dashicons dashicons-update"></span>
 						<?php esc_html_e('Schedules Executed', 'ai-post-scheduler'); ?>
 					</button>

--- a/ai-post-scheduler/templates/admin/history.php
+++ b/ai-post-scheduler/templates/admin/history.php
@@ -90,7 +90,7 @@ if (is_object($history)) {
                         <button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-history-quick-date" data-days="30"><?php esc_html_e('30 days', 'ai-post-scheduler'); ?></button>
                     </div>
                     <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary" id="aips-history-more-filters" aria-expanded="false" aria-controls="aips-history-advanced-filters"><?php esc_html_e('More filters', 'ai-post-scheduler'); ?></button>
-                    <button class="aips-btn aips-btn-sm aips-btn-primary" id="aips-filter-btn"><span class="dashicons dashicons-filter"></span><?php esc_html_e('Filter', 'ai-post-scheduler'); ?></button>
+                    <button type="button" class="aips-btn aips-btn-sm aips-btn-primary" id="aips-filter-btn"><span class="dashicons dashicons-filter"></span><?php esc_html_e('Filter', 'ai-post-scheduler'); ?></button>
                 </div>
                 <div id="aips-history-advanced-filters" class="aips-history-advanced-filters" hidden>
                     <select id="aips-filter-domain" class="aips-form-select">
@@ -122,15 +122,15 @@ if (is_object($history)) {
             <!-- Toolbar (bulk actions) -->
             <div class="aips-panel-toolbar">
                 <div class="aips-toolbar-left aips-btn-group aips-btn-group-inline">
-                    <button class="aips-btn aips-btn-sm aips-btn-danger aips-btn-danger-solid" id="aips-delete-selected-btn" disabled>
+                    <button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-btn-danger-solid" id="aips-delete-selected-btn" disabled>
                         <span class="dashicons dashicons-trash"></span>
                         <?php esc_html_e('Delete', 'ai-post-scheduler'); ?>
                     </button>
-                    <button class="aips-btn aips-btn-sm aips-btn-secondary" id="aips-reload-history-btn">
+                    <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary" id="aips-reload-history-btn">
                         <span class="dashicons dashicons-update"></span>
                         <?php esc_html_e('Reload', 'ai-post-scheduler'); ?>
                     </button>
-                    <button class="aips-btn aips-btn-sm aips-btn-secondary" id="aips-export-history-btn">
+                    <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary" id="aips-export-history-btn">
                         <span class="dashicons dashicons-download"></span>
                         <?php esc_html_e('Export CSV', 'ai-post-scheduler'); ?>
                     </button>

--- a/ai-post-scheduler/templates/admin/research.php
+++ b/ai-post-scheduler/templates/admin/research.php
@@ -497,7 +497,7 @@ if (!in_array($active_tab, $valid_tabs, true)) {
             <td>{{researched_at}}</td>
             <td>
                 <div class="aips-topic-actions">
-                    <button class="aips-btn aips-btn-sm aips-btn-danger delete-topic" data-id="{{id}}">
+                    <button type="button" class="aips-btn aips-btn-sm aips-btn-danger delete-topic" data-id="{{id}}">
                         <span class="dashicons dashicons-trash"></span> {{delete_label}}
                     </button>
                 </div>
@@ -569,7 +569,7 @@ if (!in_array($active_tab, $valid_tabs, true)) {
             <p class="aips-gap-reason">{{reason}}</p>
             <p class="aips-gap-intent"><?php esc_html_e('Intent:', 'ai-post-scheduler'); ?> {{search_intent}}</p>
             <div class="aips-gap-actions">
-                <button class="aips-btn aips-btn-sm aips-btn-secondary generate-gap-ideas" data-topic="{{missing_topic}}">{{generate_ideas_label}}</button>
+                <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary generate-gap-ideas" data-topic="{{missing_topic}}">{{generate_ideas_label}}</button>
             </div>
         </div>
     </script>

--- a/ai-post-scheduler/templates/admin/schedule.php
+++ b/ai-post-scheduler/templates/admin/schedule.php
@@ -169,7 +169,7 @@ if (!function_exists('aips_datetime_from_db_value')) {
 				</div>
 				<div class="aips-page-actions">
 					<?php if (!empty($templates)): ?>
-					<button class="aips-btn aips-btn-primary aips-add-schedule-btn">
+					<button type="button" class="aips-btn aips-btn-primary aips-add-schedule-btn">
 						<span class="dashicons dashicons-plus-alt"></span>
 						<?php esc_html_e('Add Template Schedule', 'ai-post-scheduler'); ?>
 					</button>
@@ -454,7 +454,7 @@ if (!function_exists('aips_datetime_from_db_value')) {
 							<div class="cell-actions">
 								<!-- Edit (template schedules only) -->
 								<?php if ($sched['type'] === AIPS_Unified_Schedule_Service::TYPE_TEMPLATE): ?>
-								<button class="aips-btn aips-btn-sm aips-btn-ghost aips-edit-schedule"
+								<button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-edit-schedule"
 									aria-label="<?php esc_attr_e('Edit schedule', 'ai-post-scheduler'); ?>"
 									title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>"
 									data-schedule-id="<?php echo esc_attr($sched['id']); ?>"
@@ -471,7 +471,7 @@ if (!function_exists('aips_datetime_from_db_value')) {
 								<?php endif; ?>
 
 								<!-- Run Now (all types) -->
-								<button class="aips-btn aips-btn-sm aips-btn-ghost aips-unified-run-now"
+								<button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-unified-run-now"
 									data-id="<?php echo esc_attr($sched['id']); ?>"
 									data-type="<?php echo esc_attr($sched['type']); ?>"
 									aria-label="<?php esc_attr_e('Run now', 'ai-post-scheduler'); ?>"
@@ -481,7 +481,7 @@ if (!function_exists('aips_datetime_from_db_value')) {
 
 								<!-- Reset Circuit (template schedules only, when circuit is open) -->
 								<?php if ($sched['type'] === AIPS_Unified_Schedule_Service::TYPE_TEMPLATE && $circuit_state === 'open'): ?>
-								<button class="aips-btn aips-btn-sm aips-btn-warning aips-reset-circuit"
+								<button type="button" class="aips-btn aips-btn-sm aips-btn-warning aips-reset-circuit"
 									data-id="<?php echo esc_attr($sched['id']); ?>"
 									data-type="<?php echo esc_attr($sched['type']); ?>"
 									aria-label="<?php esc_attr_e('Reset circuit breaker', 'ai-post-scheduler'); ?>"
@@ -492,7 +492,7 @@ if (!function_exists('aips_datetime_from_db_value')) {
 
 								<!-- Resume Batch (template schedules only, when batch is incomplete) -->
 								<?php if ($sched['type'] === AIPS_Unified_Schedule_Service::TYPE_TEMPLATE && $has_incomplete_batch): ?>
-								<button class="aips-btn aips-btn-sm aips-btn-info aips-resume-batch"
+								<button type="button" class="aips-btn aips-btn-sm aips-btn-info aips-resume-batch"
 									data-id="<?php echo esc_attr($sched['id']); ?>"
 									data-type="<?php echo esc_attr($sched['type']); ?>"
 									aria-label="<?php esc_attr_e('Resume incomplete batch', 'ai-post-scheduler'); ?>"
@@ -503,14 +503,14 @@ if (!function_exists('aips_datetime_from_db_value')) {
 
 								<!-- Delete (template schedules only) -->
 								<?php if ($sched['can_delete']): ?>
-								<button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-schedule"
+								<button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-schedule"
 									data-id="<?php echo esc_attr($sched['id']); ?>"
 									aria-label="<?php esc_attr_e('Delete schedule', 'ai-post-scheduler'); ?>"
 									title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
 									<span class="dashicons dashicons-trash"></span>
 								</button>
 								<?php elseif (!empty($sched['campaign_id'])): ?>
-								<button class="aips-btn aips-btn-sm aips-btn-danger" disabled
+								<button type="button" class="aips-btn aips-btn-sm aips-btn-danger" disabled
 									aria-label="<?php esc_attr_e('Delete schedule', 'ai-post-scheduler'); ?>"
 									title="<?php esc_attr_e('This schedule cannot be deleted here because it belongs to a campaign. Delete it from the Campaigns page.', 'ai-post-scheduler'); ?>">
 									<span class="dashicons dashicons-trash"></span>
@@ -550,7 +550,7 @@ if (!function_exists('aips_datetime_from_db_value')) {
 					</p>
 					<?php if (!empty($templates)): ?>
 					<div class="aips-empty-state-actions">
-						<button class="aips-btn aips-btn-primary aips-add-schedule-btn">
+						<button type="button" class="aips-btn aips-btn-primary aips-add-schedule-btn">
 							<span class="dashicons dashicons-plus-alt"></span>
 							<?php esc_html_e('Add Template Schedule', 'ai-post-scheduler'); ?>
 						</button>

--- a/ai-post-scheduler/templates/admin/sections.php
+++ b/ai-post-scheduler/templates/admin/sections.php
@@ -17,7 +17,7 @@ if (!isset($sections) || !is_array($sections)) {
 					<p class="aips-page-description"><?php esc_html_e('Create and manage reusable prompt sections that can be inserted into your templates using placeholders.', 'ai-post-scheduler'); ?></p>
 				</div>
 				<div class="aips-page-actions">
-					<button class="aips-btn aips-btn-primary aips-add-section-btn">
+					<button type="button" class="aips-btn aips-btn-primary aips-add-section-btn">
 						<span class="dashicons dashicons-plus-alt"></span>
 						<?php esc_html_e('Add Section', 'ai-post-scheduler'); ?>
 					</button>
@@ -76,10 +76,10 @@ if (!isset($sections) || !is_array($sections)) {
 								<?php endif; ?>
 							</td>
 							<td class="column-actions">
-								<button class="aips-btn aips-btn-sm aips-btn-ghost aips-edit-section" data-id="<?php echo esc_attr($section->id); ?>" aria-label="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
+								<button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-edit-section" data-id="<?php echo esc_attr($section->id); ?>" aria-label="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
 									<span class="dashicons dashicons-edit"></span>
 								</button>
-								<button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-section" data-id="<?php echo esc_attr($section->id); ?>" aria-label="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
+								<button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-section" data-id="<?php echo esc_attr($section->id); ?>" aria-label="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
 									<span class="dashicons dashicons-trash"></span>
 								</button>
 							</td>
@@ -108,7 +108,7 @@ if (!isset($sections) || !is_array($sections)) {
 				<h3 class="aips-empty-state-title"><?php esc_html_e('No Prompt Sections', 'ai-post-scheduler'); ?></h3>
 				<p class="aips-empty-state-description"><?php esc_html_e('Create reusable prompt sections that can be inserted into your article structures using placeholders like {{section:key}}.', 'ai-post-scheduler'); ?></p>
 				<div class="aips-empty-state-actions">
-					<button class="aips-btn aips-btn-primary aips-add-section-btn">
+					<button type="button" class="aips-btn aips-btn-primary aips-add-section-btn">
 						<span class="dashicons dashicons-plus-alt"></span>
 						<?php esc_html_e('Create First Section', 'ai-post-scheduler'); ?>
 					</button>

--- a/ai-post-scheduler/templates/admin/sources.php
+++ b/ai-post-scheduler/templates/admin/sources.php
@@ -179,13 +179,13 @@ $is_embedded_sources_view = !empty($embedded);
 							</td>
 							<td class="column-actions">
 								<div class="aips-action-buttons">
-									<button class="aips-btn aips-btn-sm aips-edit-source"
+									<button type="button" class="aips-btn aips-btn-sm aips-edit-source"
 										data-id="<?php echo esc_attr($source->id); ?>"
 										title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
 										<span class="dashicons dashicons-edit"></span>
 										<span class="screen-reader-text"><?php esc_html_e('Edit', 'ai-post-scheduler'); ?></span>
 									</button>
-									<button class="aips-btn aips-btn-sm aips-btn-secondary aips-fetch-source-now"
+									<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-fetch-source-now"
 										data-id="<?php echo esc_attr($source->id); ?>"
 										title="<?php esc_attr_e('Fetch content now', 'ai-post-scheduler'); ?>">
 										<span class="dashicons dashicons-download"></span>
@@ -197,7 +197,7 @@ $is_embedded_sources_view = !empty($embedded);
 										<span class="dashicons dashicons-archive"></span>
 										<span><?php esc_html_e('Manage Data', 'ai-post-scheduler'); ?></span>
 									</a>
-									<button class="aips-btn aips-btn-sm aips-btn-ghost aips-toggle-source"
+									<button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-toggle-source"
 										data-id="<?php echo esc_attr($source->id); ?>"
 										data-active="<?php echo esc_attr($source->is_active); ?>"
 										title="<?php echo $source->is_active ? esc_attr__('Deactivate', 'ai-post-scheduler') : esc_attr__('Activate', 'ai-post-scheduler'); ?>">
@@ -206,7 +206,7 @@ $is_embedded_sources_view = !empty($embedded);
 											<?php echo $source->is_active ? esc_html__('Deactivate', 'ai-post-scheduler') : esc_html__('Activate', 'ai-post-scheduler'); ?>
 										</span>
 									</button>
-									<button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-source"
+									<button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-source"
 										data-id="<?php echo esc_attr($source->id); ?>"
 										title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
 										<span class="dashicons dashicons-trash"></span>
@@ -376,7 +376,7 @@ $is_embedded_sources_view = !empty($embedded);
 								<tr data-term-id="<?php echo esc_attr($group->term_id); ?>">
 									<td><?php echo esc_html($group->name); ?></td>
 									<td>
-										<button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-source-group"
+										<button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-source-group"
 											data-term-id="<?php echo esc_attr($group->term_id); ?>"
 											title="<?php esc_attr_e('Delete group', 'ai-post-scheduler'); ?>">
 											<span class="dashicons dashicons-trash"></span>

--- a/ai-post-scheduler/templates/admin/structures.php
+++ b/ai-post-scheduler/templates/admin/structures.php
@@ -77,7 +77,7 @@ if (!isset($sections) || !is_array($sections)) {
 						</td>
 						<td class="column-actions">
 							<div class="aips-action-buttons">
-								<button class="aips-btn aips-btn-sm aips-edit-structure" data-id="<?php echo esc_attr($structure->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
+								<button type="button" class="aips-btn aips-btn-sm aips-edit-structure" data-id="<?php echo esc_attr($structure->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
 									<span class="dashicons dashicons-edit"></span>
 									<span class="screen-reader-text"><?php esc_html_e('Edit', 'ai-post-scheduler'); ?></span>
 								</button>
@@ -85,7 +85,7 @@ if (!isset($sections) || !is_array($sections)) {
 									<span class="dashicons dashicons-calendar-alt"></span>
 									<span class="screen-reader-text"><?php esc_html_e('Schedule', 'ai-post-scheduler'); ?></span>
 								</a>
-								<button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-structure" data-id="<?php echo esc_attr($structure->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
+								<button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-structure" data-id="<?php echo esc_attr($structure->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
 									<span class="dashicons dashicons-trash"></span>
 									<span class="screen-reader-text"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></span>
 								</button>
@@ -134,7 +134,7 @@ if (!isset($sections) || !is_array($sections)) {
 				<h3 class="aips-empty-state-title"><?php esc_html_e('No Article Structures', 'ai-post-scheduler'); ?></h3>
 				<p class="aips-empty-state-description"><?php esc_html_e('Create article structures to customize how templates assemble content.', 'ai-post-scheduler'); ?></p>
 				<div class="aips-empty-state-actions">
-					<button class="aips-btn aips-btn-primary aips-add-structure-btn"><?php esc_html_e('Create Structure', 'ai-post-scheduler'); ?></button>
+					<button type="button" class="aips-btn aips-btn-primary aips-add-structure-btn"><?php esc_html_e('Create Structure', 'ai-post-scheduler'); ?></button>
 				</div>
 			</div>
 			<?php endif; ?>
@@ -180,11 +180,11 @@ if (!isset($sections) || !is_array($sections)) {
 						</td>
 						<td>
 							<div class="aips-action-buttons">
-								<button class="aips-btn aips-btn-sm aips-edit-section" data-id="<?php echo esc_attr($section->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
+								<button type="button" class="aips-btn aips-btn-sm aips-edit-section" data-id="<?php echo esc_attr($section->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
 									<span class="dashicons dashicons-edit"></span>
 									<span class="screen-reader-text"><?php esc_html_e('Edit', 'ai-post-scheduler'); ?></span>
 								</button>
-								<button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-section" data-id="<?php echo esc_attr($section->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
+								<button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-section" data-id="<?php echo esc_attr($section->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
 									<span class="dashicons dashicons-trash"></span>
 									<span class="screen-reader-text"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></span>
 								</button>
@@ -226,7 +226,7 @@ if (!isset($sections) || !is_array($sections)) {
 				<h3 class="aips-empty-state-title"><?php esc_html_e('No Prompt Sections', 'ai-post-scheduler'); ?></h3>
 				<p class="aips-empty-state-description"><?php esc_html_e('Create prompt sections to reuse across article structures.', 'ai-post-scheduler'); ?></p>
 				<div class="aips-empty-state-actions">
-					<button class="aips-btn aips-btn-primary aips-add-section-btn"><?php esc_html_e('Create Section', 'ai-post-scheduler'); ?></button>
+					<button type="button" class="aips-btn aips-btn-primary aips-add-section-btn"><?php esc_html_e('Create Section', 'ai-post-scheduler'); ?></button>
 				</div>
 			</div>
 			<?php endif; ?>
@@ -343,7 +343,7 @@ if (!isset($sections) || !is_array($sections)) {
 	<td class="column-active">{{activeBadge}}</td>
 	<td class="column-actions">
 		<div class="aips-action-buttons">
-			<button class="aips-btn aips-btn-sm aips-edit-structure" data-id="{{id}}" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
+			<button type="button" class="aips-btn aips-btn-sm aips-edit-structure" data-id="{{id}}" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
 				<span class="dashicons dashicons-edit"></span>
 				<span class="screen-reader-text"><?php esc_html_e('Edit', 'ai-post-scheduler'); ?></span>
 			</button>
@@ -351,7 +351,7 @@ if (!isset($sections) || !is_array($sections)) {
 				<span class="dashicons dashicons-calendar-alt"></span>
 				<span class="screen-reader-text"><?php esc_html_e('Schedule', 'ai-post-scheduler'); ?></span>
 			</a>
-			<button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-structure" data-id="{{id}}" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
+			<button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-structure" data-id="{{id}}" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
 				<span class="dashicons dashicons-trash"></span>
 				<span class="screen-reader-text"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></span>
 			</button>
@@ -368,11 +368,11 @@ if (!isset($sections) || !is_array($sections)) {
 	<td>{{activeBadge}}</td>
 	<td>
 		<div class="aips-action-buttons">
-			<button class="aips-btn aips-btn-sm aips-edit-section" data-id="{{id}}" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
+			<button type="button" class="aips-btn aips-btn-sm aips-edit-section" data-id="{{id}}" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
 				<span class="dashicons dashicons-edit"></span>
 				<span class="screen-reader-text"><?php esc_html_e('Edit', 'ai-post-scheduler'); ?></span>
 			</button>
-			<button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-section" data-id="{{id}}" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
+			<button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-section" data-id="{{id}}" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
 				<span class="dashicons dashicons-trash"></span>
 				<span class="screen-reader-text"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></span>
 			</button>

--- a/ai-post-scheduler/templates/admin/taxonomy.php
+++ b/ai-post-scheduler/templates/admin/taxonomy.php
@@ -32,7 +32,7 @@ $is_embedded_taxonomy_view = !empty($embedded);
 					</p>
 				</div>
 				<div class="aips-page-actions">
-					<button class="aips-btn aips-btn-primary aips-generate-taxonomy" id="aips-open-generate-modal">
+					<button type="button" class="aips-btn aips-btn-primary aips-generate-taxonomy" id="aips-open-generate-modal">
 						<span class="dashicons dashicons-update"></span>
 						<?php esc_html_e('Generate Taxonomy', 'ai-post-scheduler'); ?>
 					</button>
@@ -65,11 +65,11 @@ $is_embedded_taxonomy_view = !empty($embedded);
 		<div class="aips-content-panel" id="aips-taxonomy-panel">
 			<!-- Tabs -->
 			<div class="aips-topics-tabs aips-page-tabs">
-				<button class="aips-tab-link active" data-tab="categories">
+				<button type="button" class="aips-tab-link active" data-tab="categories">
 					<?php esc_html_e('Categories', 'ai-post-scheduler'); ?>
 					<span class="aips-tab-count" id="categories-count"><?php echo esc_html($status_counts['categories']['pending'] + $status_counts['categories']['approved'] + $status_counts['categories']['rejected']); ?></span>
 				</button>
-				<button class="aips-tab-link" data-tab="tags">
+				<button type="button" class="aips-tab-link" data-tab="tags">
 					<?php esc_html_e('Tags', 'ai-post-scheduler'); ?>
 					<span class="aips-tab-count" id="tags-count"><?php echo esc_html($status_counts['tags']['pending'] + $status_counts['tags']['approved'] + $status_counts['tags']['rejected']); ?></span>
 				</button>
@@ -85,7 +85,7 @@ $is_embedded_taxonomy_view = !empty($embedded);
 						<option value="generate_terms"><?php esc_html_e('Generate Terms', 'ai-post-scheduler'); ?></option>
 						<option value="delete"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></option>
 					</select>
-					<button class="aips-btn aips-btn-sm aips-btn-secondary aips-bulk-action-execute"><?php esc_html_e('Execute', 'ai-post-scheduler'); ?></button>
+					<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-bulk-action-execute"><?php esc_html_e('Execute', 'ai-post-scheduler'); ?></button>
 				</div>
 				<div class="aips-filter-right">
 					<label class="screen-reader-text" for="aips-taxonomy-search"><?php esc_html_e('Search Taxonomy:', 'ai-post-scheduler'); ?></label>
@@ -210,15 +210,15 @@ $is_embedded_taxonomy_view = !empty($embedded);
 
 <script type="text/html" id="aips-tmpl-taxonomy-actions-pending">
 <div class="cell-actions">
-	<button class="aips-btn aips-btn-sm aips-btn-secondary aips-approve-taxonomy" data-id="{{id}}">{{approveLabel}}</button>
-	<button class="aips-btn aips-btn-sm aips-btn-secondary aips-reject-taxonomy" data-id="{{id}}">{{rejectLabel}}</button>
+	<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-approve-taxonomy" data-id="{{id}}">{{approveLabel}}</button>
+	<button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-reject-taxonomy" data-id="{{id}}">{{rejectLabel}}</button>
 </div>
 </script>
 
 <script type="text/html" id="aips-tmpl-taxonomy-actions-approved">
 <div class="cell-actions">
 	{{createControl}}
-	<button class="aips-btn aips-btn-sm aips-btn-ghost aips-btn-icon aips-delete-taxonomy" data-id="{{id}}" aria-label="{{deleteLabel}}">
+	<button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-btn-icon aips-delete-taxonomy" data-id="{{id}}" aria-label="{{deleteLabel}}">
 		<span class="dashicons dashicons-trash" aria-hidden="true"></span>
 		<span class="screen-reader-text">{{deleteLabel}}</span>
 	</button>
@@ -227,7 +227,7 @@ $is_embedded_taxonomy_view = !empty($embedded);
 
 <script type="text/html" id="aips-tmpl-taxonomy-actions-rejected">
 <div class="cell-actions">
-	<button class="aips-btn aips-btn-sm aips-btn-ghost aips-delete-taxonomy" data-id="{{id}}">{{deleteLabel}}</button>
+	<button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-delete-taxonomy" data-id="{{id}}">{{deleteLabel}}</button>
 </div>
 </script>
 

--- a/ai-post-scheduler/templates/admin/templates.php
+++ b/ai-post-scheduler/templates/admin/templates.php
@@ -15,7 +15,7 @@ $is_embedded_templates_view = !empty($embedded);
                     <p class="aips-page-description"><?php esc_html_e('Create and manage AI post generation templates with custom prompts and settings.', 'ai-post-scheduler'); ?></p>
                 </div>
                 <div class="aips-page-actions">
-                    <button class="aips-btn aips-btn-primary aips-add-template-btn">
+                    <button type="button" class="aips-btn aips-btn-primary aips-add-template-btn">
                         <span class="dashicons dashicons-plus-alt"></span>
                         <?php esc_html_e('Add Template', 'ai-post-scheduler'); ?>
                     </button>
@@ -140,11 +140,11 @@ $is_embedded_templates_view = !empty($embedded);
                             </td>
                             <td>
                                 <div class="cell-actions">
-                                    <button class="aips-btn aips-btn-sm aips-btn-secondary aips-edit-template" data-id="<?php echo esc_attr($template->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
+                                    <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-edit-template" data-id="<?php echo esc_attr($template->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
                                         <span class="dashicons dashicons-edit"></span>
                                         <?php esc_html_e('Edit', 'ai-post-scheduler'); ?>
                                     </button>
-                                    <button class="aips-btn aips-btn-sm aips-btn-secondary aips-run-now" data-id="<?php echo esc_attr($template->id); ?>" title="<?php esc_attr_e('Run Now', 'ai-post-scheduler'); ?>">
+                                    <button type="button" class="aips-btn aips-btn-sm aips-btn-secondary aips-run-now" data-id="<?php echo esc_attr($template->id); ?>" title="<?php esc_attr_e('Run Now', 'ai-post-scheduler'); ?>">
                                         <span class="dashicons dashicons-controls-play"></span>
                                         <?php esc_html_e('Run Now', 'ai-post-scheduler'); ?>
                                     </button>
@@ -152,11 +152,11 @@ $is_embedded_templates_view = !empty($embedded);
                                         <span class="dashicons dashicons-calendar-alt"></span>
                                         <span class="screen-reader-text"><?php esc_html_e('Schedule', 'ai-post-scheduler'); ?></span>
                                     </a>
-                                    <button class="aips-btn aips-btn-sm aips-btn-ghost aips-clone-template" data-id="<?php echo esc_attr($template->id); ?>" title="<?php esc_attr_e('Clone', 'ai-post-scheduler'); ?>">
+                                    <button type="button" class="aips-btn aips-btn-sm aips-btn-ghost aips-clone-template" data-id="<?php echo esc_attr($template->id); ?>" title="<?php esc_attr_e('Clone', 'ai-post-scheduler'); ?>">
                                         <span class="dashicons dashicons-admin-page"></span>
                                         <span class="screen-reader-text"><?php esc_html_e('Clone', 'ai-post-scheduler'); ?></span>
                                     </button>
-                                    <button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-template" data-id="<?php echo esc_attr($template->id); ?>" title="<?php echo !empty($template->campaign_id) ? esc_attr__('This template cannot be deleted here because it belongs to a campaign. Delete it from the Campaigns page.', 'ai-post-scheduler') : esc_attr__('Delete', 'ai-post-scheduler'); ?>" <?php disabled(!empty($template->campaign_id)); ?>>
+                                    <button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-template" data-id="<?php echo esc_attr($template->id); ?>" title="<?php echo !empty($template->campaign_id) ? esc_attr__('This template cannot be deleted here because it belongs to a campaign. Delete it from the Campaigns page.', 'ai-post-scheduler') : esc_attr__('Delete', 'ai-post-scheduler'); ?>" <?php disabled(!empty($template->campaign_id)); ?>>
                                         <span class="dashicons dashicons-trash"></span>
                                         <span class="screen-reader-text"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></span>
                                     </button>
@@ -209,7 +209,7 @@ $is_embedded_templates_view = !empty($embedded);
                     <h3 class="aips-empty-state-title"><?php esc_html_e('No Templates Yet', 'ai-post-scheduler'); ?></h3>
                     <p class="aips-empty-state-description"><?php esc_html_e('Templates define how your AI-generated posts are structured. Create your first template to start generating content automatically.', 'ai-post-scheduler'); ?></p>
                     <div class="aips-empty-state-actions">
-                        <button class="aips-btn aips-btn-primary aips-add-template-btn">
+                        <button type="button" class="aips-btn aips-btn-primary aips-add-template-btn">
                             <span class="dashicons dashicons-plus-alt"></span>
                             <?php esc_html_e('Create Template', 'ai-post-scheduler'); ?>
                         </button>

--- a/ai-post-scheduler/templates/admin/voices.php
+++ b/ai-post-scheduler/templates/admin/voices.php
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
                     </p>
                 </div>
                 <div class="aips-page-actions">
-                    <button class="aips-btn aips-btn-primary aips-add-voice-btn">
+                    <button type="button" class="aips-btn aips-btn-primary aips-add-voice-btn">
                         <span class="dashicons dashicons-plus-alt2"></span>
                         <?php esc_html_e('Add Voice', 'ai-post-scheduler'); ?>
                     </button>
@@ -75,11 +75,11 @@ if (!defined('ABSPATH')) {
                                 </td>
                                 <td class="column-actions">
                                     <div class="aips-action-buttons">
-                                        <button class="aips-btn aips-btn-sm aips-edit-voice" data-id="<?php echo esc_attr($voice->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
+                                        <button type="button" class="aips-btn aips-btn-sm aips-edit-voice" data-id="<?php echo esc_attr($voice->id); ?>" title="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Edit', 'ai-post-scheduler'); ?>">
                                             <span class="dashicons dashicons-edit"></span>
                                             <span class="screen-reader-text"><?php esc_html_e('Edit', 'ai-post-scheduler'); ?></span>
                                         </button>
-                                        <button class="aips-btn aips-btn-sm aips-btn-danger aips-delete-voice" data-id="<?php echo esc_attr($voice->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
+                                        <button type="button" class="aips-btn aips-btn-sm aips-btn-danger aips-delete-voice" data-id="<?php echo esc_attr($voice->id); ?>" title="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>" aria-label="<?php esc_attr_e('Delete', 'ai-post-scheduler'); ?>">
                                             <span class="dashicons dashicons-trash"></span>
                                             <span class="screen-reader-text"><?php esc_html_e('Delete', 'ai-post-scheduler'); ?></span>
                                         </button>
@@ -118,7 +118,7 @@ if (!defined('ABSPATH')) {
                     <h3 class="aips-empty-state-title"><?php esc_html_e('No Voices Yet', 'ai-post-scheduler'); ?></h3>
                     <p class="aips-empty-state-description"><?php esc_html_e('Create a voice to establish consistent tone and style for your generated posts.', 'ai-post-scheduler'); ?></p>
                     <div class="aips-empty-state-actions">
-                        <button class="aips-btn aips-btn-primary aips-btn-lg aips-add-voice-btn">
+                        <button type="button" class="aips-btn aips-btn-primary aips-btn-lg aips-add-voice-btn">
                             <span class="dashicons dashicons-plus-alt2"></span>
                             <?php esc_html_e('Create Voice', 'ai-post-scheduler'); ?>
                         </button>


### PR DESCRIPTION
**What:** 
Added explicit `type="button"` attributes to all interactive `<button>` elements across the admin templates that currently lack a `type` attribute and reside outside of explicit `<form>` contexts.

**Why:** 
In HTML, a `<button>` without a defined `type` defaults to `type="submit"`. In a complex WordPress admin interface, if these buttons are ever wrapped dynamically by JavaScript, placed near form boundaries, or if JS event handlers fail to explicitly call `preventDefault()`, they can trigger an unintended form submission and page reload. This degrades the user experience, especially in AJAX-driven dashboards. Explicitly defining `type="button"` ensures these elements are strictly treated as interactive JS triggers.

**Accessibility:** 
Improves form semantics and prevents unexpected behavior, aiding users navigating via keyboard or assistive technologies.

**Verification:** 
- The codebase was systematically scanned with a PHP script targeting `<button>` elements outside `<form>` tags.
- Verified that 81 button elements were updated.
- Verified syntax validity for all modified templates.
- Checked test suite to ensure no backend regressions occurred.

---
*PR created automatically by Jules for task [14908353852925562423](https://jules.google.com/task/14908353852925562423) started by @rpnunez*