### PR TITLE
Redesign Schedule History modal with stats grid, tabular per-post rows, search/filters, and AJAX pagination

### DIFF
--- a/ai-post-scheduler/assets/css/admin.css
+++ b/ai-post-scheduler/assets/css/admin.css
@@ -5710,3 +5710,222 @@ li.toplevel_page_ai-post-scheduler li:has(> a[href*="aips-author-topics"]) {
 .column-status {
 	min-width: 160px;
 }
+
+/* ============================================================ */
+/* Redesigned Schedule History Modal                             */
+/* ============================================================ */
+.aips-schedule-history-modal-content {
+	max-width: 900px;
+	width: 90%;
+}
+
+.aips-modal-stats-grid {
+	display: grid;
+	grid-template-columns: repeat(4, 1fr);
+	gap: 12px;
+	margin-bottom: 16px;
+}
+
+.aips-stat-card {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	background: #f8fafc;
+	border: 1px solid #e2e8f0;
+	border-radius: 6px;
+	padding: 10px 14px;
+}
+
+.aips-stat-icon {
+	flex-shrink: 0;
+	width: 34px;
+	height: 34px;
+	border-radius: 6px;
+	background: #e2e8f0;
+	color: #334155;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.aips-stat-icon .dashicons {
+	font-size: 18px;
+	width: 18px;
+	height: 18px;
+	line-height: 18px;
+}
+
+.aips-stat-value {
+	font-size: 15px;
+	font-weight: 600;
+	color: #0f172a;
+	line-height: 1.2;
+}
+
+.aips-stat-label {
+	font-size: 11px;
+	color: #64748b;
+	margin-top: 2px;
+}
+
+.aips-modal-toolbar {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: 12px;
+	margin-bottom: 16px;
+	background: #fff;
+	padding: 10px 12px;
+	border: 1px solid #e2e8f0;
+	border-radius: 6px;
+	flex-wrap: wrap;
+}
+
+.aips-toolbar-left,
+.aips-toolbar-right {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	flex-wrap: wrap;
+}
+
+.aips-search-box {
+	position: relative;
+	display: flex;
+	align-items: center;
+}
+
+.aips-search-box .dashicons {
+	position: absolute;
+	left: 8px;
+	color: #94a3b8;
+	font-size: 15px;
+	pointer-events: none;
+}
+
+.aips-search-box input[type="search"] {
+	padding-left: 28px;
+	height: 30px;
+	font-size: 12px;
+	border-radius: 4px;
+	border: 1px solid #cbd5e1;
+	width: 220px;
+}
+
+.aips-select-sm {
+	height: 30px;
+	font-size: 12px;
+	border-radius: 4px;
+	border: 1px solid #cbd5e1;
+	padding: 0 8px;
+}
+
+.aips-custom-dates-bar {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.aips-date-input {
+	height: 30px;
+	font-size: 12px;
+	border-radius: 4px;
+	border: 1px solid #cbd5e1;
+	padding: 0 6px;
+}
+
+.aips-date-sep {
+	color: #64748b;
+}
+
+.aips-modal-data-table {
+	width: 100%;
+	border-collapse: collapse;
+	border: 1px solid #e2e8f0;
+	border-radius: 6px;
+	overflow: hidden;
+}
+
+.aips-modal-data-table th {
+	background: #f8fafc;
+	color: #475569;
+	font-weight: 600;
+	font-size: 12px;
+	padding: 10px 12px;
+	text-align: left;
+	border-bottom: 1px solid #e2e8f0;
+}
+
+.aips-modal-data-table td {
+	padding: 10px 12px;
+	font-size: 13px;
+	color: #1e293b;
+	border-bottom: 1px solid #f1f5f9;
+	vertical-align: middle;
+}
+
+.aips-modal-data-table tbody tr:last-child td {
+	border-bottom: none;
+}
+
+.aips-modal-data-table tbody tr:hover td {
+	background: #f8fafc;
+}
+
+.aips-history-item-title-wrap {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.aips-history-type-icon {
+	color: #64748b;
+	font-size: 16px;
+	width: 16px;
+	height: 16px;
+	flex-shrink: 0;
+}
+
+.aips-history-item-name {
+	font-weight: 600;
+	color: #0f172a;
+}
+
+.style-badge {
+	margin-left: 8px;
+	font-size: 10px;
+	padding: 2px 6px;
+	text-transform: uppercase;
+	letter-spacing: 0.02em;
+}
+
+.col-name { width: 55%; }
+.col-date { width: 25%; color: #64748b; font-size: 12px; }
+.col-actions { width: 20%; text-align: right; }
+
+.aips-modal-pagination {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-top: 14px;
+	padding-top: 10px;
+	border-top: 1px solid #e2e8f0;
+	font-size: 12px;
+	color: #64748b;
+}
+
+.aips-pagination-controls {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+@media (max-width: 768px) {
+	.aips-modal-stats-grid {
+		grid-template-columns: repeat(2, 1fr);
+	}
+	.aips-modal-toolbar {
+		flex-direction: column;
+		align-items: stretch;
+	}
+}

--- a/ai-post-scheduler/assets/js/admin.js
+++ b/ai-post-scheduler/assets/js/admin.js
@@ -297,7 +297,12 @@
             $(document).on('click', '#aips-unified-bulk-apply', this.applyUnifiedBulkAction);
             $(document).on('change', '.aips-unified-toggle-schedule', this.toggleUnifiedSchedule);
             $(document).on('click', '.aips-unified-run-now', this.runNowUnified);
-            $(document).on('click', '.aips-view-unified-history', this.viewUnifiedScheduleHistory);
+            $(document).on('click', '.aips-view-unified-history', this.viewUnifiedScheduleHistory.bind(this));
+            $(document).on('keyup search', '#aips-history-search-input', AIPS.Utilities.debounce(this.onScheduleHistorySearch.bind(this), 300));
+            $(document).on('change', '#aips-history-event-filter', this.onScheduleHistoryEventFilter.bind(this));
+            $(document).on('change', '#aips-history-date-range', this.onScheduleHistoryDateRange.bind(this));
+            $(document).on('click', '#aips-history-apply-dates', this.onScheduleHistoryApplyCustomDates.bind(this));
+            $(document).on('click', '.aips-modal-pagination-btn', this.onScheduleHistoryPaginationClick.bind(this));
             $(document).on('change', '#aips-unified-type-filter', this.filterUnifiedByType);
             $(document).on('keyup search', '#aips-unified-search', this.filterUnifiedSchedules);
             $(document).on('click', '#aips-unified-search-clear', this.clearUnifiedSearch);
@@ -2985,28 +2990,84 @@
          *
          * @param {Event} e - Click event from `.aips-view-unified-history`.
          */
-        viewUnifiedScheduleHistory: function(e) {
-            e.preventDefault();
+        _scheduleHistoryState: {
+            id: 0,
+            type: '',
+            name: '',
+            page: 1,
+            perPage: 10,
+            search: '',
+            eventFilter: 'all',
+            dateRange: 'all',
+            dateFrom: '',
+            dateTo: ''
+        },
 
-            var $btn  = $(this);
-            var id    = $btn.data('id');
-            var type  = $btn.data('type');
-            var name  = $btn.data('name') || id;
-            var limit = $btn.data('limit') || 0;
+        /**
+         * Open the Schedule History modal and load entries for any schedule type.
+         *
+         * @param {Event} e - Click event from `.aips-view-unified-history`.
+         */
+        viewUnifiedScheduleHistory: function(e) {
+            if (e && e.preventDefault) { e.preventDefault(); }
+
+            var $btn = $(e.currentTarget || this);
+            var id   = $btn.data('id');
+            var type = $btn.data('type');
+            var name = $btn.data('name') || id;
 
             if (!id || !type) { return; }
 
-            var $modal   = $('#aips-schedule-history-modal');
-            var $title   = $modal.find('#aips-schedule-history-modal-title');
-            var $loading = $modal.find('#aips-schedule-history-loading');
-            var $empty   = $modal.find('#aips-schedule-history-empty');
-            var $list    = $modal.find('#aips-schedule-history-list');
+            this._scheduleHistoryState = {
+                id: id,
+                type: type,
+                name: name,
+                page: 1,
+                perPage: 10,
+                search: '',
+                eventFilter: 'all',
+                dateRange: 'all',
+                dateFrom: '',
+                dateTo: ''
+            };
 
-            $title.text('Recent History: ' + name);
+            var $modal = $('#aips-schedule-history-modal');
+            var $title = $modal.find('#aips-schedule-history-modal-title');
+
+            $title.text(name + ' History');
+
+            // Reset control elements
+            $('#aips-history-search-input').val('');
+            $('#aips-history-event-filter').val('all');
+            $('#aips-history-date-range').val('all');
+            $('#aips-history-custom-dates').hide();
+            $('#aips-history-date-from').val('');
+            $('#aips-history-date-to').val('');
+
+            $modal.show();
+            this.fetchScheduleHistory();
+        },
+
+        /**
+         * Fetch schedule history data via AJAX with current state parameters.
+         */
+        fetchScheduleHistory: function() {
+            var self   = this;
+            var state  = this._scheduleHistoryState;
+            var $modal = $('#aips-schedule-history-modal');
+
+            var $loading    = $modal.find('#aips-schedule-history-loading');
+            var $empty      = $modal.find('#aips-schedule-history-empty');
+            var $tableWrap  = $modal.find('#aips-schedule-history-table-wrapper');
+            var $tbody      = $modal.find('#aips-schedule-history-tbody');
+            var $stats      = $modal.find('#aips-schedule-history-stats');
+            var $toolbar    = $modal.find('#aips-schedule-history-toolbar');
+            var $pagination = $modal.find('#aips-schedule-history-pagination');
+
             $loading.show();
             $empty.hide();
-            $list.hide().empty();
-            $modal.show();
+            $tableWrap.hide();
+            $pagination.hide();
 
             $.ajax({
                 url: aipsAjax.ajaxUrl,
@@ -3014,71 +3075,213 @@
                 data: {
                     action: 'aips_get_unified_schedule_history',
                     nonce: aipsAjax.nonce,
-                    id: id,
-                    type: type,
-                    limit: limit
+                    id: state.id,
+                    type: state.type,
+                    page: state.page,
+                    per_page: state.perPage,
+                    search: state.search,
+                    event_filter: state.eventFilter,
+                    date_range: state.dateRange,
+                    date_from: state.dateFrom,
+                    date_to: state.dateTo
                 },
                 success: function(response) {
                     $loading.hide();
 
                     if (!response.success) {
-                        AIPS.Utilities.showToast(response.data.message || aipsAdminL10n.errorOccurred, 'error');
-                        $modal.hide();
+                        AIPS.Utilities.showToast(response.data ? response.data.message : (aipsAdminL10n.errorOccurred || 'Error occurred'), 'error');
                         return;
                     }
 
-                    var entries = response.data.entries;
+                    var data    = response.data || {};
+                    var entries = data.entries || [];
+                    var stats   = data.stats || {};
+                    var pag     = data.pagination || {};
+
+                    // Render Stats Cards
+                    self.renderScheduleHistoryStats($stats, stats);
+                    $stats.show();
+                    $toolbar.show();
+
                     if (!entries || entries.length === 0) {
                         $empty.show();
+                        $tbody.empty();
                         return;
                     }
 
-                    var iconMap = {
-                        'schedule_created':          { icon: 'dashicons-plus-alt',      cls: 'aips-timeline-created'  },
-                        'schedule_updated':          { icon: 'dashicons-edit',           cls: 'aips-timeline-updated'  },
-                        'schedule_enabled':          { icon: 'dashicons-yes-alt',        cls: 'aips-timeline-enabled'  },
-                        'schedule_disabled':         { icon: 'dashicons-minus',          cls: 'aips-timeline-disabled' },
-                        'schedule_executed':         { icon: 'dashicons-controls-play',  cls: 'aips-timeline-executed' },
-                        'manual_schedule_started':   { icon: 'dashicons-controls-play',  cls: 'aips-timeline-executed' },
-                        'manual_schedule_completed': { icon: 'dashicons-yes',            cls: 'aips-timeline-success'  },
-                        'manual_schedule_failed':    { icon: 'dashicons-warning',        cls: 'aips-timeline-error'    },
-                        'schedule_failed':           { icon: 'dashicons-warning',        cls: 'aips-timeline-error'    },
-                        'post_published':            { icon: 'dashicons-media-document', cls: 'aips-timeline-success'  },
-                        'post_draft':                { icon: 'dashicons-media-document', cls: 'aips-timeline-draft'    },
-                        'post_generated':            { icon: 'dashicons-media-document', cls: 'aips-timeline-draft'    },
-                        'author_topic_generation':   { icon: 'dashicons-tag',            cls: 'aips-timeline-executed' },
-                        'topic_post_generation':     { icon: 'dashicons-admin-users',    cls: 'aips-timeline-executed' },
-                    };
-                    var defaultIcon = { icon: 'dashicons-info', cls: '' };
-
+                    // Render Table Rows
+                    $tbody.empty();
                     entries.forEach(function(entry) {
-                        var info    = iconMap[entry.event_type] || defaultIcon;
-                        var isError = (entry.history_type_id === 2 || entry.event_status === 'failed');
-                        if (isError && !info.cls) {
-                            info = { icon: 'dashicons-warning', cls: 'aips-timeline-error' };
-                        }
-
-                        var $item    = $('<li>', { 'class': 'aips-timeline-item ' + info.cls });
-                        var $icon    = $('<span>', { 'class': 'aips-timeline-icon', 'aria-hidden': 'true' })
-                                           .append($('<span>', { 'class': 'dashicons ' + info.icon }));
-                        var $content = $('<div>', { 'class': 'aips-timeline-content' });
-                        var $msg     = $('<p>', { 'class': 'aips-timeline-message' }).text(entry.message || entry.log_type);
-                        var $time    = $('<time>', { 'class': 'aips-timeline-timestamp', 'datetime': entry.timestamp })
-                                           .text(entry.timestamp);
-
-                        $content.append($msg).append($time);
-                        $item.append($icon).append($content);
-                        $list.append($item);
+                        var $row = self.buildScheduleHistoryRow(entry);
+                        $tbody.append($row);
                     });
 
-                    $list.show();
+                    $tableWrap.show();
+
+                    // Render Pagination
+                    self.renderScheduleHistoryPagination($pagination, pag);
+                    $pagination.show();
                 },
                 error: function() {
                     $loading.hide();
-                    AIPS.Utilities.showToast(aipsAdminL10n.errorTryAgain, 'error');
-                    $modal.hide();
+                    AIPS.Utilities.showToast(aipsAdminL10n.errorTryAgain || 'Error, please try again.', 'error');
                 }
             });
+        },
+
+        /**
+         * Render top statistics cards for the schedule modal using AIPS.Templates.
+         */
+        renderScheduleHistoryStats: function($container, stats) {
+            $container.empty();
+
+            var cards = [
+                { label: 'Posts This Week', value: stats.posts_this_week || 0, icon: 'dashicons-calendar-alt' },
+                { label: 'Posts This Month', value: stats.posts_this_month || 0, icon: 'dashicons-calendar' },
+                { label: 'Posts All Time', value: stats.posts_all_time || 0, icon: 'dashicons-admin-post' },
+                { label: 'Total Executions', value: (stats.total_runs || 0) + ' (' + (stats.success_rate || '100%') + ')', icon: 'dashicons-performance' }
+            ];
+
+            cards.forEach(function(card) {
+                var html = AIPS.Templates.render('aips-tmpl-schedule-history-stat-card', card);
+                $container.append(html);
+            });
+        },
+
+        /**
+         * Build a single table row DOM element for a history entry using AIPS.Templates.
+         */
+        buildScheduleHistoryRow: function(entry) {
+            var iconClass = 'dashicons-info';
+            if (entry.is_post) {
+                iconClass = 'dashicons-media-document';
+            } else if (entry.event_type && entry.event_type.indexOf('manual_') === 0) {
+                iconClass = 'dashicons-controls-play';
+            } else if (entry.event_status === 'failed') {
+                iconClass = 'dashicons-warning';
+            }
+
+            var badgeHtml = '';
+            if (entry.is_post) {
+                var isDraft = (entry.post_status === 'draft');
+                badgeHtml = AIPS.Templates.render('aips-tmpl-schedule-history-badge', {
+                    badgeClass: isDraft ? 'aips-badge-warning' : 'aips-badge-success',
+                    badgeText: isDraft ? 'Draft' : 'Published'
+                });
+            } else if (entry.event_type && entry.event_type.indexOf('manual_') === 0) {
+                badgeHtml = AIPS.Templates.render('aips-tmpl-schedule-history-badge', { badgeClass: 'aips-badge-info', badgeText: 'Manual Run' });
+            } else if (entry.event_status === 'failed') {
+                badgeHtml = AIPS.Templates.render('aips-tmpl-schedule-history-badge', { badgeClass: 'aips-badge-danger', badgeText: 'Failed' });
+            }
+
+            var actionsHtml = '';
+            if (entry.view_url) {
+                actionsHtml += AIPS.Templates.render('aips-tmpl-schedule-history-action-view', { url: entry.view_url });
+            }
+            if (entry.edit_url) {
+                actionsHtml += AIPS.Templates.render('aips-tmpl-schedule-history-action-edit', { url: entry.edit_url });
+            }
+
+            var nameText = entry.name || entry.message || 'Schedule event';
+
+            var rowHtml = AIPS.Templates.renderRaw('aips-tmpl-schedule-history-row', {
+                iconClass: iconClass,
+                name: AIPS.Templates.escape(nameText),
+                badgeHtml: badgeHtml,
+                formattedDate: AIPS.Templates.escape(entry.formatted_date || entry.timestamp),
+                actionsHtml: actionsHtml
+            });
+
+            return $(rowHtml);
+        },
+
+        /**
+         * Render pagination controls using AIPS.Templates.
+         */
+        renderScheduleHistoryPagination: function($container, pag) {
+            $container.empty();
+
+            var current = pag.current_page || 1;
+            var total   = pag.total_pages || 1;
+            var totalEntries = pag.total_entries || 0;
+            var perPage = pag.per_page || 10;
+
+            var start = totalEntries > 0 ? ((current - 1) * perPage) + 1 : 0;
+            var end   = Math.min(current * perPage, totalEntries);
+
+            var html = AIPS.Templates.renderRaw('aips-tmpl-schedule-history-pagination', {
+                infoText: AIPS.Templates.escape('Showing ' + start + '-' + end + ' of ' + totalEntries + ' entries'),
+                prevPage: current - 1,
+                prevDisabled: current <= 1 ? 'disabled' : '',
+                pageText: AIPS.Templates.escape('Page ' + current + ' of ' + total),
+                nextPage: current + 1,
+                nextDisabled: current >= total ? 'disabled' : ''
+            });
+
+            $container.html(html);
+        },
+
+        /**
+         * Event handler for search input.
+         */
+        onScheduleHistorySearch: function(e) {
+            var val = $(e.target).val();
+            this._scheduleHistoryState.search = val;
+            this._scheduleHistoryState.page = 1;
+            this.fetchScheduleHistory();
+        },
+
+        /**
+         * Event handler for event filter dropdown.
+         */
+        onScheduleHistoryEventFilter: function(e) {
+            var val = $(e.target).val();
+            this._scheduleHistoryState.eventFilter = val;
+            this._scheduleHistoryState.page = 1;
+            this.fetchScheduleHistory();
+        },
+
+        /**
+         * Event handler for date range filter dropdown.
+         */
+        onScheduleHistoryDateRange: function(e) {
+            var val = $(e.target).val();
+            this._scheduleHistoryState.dateRange = val;
+            this._scheduleHistoryState.page = 1;
+
+            if (val === 'custom') {
+                $('#aips-history-custom-dates').show();
+            } else {
+                $('#aips-history-custom-dates').hide();
+                this._scheduleHistoryState.dateFrom = '';
+                this._scheduleHistoryState.dateTo = '';
+                this.fetchScheduleHistory();
+            }
+        },
+
+        /**
+         * Event handler for applying custom date range.
+         */
+        onScheduleHistoryApplyCustomDates: function() {
+            var from = $('#aips-history-date-from').val();
+            var to   = $('#aips-history-date-to').val();
+
+            this._scheduleHistoryState.dateFrom = from;
+            this._scheduleHistoryState.dateTo   = to;
+            this._scheduleHistoryState.page     = 1;
+            this.fetchScheduleHistory();
+        },
+
+        /**
+         * Event handler for pagination clicks.
+         */
+        onScheduleHistoryPaginationClick: function(e) {
+            e.preventDefault();
+            var page = parseInt($(e.currentTarget).data('page'), 10);
+            if (page && page > 0 && page !== this._scheduleHistoryState.page) {
+                this._scheduleHistoryState.page = page;
+                this.fetchScheduleHistory();
+            }
         },
 
         /**

--- a/ai-post-scheduler/includes/class-aips-schedule-controller.php
+++ b/ai-post-scheduler/includes/class-aips-schedule-controller.php
@@ -1115,18 +1115,41 @@ class AIPS_Schedule_Controller {
             AIPS_Ajax_Response::permission_denied();
         }
 
-        $id    = isset($_POST['id']) ? absint($_POST['id']) : 0;
-        $type  = isset($_POST['type']) ? sanitize_key(wp_unslash($_POST['type'])) : '';
-        $limit = isset($_POST['limit']) ? absint($_POST['limit']) : 0;
+        $id           = isset($_POST['id']) ? absint($_POST['id']) : 0;
+        $type         = isset($_POST['type']) ? sanitize_key(wp_unslash($_POST['type'])) : '';
+        $page         = isset($_POST['page']) ? absint($_POST['page']) : 1;
+        $per_page     = isset($_POST['per_page']) ? absint($_POST['per_page']) : 10;
+        $search       = isset($_POST['search']) ? sanitize_text_field(wp_unslash($_POST['search'])) : '';
+        $event_filter = isset($_POST['event_filter']) ? sanitize_key(wp_unslash($_POST['event_filter'])) : 'all';
+        $date_range   = isset($_POST['date_range']) ? sanitize_key(wp_unslash($_POST['date_range'])) : 'all';
+        $date_from    = isset($_POST['date_from']) ? sanitize_text_field(wp_unslash($_POST['date_from'])) : '';
+        $date_to      = isset($_POST['date_to']) ? sanitize_text_field(wp_unslash($_POST['date_to'])) : '';
 
         if (!$id || empty($type)) {
             AIPS_Ajax_Response::error(__('Invalid parameters.', 'ai-post-scheduler'));
         }
 
         $service = new AIPS_Unified_Schedule_Service();
-        $entries = $service->get_history($id, $type, $limit);
 
-        AIPS_Ajax_Response::success(array('entries' => $entries));
+        // If legacy caller only requested entries with limit, stay compatible
+        if (isset($_POST['limit']) && !isset($_POST['page']) && !isset($_POST['event_filter'])) {
+            $limit   = absint($_POST['limit']);
+            $entries = $service->get_history($id, $type, $limit);
+            AIPS_Ajax_Response::success(array('entries' => $entries));
+            return;
+        }
+
+        $data = $service->get_history_data($id, $type, array(
+            'page'         => $page,
+            'per_page'     => $per_page,
+            'search'       => $search,
+            'event_filter' => $event_filter,
+            'date_range'   => $date_range,
+            'date_from'    => $date_from,
+            'date_to'      => $date_to,
+        ));
+
+        AIPS_Ajax_Response::success($data);
     }
 
     /**

--- a/ai-post-scheduler/includes/class-aips-unified-schedule-service.php
+++ b/ai-post-scheduler/includes/class-aips-unified-schedule-service.php
@@ -248,7 +248,7 @@ class AIPS_Unified_Schedule_Service {
 					array(AIPS_History_Type::ACTIVITY, AIPS_History_Type::ERROR),
 					$limit
 				);
-				return $this->format_history_logs($logs);
+				return $this->expand_and_format_logs($logs);
 
 			case self::TYPE_AUTHOR_TOPIC:
 				$logs = $this->history_repository->get_author_schedule_logs_by_event_types(
@@ -256,7 +256,7 @@ class AIPS_Unified_Schedule_Service {
 					array('author_topic_generation'),
 					$limit > 0 ? $limit : 100
 				);
-				return $this->format_history_logs($logs);
+				return $this->expand_and_format_logs($logs);
 
 			case self::TYPE_AUTHOR_POST:
 				$logs = $this->history_repository->get_author_schedule_logs_by_event_types(
@@ -264,91 +264,272 @@ class AIPS_Unified_Schedule_Service {
 					array('topic_post_generation'),
 					$limit > 0 ? $limit : 100
 				);
-				return $this->format_history_logs($logs);
+				return $this->expand_and_format_logs($logs);
 
 			default:
 				return array();
 		}
 	}
 
-	// -------------------------------------------------------------------------
-	// Private helpers
-	// -------------------------------------------------------------------------
-
 	/**
-	 * Normalise template-based schedules.
+	 * Get detailed, paginated, filtered run-history log entries and statistics for a schedule.
 	 *
-	 * @param bool $include_stats Whether to run the aggregate stats query.
-	 * @return array
+	 * @param int    $id   Numeric ID.
+	 * @param string $type One of the TYPE_* constants.
+	 * @param array  $args Filter & pagination parameters.
+	 * @return array Payload containing entries, stats, and pagination metadata.
 	 */
-	private function get_template_schedules($include_stats = true) {
-		$raw    = $this->schedule_repository->get_all();
-		$result = array();
+	public function get_history_data($id, $type, $args = array()) {
+		$id           = absint($id);
+		$page         = isset($args['page']) ? max(1, absint($args['page'])) : 1;
+		$per_page     = isset($args['per_page']) ? max(1, absint($args['per_page'])) : 10;
+		$search       = isset($args['search']) ? sanitize_text_field(wp_unslash($args['search'])) : '';
+		$event_filter = isset($args['event_filter']) ? sanitize_key($args['event_filter']) : 'all';
+		$date_range   = isset($args['date_range']) ? sanitize_key($args['date_range']) : 'all';
+		$date_from    = isset($args['date_from']) ? sanitize_text_field($args['date_from']) : '';
+		$date_to      = isset($args['date_to']) ? sanitize_text_field($args['date_to']) : '';
 
-		// Batch-fetch generated-post counts by schedule history container.
-		$schedule_stats = array();
-		if ($include_stats) {
-			$history_ids = array();
-			foreach ($raw as $schedule) {
-				if (!empty($schedule->schedule_history_id)) {
-					$history_ids[] = absint($schedule->schedule_history_id);
+		$logs = array();
+
+		switch ($type) {
+			case self::TYPE_TEMPLATE:
+				$schedule = $this->schedule_repository->get_by_id($id);
+				if ($schedule && !empty($schedule->schedule_history_id)) {
+					$logs = $this->history_repository->get_logs_by_history_id(
+						absint($schedule->schedule_history_id),
+						array(AIPS_History_Type::ACTIVITY, AIPS_History_Type::ERROR),
+						0
+					);
 				}
-			}
-			$schedule_stats = $this->history_repository->get_schedule_generated_post_counts($history_ids);
+				break;
+
+			case self::TYPE_AUTHOR_TOPIC:
+				$logs = $this->history_repository->get_author_schedule_logs_by_event_types(
+					$id,
+					array('author_topic_generation'),
+					500
+				);
+				break;
+
+			case self::TYPE_AUTHOR_POST:
+				$logs = $this->history_repository->get_author_schedule_logs_by_event_types(
+					$id,
+					array('topic_post_generation'),
+					500
+				);
+				break;
 		}
 
-		foreach ($raw as $schedule) {
-			$schedule_history_id = !empty($schedule->schedule_history_id) ? (int) $schedule->schedule_history_id : 0;
-			$stats  = isset($schedule_stats[$schedule_history_id]) ? (int) $schedule_stats[$schedule_history_id] : 0;
-			$status = !empty($schedule->is_active) ? 'active' : 'inactive';
-			if (isset($schedule->status) && $schedule->status === 'failed') {
-				$status = 'failed';
-			}
+		$all_entries = $this->expand_and_format_logs($logs);
 
-			$title = !empty($schedule->title) ? $schedule->title
-				: ($schedule->template_name ?: sprintf(__('Schedule #%d', 'ai-post-scheduler'), $schedule->id));
+		// Calculate Statistics (All Time, Week, Month, Execution count)
+		$now       = current_time('timestamp');
+		$week_ago  = $now - (7 * DAY_IN_SECONDS);
+		$month_ago = $now - (30 * DAY_IN_SECONDS);
 
-			// Parse batch_progress to detect incomplete batches
-			$batch_progress_data = null;
-			$has_incomplete_batch = false;
-			if (!empty($schedule->batch_progress)) {
-				$batch_progress_data = json_decode($schedule->batch_progress, true);
-				if (is_array($batch_progress_data) && isset($batch_progress_data['completed'], $batch_progress_data['total'])) {
-					$has_incomplete_batch = $batch_progress_data['completed'] < $batch_progress_data['total'];
+		$posts_this_week  = 0;
+		$posts_this_month = 0;
+		$posts_all_time   = 0;
+		$total_runs       = 0;
+		$successful_runs  = 0;
+
+		foreach ($all_entries as $entry) {
+			if (!empty($entry['is_post'])) {
+				$posts_all_time++;
+				if ($entry['timestamp'] >= $week_ago) {
+					$posts_this_week++;
+				}
+				if ($entry['timestamp'] >= $month_ago) {
+					$posts_this_month++;
 				}
 			}
 
-			$result[] = array(
-				'id'                   => absint($schedule->id),
-				'type'                 => self::TYPE_TEMPLATE,
-				'title'                => $title,
-				'subtitle'             => $schedule->template_name ?: __('Unknown Template', 'ai-post-scheduler'),
-				'campaign_id'          => !empty($schedule->campaign_id) ? (int) $schedule->campaign_id : 0,
-				'cron_hook'            => 'aips_generate_scheduled_posts',
-				'frequency'            => $schedule->frequency,
-				'topic'                => isset($schedule->topic) ? $schedule->topic : '',
-				'article_structure_id' => isset($schedule->article_structure_id) ? $schedule->article_structure_id : '',
-				'rotation_pattern'     => isset($schedule->rotation_pattern) ? $schedule->rotation_pattern : '',
-				'last_run'             => $schedule->last_run,
-				'next_run'             => $schedule->next_run,
-				'is_active'            => (int) $schedule->is_active,
-				'status'               => $status,
-				'stats_count'          => $stats,
-				'stats_label'          => _n('post generated', 'posts generated', $stats, 'ai-post-scheduler'),
-				'can_delete'           => empty($schedule->campaign_id),
-				'history_id'           => $schedule_history_id ? $schedule_history_id : null,
-				'template_id'          => (int) $schedule->template_id,
-				'circuit_state'        => isset($schedule->circuit_state) ? $schedule->circuit_state : 'closed',
-				'batch_progress'       => $batch_progress_data,
-				'has_incomplete_batch' => $has_incomplete_batch,
-			);
+			if (in_array($entry['event_type'], array('schedule_executed', 'manual_schedule_started', 'manual_schedule_completed', 'manual_schedule_failed', 'schedule_failed'), true)) {
+				$total_runs++;
+				if ($entry['event_status'] !== 'failed') {
+					$successful_runs++;
+				}
+			}
 		}
 
-		return $result;
+		$stats = array(
+			'posts_this_week'  => $posts_this_week,
+			'posts_this_month' => $posts_this_month,
+			'posts_all_time'   => $posts_all_time,
+			'total_runs'       => $total_runs,
+			'success_rate'     => $total_runs > 0 ? round(($successful_runs / $total_runs) * 100) . '%' : '100%',
+		);
+
+		// Filter entries
+		$filtered_entries = array();
+		foreach ($all_entries as $entry) {
+			// Date Range Filter
+			if ($date_range === 'week' && $entry['timestamp'] < $week_ago) {
+				continue;
+			}
+			if (($date_range === 'month' || $date_range === '30days') && $entry['timestamp'] < $month_ago) {
+				continue;
+			}
+			if ($date_range === 'custom') {
+				if (!empty($date_from) && $entry['timestamp'] < strtotime($date_from . ' 00:00:00')) {
+					continue;
+				}
+				if (!empty($date_to) && $entry['timestamp'] > strtotime($date_to . ' 23:59:59')) {
+					continue;
+				}
+			}
+
+			// Event Filter
+			if ($event_filter === 'posts' && empty($entry['is_post'])) {
+				continue;
+			}
+			if ($event_filter === 'manual' && strpos($entry['event_type'], 'manual_') === false) {
+				continue;
+			}
+			if ($event_filter === 'system' && (!empty($entry['is_post']) || strpos($entry['event_type'], 'manual_') !== false)) {
+				continue;
+			}
+
+			// Text Search Filter
+			if (!empty($search)) {
+				$needle   = mb_strtolower($search);
+				$haystack = mb_strtolower($entry['name'] . ' ' . $entry['message'] . ' ' . $entry['event_type']);
+				if (mb_strpos($haystack, $needle) === false) {
+					continue;
+				}
+			}
+
+			$filtered_entries[] = $entry;
+		}
+
+		// Pagination
+		$total_entries = count($filtered_entries);
+		$total_pages   = max(1, (int) ceil($total_entries / $per_page));
+		$page          = min($page, $total_pages);
+		$offset        = ($page - 1) * $per_page;
+
+		$paged_entries = array_slice($filtered_entries, $offset, $per_page);
+
+		return array(
+			'entries'    => $paged_entries,
+			'stats'      => $stats,
+			'pagination' => array(
+				'current_page'  => $page,
+				'per_page'      => $per_page,
+				'total_entries' => $total_entries,
+				'total_pages'   => $total_pages,
+			),
+		);
 	}
 
 	/**
-	 * Normalise author topic-generation schedules.
+	 * Expand multi-post execution logs into discrete individual post entries.
+	 * Decodes HTML entities and formats timestamps.
+	 *
+	 * @param array $logs Raw log objects.
+	 * @return array Formatted entries.
+	 */
+	private function expand_and_format_logs($logs) {
+		$entries = array();
+
+		foreach ($logs as $log) {
+			$details = array();
+			if (!empty($log->details)) {
+				$decoded = json_decode($log->details, true);
+				if (is_array($decoded)) {
+					$details = $decoded;
+				}
+			}
+
+			$input     = isset($details['input']) && is_array($details['input']) ? $details['input'] : array();
+			$context   = isset($details['context']) && is_array($details['context']) ? $details['context'] : array();
+			$raw_msg   = isset($details['message']) ? $details['message'] : '';
+			$clean_msg = html_entity_decode($raw_msg, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+			$event_type   = isset($input['event_type']) ? esc_html($input['event_type']) : '';
+			$event_status = isset($input['event_status']) ? esc_html($input['event_status']) : '';
+			$ts           = (int) $log->timestamp;
+			$date_fmt     = wp_date(get_option('date_format') . ' ' . get_option('time_format'), $ts);
+
+			// Extract post ID or post IDs array from context or details
+			$post_ids = array();
+			if (isset($context['post_id'])) {
+				if (is_array($context['post_id'])) {
+					$post_ids = array_map('absint', $context['post_id']);
+				} elseif (is_numeric($context['post_id']) && (int) $context['post_id'] > 0) {
+					$post_ids = array((int) $context['post_id']);
+				}
+			} elseif (isset($details['post_id'])) {
+				if (is_array($details['post_id'])) {
+					$post_ids = array_map('absint', $details['post_id']);
+				} elseif (is_numeric($details['post_id']) && (int) $details['post_id'] > 0) {
+					$post_ids = array((int) $details['post_id']);
+				}
+			}
+
+			// Filter out invalid IDs
+			$post_ids = array_filter($post_ids);
+
+			if (!empty($post_ids)) {
+				foreach ($post_ids as $post_id) {
+					$post = get_post($post_id);
+					if ($post) {
+						$post_title  = html_entity_decode(get_the_title($post), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+						$post_status = $post->post_status;
+						$view_url    = get_permalink($post_id);
+						$edit_url    = get_edit_post_link($post_id, '');
+
+						$entries[] = array(
+							'id'             => absint($log->id) . '_' . absint($post_id),
+							'raw_id'         => absint($log->id),
+							'timestamp'      => $ts,
+							'formatted_date' => $date_fmt,
+							'name'           => $post_title ? $post_title : sprintf(__('Post #%d', 'ai-post-scheduler'), $post_id),
+							'event_type'     => ($post_status === 'draft') ? 'post_draft' : 'post_published',
+							'event_status'   => ($post_status === 'draft') ? 'draft' : 'success',
+							'log_type'       => isset($details['log_subtype']) ? esc_html($details['log_subtype']) : 'post_created',
+							'post_id'        => $post_id,
+							'post_title'     => $post_title,
+							'post_status'    => $post_status,
+							'view_url'       => $view_url ? $view_url : '',
+							'edit_url'       => $edit_url ? $edit_url : '',
+							'is_post'        => true,
+							'message'        => sprintf(__('Post created: %s', 'ai-post-scheduler'), $post_title),
+						);
+					}
+				}
+			} else {
+				// Non-post entry or post not found
+				// Remove "(and X more)" if present in legacy text
+				$clean_msg = preg_replace('/\s*\([^)]*and \d+ more\)/i', '', $clean_msg);
+
+				$entries[] = array(
+					'id'             => absint($log->id),
+					'raw_id'         => absint($log->id),
+					'timestamp'      => $ts,
+					'formatted_date' => $date_fmt,
+					'name'           => $clean_msg ? $clean_msg : __('Schedule event', 'ai-post-scheduler'),
+					'event_type'     => $event_type ? $event_type : 'system_event',
+					'event_status'   => $event_status ? $event_status : 'info',
+					'log_type'       => isset($details['log_subtype']) ? esc_html($details['log_subtype']) : '',
+					'post_id'        => null,
+					'view_url'       => null,
+					'edit_url'       => null,
+					'is_post'        => false,
+					'message'        => $clean_msg,
+				);
+			}
+		}
+
+		// Sort by timestamp DESC
+		usort($entries, static function($a, $b) {
+			return $b['timestamp'] <=> $a['timestamp'];
+		});
+
+		return $entries;
+	}
+
+	/**
 	 *
 	 * Each active author with `topic_generation_next_run` set appears as one row.
 	 *

--- a/ai-post-scheduler/templates/admin/schedule.php
+++ b/ai-post-scheduler/templates/admin/schedule.php
@@ -370,15 +370,14 @@ if (!function_exists('aips_datetime_from_db_value')) {
 								</a>
 							</div>
 							<?php endif; ?>
-							<div class="aips-row-actions">
-								<a href="#"
-									class="aips-view-unified-history"
+							<div class="aips-history-btn-wrap" style="margin-top:6px;">
+								<button type="button"
+									class="aips-btn aips-btn-xs aips-btn-secondary aips-view-unified-history"
 									data-id="<?php echo esc_attr($sched['id']); ?>"
 									data-type="<?php echo esc_attr($sched['type']); ?>"
-									data-name="<?php echo esc_attr($sched['title']); ?>"
-									data-limit="5">
-									<?php esc_html_e('History', 'ai-post-scheduler'); ?>
-								</a>
+									data-name="<?php echo esc_attr($sched['title']); ?>">
+									<span class="dashicons dashicons-backup" aria-hidden="true" style="font-size:13px;width:13px;height:13px;line-height:13px;vertical-align:-2px;margin-right:4px;"></span><?php esc_html_e('History', 'ai-post-scheduler'); ?>
+								</button>
 							</div>
 						</td>
 						<td class="column-type">
@@ -732,22 +731,132 @@ if (!function_exists('aips_datetime_from_db_value')) {
 <!-- ============================================================ -->
 <div id="aips-schedule-history-modal" class="aips-modal" style="display:none;"
 	role="dialog" aria-modal="true">
-	<div class="aips-modal-content aips-modal-large">
+	<div class="aips-modal-content aips-modal-large aips-schedule-history-modal-content">
 		<div class="aips-modal-header">
-			<h2 class="aips-modal-title"><?php esc_html_e('Recent History', 'ai-post-scheduler'); ?></h2>
+			<h2 id="aips-schedule-history-modal-title" class="aips-modal-title"><?php esc_html_e('Schedule History', 'ai-post-scheduler'); ?></h2>
 			<button type="button" class="aips-modal-close" aria-label="<?php esc_attr_e('Close modal', 'ai-post-scheduler'); ?>">&times;</button>
 		</div>
 		<div class="aips-modal-body">
-			<div id="aips-schedule-history-loading" style="text-align:center;padding:20px;">
+			<!-- Top Schedule Statistics Cards -->
+			<div id="aips-schedule-history-stats" class="aips-modal-stats-grid" style="display:none;"></div>
+
+			<!-- Filters Toolbar -->
+			<div id="aips-schedule-history-toolbar" class="aips-modal-toolbar" style="display:none;">
+				<div class="aips-toolbar-left">
+					<div class="aips-search-box">
+						<span class="dashicons dashicons-search" aria-hidden="true"></span>
+						<input type="search" id="aips-history-search-input" placeholder="<?php esc_attr_e('Search post title or event…', 'ai-post-scheduler'); ?>" />
+					</div>
+					<select id="aips-history-event-filter" class="aips-select-sm">
+						<option value="all"><?php esc_html_e('All Events', 'ai-post-scheduler'); ?></option>
+						<option value="posts"><?php esc_html_e('Posts Created', 'ai-post-scheduler'); ?></option>
+						<option value="manual"><?php esc_html_e('Manual Executions', 'ai-post-scheduler'); ?></option>
+						<option value="system"><?php esc_html_e('System Events', 'ai-post-scheduler'); ?></option>
+					</select>
+				</div>
+				<div class="aips-toolbar-right">
+					<select id="aips-history-date-range" class="aips-select-sm">
+						<option value="all"><?php esc_html_e('All Time', 'ai-post-scheduler'); ?></option>
+						<option value="week"><?php esc_html_e('This Week', 'ai-post-scheduler'); ?></option>
+						<option value="month"><?php esc_html_e('This Month', 'ai-post-scheduler'); ?></option>
+						<option value="30days"><?php esc_html_e('Last 30 Days', 'ai-post-scheduler'); ?></option>
+						<option value="custom"><?php esc_html_e('Custom Date Range', 'ai-post-scheduler'); ?></option>
+					</select>
+					<div id="aips-history-custom-dates" class="aips-custom-dates-bar" style="display:none;">
+						<input type="date" id="aips-history-date-from" class="aips-date-input" />
+						<span class="aips-date-sep">&ndash;</span>
+						<input type="date" id="aips-history-date-to" class="aips-date-input" />
+						<button type="button" id="aips-history-apply-dates" class="aips-btn aips-btn-xs aips-btn-secondary"><?php esc_html_e('Apply', 'ai-post-scheduler'); ?></button>
+					</div>
+				</div>
+			</div>
+
+			<!-- Loading State -->
+			<div id="aips-schedule-history-loading" style="text-align:center;padding:30px 20px;">
 				<span class="dashicons dashicons-update aips-spin" aria-hidden="true"></span>
 				<span class="screen-reader-text"><?php esc_html_e('Loading history…', 'ai-post-scheduler'); ?></span>
 			</div>
+
+			<!-- Empty State -->
 			<div id="aips-schedule-history-empty" class="aips-empty-state" style="display:none;padding:40px 20px;">
 				<div class="dashicons dashicons-backup aips-empty-state-icon" aria-hidden="true"></div>
-				<h3 class="aips-empty-state-title"><?php esc_html_e('No History Yet', 'ai-post-scheduler'); ?></h3>
-				<p class="aips-empty-state-description"><?php esc_html_e('No history events have been recorded for this schedule yet.', 'ai-post-scheduler'); ?></p>
+				<h3 class="aips-empty-state-title"><?php esc_html_e('No History Records Found', 'ai-post-scheduler'); ?></h3>
+				<p class="aips-empty-state-description"><?php esc_html_e('No history events match the selected filters for this schedule.', 'ai-post-scheduler'); ?></p>
 			</div>
-			<ul id="aips-schedule-history-list" class="aips-history-timeline" style="display:none;margin:0;padding:0;list-style:none;"></ul>
+
+			<!-- Tabular Data Table -->
+			<div id="aips-schedule-history-table-wrapper" style="display:none;">
+				<table class="aips-table aips-modal-data-table">
+					<thead>
+						<tr>
+							<th class="col-name"><?php esc_html_e('Name / Activity', 'ai-post-scheduler'); ?></th>
+							<th class="col-date"><?php esc_html_e('Date', 'ai-post-scheduler'); ?></th>
+							<th class="col-actions"><?php esc_html_e('Actions', 'ai-post-scheduler'); ?></th>
+						</tr>
+					</thead>
+					<tbody id="aips-schedule-history-tbody"></tbody>
+				</table>
+			</div>
+
+			<!-- Pagination Controls -->
+			<div id="aips-schedule-history-pagination" class="aips-modal-pagination" style="display:none;"></div>
 		</div>
 	</div>
 </div>
+
+<!-- =====================================================================
+     AIPS.Templates HTML blocks for Schedule History Modal
+     These <script type="text/html"> elements are read by AIPS.Templates.render()
+     and AIPS.Templates.renderRaw().
+     ===================================================================== -->
+
+<script type="text/html" id="aips-tmpl-schedule-history-row">
+	<tr>
+		<td class="col-name">
+			<div class="aips-history-item-title-wrap">
+				<span class="dashicons {{iconClass}} aips-history-type-icon" aria-hidden="true"></span>
+				<strong class="aips-history-item-name">{{name}}</strong>
+			</div>
+			{{badgeHtml}}
+		</td>
+		<td class="col-date">{{formattedDate}}</td>
+		<td class="col-actions">{{actionsHtml}}</td>
+	</tr>
+</script>
+
+<script type="text/html" id="aips-tmpl-schedule-history-badge">
+	<span class="aips-badge {{badgeClass}} style-badge">{{badgeText}}</span>
+</script>
+
+<script type="text/html" id="aips-tmpl-schedule-history-action-view">
+	<a href="{{url}}" target="_blank" class="aips-btn aips-btn-xs aips-btn-secondary" title="View post in new tab">
+		<span class="dashicons dashicons-external" aria-hidden="true"></span> View Post
+	</a>
+</script>
+
+<script type="text/html" id="aips-tmpl-schedule-history-action-edit">
+	<a href="{{url}}" target="_blank" class="aips-btn aips-btn-xs aips-btn-ghost" style="margin-left:4px;" title="Edit post">
+		<span class="dashicons dashicons-edit" aria-hidden="true"></span> Edit
+	</a>
+</script>
+
+<script type="text/html" id="aips-tmpl-schedule-history-stat-card">
+	<div class="aips-stat-card">
+		<div class="aips-stat-icon">
+			<span class="dashicons {{icon}}"></span>
+		</div>
+		<div class="aips-stat-info">
+			<div class="aips-stat-value">{{value}}</div>
+			<div class="aips-stat-label">{{label}}</div>
+		</div>
+	</div>
+</script>
+
+<script type="text/html" id="aips-tmpl-schedule-history-pagination">
+	<div class="aips-pagination-info">{{infoText}}</div>
+	<div class="aips-pagination-controls">
+		<button type="button" class="aips-btn aips-btn-xs aips-btn-secondary aips-modal-pagination-btn" data-page="{{prevPage}}" {{prevDisabled}}>Previous</button>
+		<span class="aips-pagination-current-text">{{pageText}}</span>
+		<button type="button" class="aips-btn aips-btn-xs aips-btn-secondary aips-modal-pagination-btn" data-page="{{nextPage}}" {{nextDisabled}}>Next</button>
+	</div>
+</script>


### PR DESCRIPTION
## Summary

Redesigns the **Schedule History** modal in the "Schedules" tab of the Automations page.

### Key Changes
- **Always-Visible History Buttons**: Replaced hidden-on-hover `.aips-row-actions` text links with inline buttons styled with a backup/history icon (`dashicons-backup`) directly in Schedule table rows.
- **Client-Side Templating (`AIPS.Templates`)**: Added script template tags (`#aips-tmpl-schedule-history-row`, `#aips-tmpl-schedule-history-badge`, `#aips-tmpl-schedule-history-action-view`, etc.) to `schedule.php` and updated JS rendering methods in `admin.js`.
- **Clean Encoding & Dates**: Decoded HTML entities (`&quot;`) across schedule names/log messages and formatted raw Unix timestamps into human-readable date strings.
- **Dynamic Title & Statistics Grid**: Updated modal title to `{SCHEDULE NAME} History` and added top summary cards (*Posts This Week*, *Posts This Month*, *Posts All Time*, *Total Executions & Success Rate*).
- **Ungrouped Per-Post Rows**: Multi-post runs now unpack into discrete rows per post with status badges and "View Post" links.
- **Filtering, Search & Pagination**: Added live text search, event type filter dropdown, date range selector with custom date pickers, and AJAX server pagination controls.
