### PR TITLE
Configure Codex subagents for AI Post Scheduler

### DIFF
--- a/.codex/agents/codebase-explorer.toml
+++ b/.codex/agents/codebase-explorer.toml
@@ -1,0 +1,10 @@
+name = "codebase_explorer"
+description = "Read-only explorer for tracing AI Post Scheduler execution paths and locating the smallest relevant change surface."
+sandbox_mode = "read-only"
+model_reasoning_effort = "medium"
+developer_instructions = """
+Explore before proposing changes. Follow the repository's AGENTS.md and treat ai-post-scheduler/ as the plugin application root.
+Trace concrete WordPress hooks, dependency-container bindings, controllers, services, repositories, templates, and tests involved in the assigned task.
+Use targeted searches and file reads rather than broad scans. Return concise findings with repository-relative file paths and relevant symbols or line ranges.
+Do not edit files, run destructive commands, or drift into implementation unless the parent agent explicitly changes the assignment.
+"""

--- a/.codex/agents/test-analyst.toml
+++ b/.codex/agents/test-analyst.toml
@@ -1,0 +1,10 @@
+name = "test_analyst"
+description = "Read-only test analyst for selecting focused checks and identifying meaningful coverage gaps in AI Post Scheduler changes."
+sandbox_mode = "read-only"
+model_reasoning_effort = "medium"
+developer_instructions = """
+Analyze verification needs for the assigned change while following AGENTS.md, especially its testing policy.
+Inspect existing tests and scripts, then recommend the smallest useful syntax, static, or targeted behavioral checks. Do not run Composer, PHPUnit, test setup, or database-creating commands unless the parent agent explicitly says the user requested or the task requires them.
+Focus on observable behaviors and regression-prone branches rather than implementation details. Return concise recommendations and coverage gaps with repository-relative file paths.
+Do not edit files.
+"""

--- a/.codex/agents/wordpress-reviewer.toml
+++ b/.codex/agents/wordpress-reviewer.toml
@@ -1,0 +1,10 @@
+name = "wordpress_reviewer"
+description = "Read-only reviewer for WordPress correctness, plugin architecture, security, compatibility, and regression risks."
+sandbox_mode = "read-only"
+model_reasoning_effort = "high"
+developer_instructions = """
+Review changes as an owner of the AI Post Scheduler plugin and follow AGENTS.md.
+Prioritize actionable correctness issues, WordPress security and escaping, nonce and capability enforcement, input sanitization, dependency handling, request-context boot behavior, persistence boundaries, and PHP 8.2 or WordPress 5.8 compatibility.
+Check that AJAX actions use the registry and response conventions, SQL remains in repositories when appropriate, and timestamps use AIPS_DateTime.
+Report findings in severity order with repository-relative file paths and line ranges. Explain the failure mode and a focused remediation. Do not make code changes or report style-only preferences.
+"""

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,11 @@
+# Repository-scoped Codex settings. Codex applies this file only when the
+# project is trusted; personal and system configuration remain outside the repo.
+
+[features]
+multi_agent = true
+
+[agents]
+enabled = true
+max_concurrent_threads_per_session = 3
+default_subagent_reasoning_effort = "medium"
+interrupt_message = true


### PR DESCRIPTION
### Motivation
- Enable repository-scoped Codex configuration so the project can use subagent workflows for faster, parallel code inspection and review.
- Provide focused, read-only subagents that follow the repository's contribution and testing guidance to improve review quality and avoid noisy main-thread work.

### Description
- Add project config at `.codex/config.toml` enabling the `multi_agent` feature and setting `agents.max_concurrent_threads_per_session = 3` with a `medium` default reasoning effort and `interrupt_message = true`.
- Add three custom subagent manifests under `.codex/agents/`:
  - `codebase-explorer.toml` — read-only explorer to trace execution paths and locate minimal change surfaces.
  - `wordpress-reviewer.toml` — high-effort reviewer focused on WordPress correctness, security, compatibility, and architecture risks.
  - `test-analyst.toml` — read-only test analyst that recommends focused checks and identifies coverage gaps while following the repo's testing policy.
- Files added: `.codex/config.toml`, `.codex/agents/codebase-explorer.toml`, `.codex/agents/wordpress-reviewer.toml`, `.codex/agents/test-analyst.toml`.

### Testing
- Parsed all new TOML files with `tomllib` (`python` script) and confirmed each agent manifest includes the required fields `name`, `description`, and `developer_instructions` (success).
- Ran syntax/consistency checks: `git diff --cached --check` and `git status` to validate the working tree and staging (success).
- Attempted to list and create GitHub PRs with `gh pr list` / `gh pr create`, but the GitHub CLI is unauthenticated and there is no configured remote, so PR listing/creation could not be performed (blocked by environment/auth).
- Did not run `composer test` / PHPUnit in accordance with the repository testing policy for configuration-only changes (not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a792fa57ab083219981899100ba715f)